### PR TITLE
Added GitHubFlowVersion and GitReleaseNotes, also included tagline

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
 
   <head>
@@ -67,6 +67,8 @@
           <li><a href="https://github.com/mexx/FeatureSwitcher/issues?labels=up-for-grabs&state=open">FeatureSwitcher</a></li>
           <li><a href="https://github.com/fsharp/FSharp.Data/issues?labels=up-for-grabs&state=open">FSharp.Data</a></li>
           <li><a href="https://github.com/dahlbyk/up-for-grabs.net/issues?labels=up-for-grabs&state=open">Up-For-Grabs.net</a></li>
+          <li><a href="https://github.com/JakeGinnivan/GitHubFlowVersion/issues?labels=up-for-grabs&state=open">GitHubFlowVersion</a> - Easy SemVer for projects using GitHub flow</li>
+          <li><a href="https://github.com/JakeGinnivan/GitReleaseNotes/issues?labels=up-for-grabs&state=open">GitReleaseNotes</a> - Release notes generator for Git projects</li>
         </ul>
          
          <h3>I maintain a project and want to participate!</h3>


### PR DESCRIPTION
I also included a tagline in preparation for #17
#17 is getting harder to do because whoever does it will have to go searching. Was wondering maybe a simple `link - tagline [tags]` format would do for now, then it can be converted easily, also makes it easier to experiment.

Can remove if it is an issue for now
