### PR TITLE
Make each tag a link to itself

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,7 +120,11 @@ layout: default
            <span class="desc"><%=project.desc%></span>
            <% } %>
            <% if (project.tags) { %>
-           <p class="tags"><%=project.tags && project.tags.join(", ")%></p>
+           <p class="tags">
+               <% _.each(project.tags, function(tag, i) { %>
+                   <a href="#/tags/<%=tag%>"><%=tag%></a><%= i != project.tags.length-1 ? "," : "" %>
+               <% }) %>
+           </p>
            <% } %>
        </td>
     </tr>


### PR DESCRIPTION
Display each tag in the tags list under a project as a link to itself for easily filtering to a tag without scrolling up and using the search box.
