### PR TITLE
Prevents reshuffling within browser session.

### DIFF
--- a/javascripts/projectsService.js
+++ b/javascripts/projectsService.js
@@ -69,9 +69,32 @@
 
 	var ProjectsService = function (projectsData) {
 		var _projectsData = extractProjectsAndTags(projectsData);
-    var projects = _.toArray(_.shuffle(_projectsData.projects));
-		var tagsMap = {};
-    
+    var tagsMap = {};
+
+    var projects = [];
+    if (JSON && sessionStorage && sessionStorage.getItem
+        && sessionStorage.setItem) {
+      // JSON serialized list of project names
+      var ordering = sessionStorage.getItem("projectOrder");
+
+      if (ordering) {
+        ordering = JSON.parse(ordering);
+        var mapping = _.object(_.map(
+          _projectsData.projects,
+          function (proj) { return [proj.name, proj]}
+        ));
+        for (var i = 0; i < ordering.length; ++i) {
+          projects.push(mapping[ordering[i]]);
+        }
+      } else {
+        projects = _.toArray(_.shuffle(_projectsData.projects));
+        ordering = _.map(projects, function(proj) { return proj.name });
+        sessionStorage.setItem("projectOrder", JSON.stringify(ordering));
+      }
+    } else {
+      projects = _.toArray(_.shuffle(_projectsData.projects))
+    }
+
 		_.each(_projectsData.tags, function(tag){
       tagsMap[tag.name.toLowerCase()] = tag;
     });


### PR DESCRIPTION
With the current setup, the project list gets reshuffled if the user clicks through to a project then comes back. This makes it hard to browse the list. Now the ordering is stored in `sessionStorage` after the initial shuffling.
- If sessions storage is unavailable, the current behavior of shuffling every time is used.
- This patch assumes that project names are unique.
- See #27.
- I don't do a whole lot with javascript so am mostly unaware of best practices. This was also a hastily done patch, so please review!

Testing:
- Clicked through to a project and came back.
- Refreshed the page.
- Fooled browser into thinking sessionStorage was unavailable.
