### PR TITLE
Prevents reshuffling within browser session

### DIFF
--- a/javascripts/projectsService.js
+++ b/javascripts/projectsService.js
@@ -69,9 +69,28 @@
 
 	var ProjectsService = function (projectsData) {
 		var _projectsData = extractProjectsAndTags(projectsData);
-    var projects = _.toArray(_.shuffle(_projectsData.projects));
-		var tagsMap = {};
-    
+    var tagsMap = {};
+
+    var canStoreOrdering = (JSON && sessionStorage && sessionStorage.getItem
+                            && sessionStorage.setItem);
+    var ordering = null;
+    if (canStoreOrdering) {
+      ordering = sessionStorage.getItem("projectOrder");
+      if (ordering) {
+        ordering = JSON.parse(ordering);
+      }
+    }
+
+    if (!ordering) {
+      ordering = _.shuffle(_.range(_projectsData.projects.length));
+      if (canStoreOrdering) {
+        sessionStorage.setItem("projectOrder", JSON.stringify(ordering));
+      }
+    }
+
+    var projects = _.map(ordering,
+                         function(i) { return _projectsData.projects[i]; });
+
 		_.each(_projectsData.tags, function(tag){
       tagsMap[tag.name.toLowerCase()] = tag;
     });

--- a/javascripts/projectsService.js
+++ b/javascripts/projectsService.js
@@ -78,6 +78,11 @@
       ordering = sessionStorage.getItem("projectOrder");
       if (ordering) {
         ordering = JSON.parse(ordering);
+
+        // This prevents anyone's page from crashing if a project is removed
+        if (ordering.length !== _projectsData.projects.length) {
+          ordering = null;
+        }
       }
     }
 


### PR DESCRIPTION
With the current setup, the project list gets reshuffled if the user clicks through to a project then comes back. This makes it hard to browse the list. Now the ordering is stored in `sessionStorage` after the initial shuffling.
- If sessions storage is unavailable, the current behavior of shuffling every time is used.
- See #27.
- I don't do a whole lot with javascript so am mostly unaware of best practices. This was also a hastily done patch, so please review!

Testing:
- Clicked through to a project and came back.
- Refreshed the page.
- Fooled browser into thinking sessionStorage was unavailable.
