### PR TITLE
Fix unescaped url fragments (when filtering projects by tag)

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-up-for-grabs.net

--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -15,7 +15,7 @@
   		no_results_text: "No tags found by that name.",
   		width: "95%"
   	}).val(tags).trigger('chosen:updated').change(function(e) {
-  		window.location.href = "#/tags/" + ($(this).val() || "");
+  		window.location.href = "#/tags/" + encodeURIComponent(($(this).val() || ""));
   	});
   };
 

--- a/tests/spec/ProjectsServiceSpec.js
+++ b/tests/spec/ProjectsServiceSpec.js
@@ -6,7 +6,7 @@ describe("ProjectsService", function() {
     projectsService = new ProjectsService(sampleProjects);
   });
 
-  it("should be not be undefined", function() {
+  it("should be defined", function() {
     expect(projectsService).toBeDefined();
   });
 


### PR DESCRIPTION
When the project tags have a special character in the tag (e.g: OR/M), current implementation is interpreting that as two segments OR and M. This is breaking the tag filter. 
Fixed this issue by encoding the tag before navigating to the selected tag using `encodeURIComponent`

Also fixed a typo in one of the test's expectation.
