### PR TITLE
Fix unescaped url fragments (when filtering projects by tag)

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@ layout: default
            <% if (project.tags) { %>
            <p class="tags">
                <% _.each(project.tags, function(tag, i) { %>
-                   <a href="#/tags/<%=tag%>"><%=tag%></a><%= i != project.tags.length-1 ? "," : "" %>
+                   <a href="#/tags/<%=encodeURIComponent(tag)%>"><%=tag%></a><%= i != project.tags.length-1 ? "," : "" %>
                <% }) %>
            </p>
            <% } %>

--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -15,7 +15,7 @@
   		no_results_text: "No tags found by that name.",
   		width: "95%"
   	}).val(tags).trigger('chosen:updated').change(function(e) {
-  		window.location.href = "#/tags/" + ($(this).val() || "");
+  		window.location.href = "#/tags/" + encodeURIComponent(($(this).val() || ""));
   	});
   };
 

--- a/tests/spec/ProjectsServiceSpec.js
+++ b/tests/spec/ProjectsServiceSpec.js
@@ -6,7 +6,7 @@ describe("ProjectsService", function() {
     projectsService = new ProjectsService(sampleProjects);
   });
 
-  it("should be not be undefined", function() {
+  it("should be defined", function() {
     expect(projectsService).toBeDefined();
   });
 


### PR DESCRIPTION
_Note: Creating another pull request (as #82 ended being a mess with old/unwanted commits)_
When the project tags have a special character in the tag (e.g: OR/M), current implementation is interpreting that as two segments OR and M. This is breaking the tag filter. 
Fixed this issue by encoding the tag before navigating to the selected tag using encodeURIComponent

Also fixed a typo in one of the test's expectation.
