### PR TITLE
Improve small device layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,8 @@ layout: default
     <meta charset='utf-8' />
     <meta http-equiv="X-UA-Compatible" content="chrome=1" />
     <meta name="description" content="Up For Grabs : Jump in!" />
-
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+	
     <link rel="stylesheet" type="text/css" media="screen" href="stylesheets/stylesheet.css">
     <link rel="stylesheet" type="text/css" media="screen" href="stylesheets/chosen.min.css">
     <link rel="stylesheet" type="text/css" media="screen" href="stylesheets/stylesheet.css">

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -379,7 +379,6 @@ Small Device Styles
   }
 
   .inner {
-    min-width: 320px;
     max-width: 480px;
   }
 
@@ -410,11 +409,19 @@ Small Device Styles
   h6 {
     font-size: 12px;
   }
+  
+  input, select {
+	font-size: 16px;
+  }
 
   code, pre {
     min-width: 320px;
     max-width: 480px;
     font-size: 11px;
+  }
+  
+  table.projects td {
+    display: block;
   }
 
 }


### PR DESCRIPTION
Improve the layout on small devices by showing the table as block,
removing min width (prevent horizontal scroll), and add a font-size of
16 to inputs and selects. This prevents most phones from zooming in when
one of them is focused.
