### PR TITLE
add popular tags section

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -6,6 +6,12 @@
       <option value="<%-key%>"><%- entry.name%>  (<%-entry.frequency%>)</option>
     <% }) %>
     </select>
+    <h5>Popular tags: </h5>
+    <ul class="popular-tags">
+    <% _.each(popularTags, function(entry, key){ %>
+      <li><a href="#/tags/<%-encodeURIComponent(entry.name)%>"><%-entry.name%></a> <%-entry.frequency%></li>
+    <% }) %>
+    </ul>
   </div>
   <table class="projects">
    <% _.each(projects, function(project){ %>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -9,7 +9,7 @@
     <h5>Popular tags: </h5>
     <ul class="popular-tags">
     <% _.each(popularTags, function(entry, key){ %>
-      <li><a href="#/tags/<%-encodeURIComponent(entry.name)%>"><%-entry.name%></a> <%-entry.frequency%></li>
+      <li><a href="#/tags/<%-encodeURIComponent(entry.name)%>"><%-entry.name%></a> (<%-entry.frequency%>)</li>
     <% }) %>
     </ul>
   </div>

--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -8,7 +8,7 @@
     projectsPanel.html(compiledtemplateFn({
       "projects" : projectsSvc.get(tags),
       "tags" : projectsSvc.getTags(),
-      "popularTags" : projectsSvc.getPopularTags(4),
+      "popularTags" : projectsSvc.getPopularTags(6),
       "selectedTags": tags
     }));
 

--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -8,6 +8,7 @@
     projectsPanel.html(compiledtemplateFn({
       "projects" : projectsSvc.get(tags),
       "tags" : projectsSvc.getTags(),
+      "popularTags" : projectsSvc.getPopularTags(4),
       "selectedTags": tags
     }));
 

--- a/javascripts/projectsService.js
+++ b/javascripts/projectsService.js
@@ -107,6 +107,10 @@
     this.getTags = function() {
       return tagsMap;
     };
+
+    this.getPopularTags = function (popularTagCount) {
+      return _.take(_.map(tagsMap, function (val) { return val; }), popularTagCount || 10);
+    }
   };
 
   host.ProjectsService = ProjectsService;

--- a/javascripts/projectsService.js
+++ b/javascripts/projectsService.js
@@ -25,7 +25,7 @@
   var TagBuilder = function(){
     var _tagsMap = {},
         _orderedTagsMap = null;
-    
+
     this.addTag = function(tag, projectName){
       var tagLowerCase = tag.toLowerCase();
       if(!_.has(_tagsMap, tagLowerCase)) {
@@ -35,7 +35,7 @@
           "projects": []
         };
       }
-      var _entry = _tagsMap[tagLowerCase]; 
+      var _entry = _tagsMap[tagLowerCase];
       _entry.frequency++;
       _entry.projects.push(projectName);
     };

--- a/javascripts/projectsService.js
+++ b/javascripts/projectsService.js
@@ -109,7 +109,7 @@
     };
 
     this.getPopularTags = function (popularTagCount) {
-      return _.take(_.map(tagsMap, function (val) { return val; }), popularTagCount || 10);
+      return _.take(_.values(tagsMap), popularTagCount || 10);
     }
   };
 

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -504,6 +504,16 @@ Custom Styles
   width: 16px;
 }
 
+.popular-tags li {
+  display: inline-block;
+  font-size: 32px;
+  padding-left: 0;
+}
+.popular-tags li + li::before {
+  content: '–';
+  margin: 0 12px;
+}
+
 input, select, textarea, button {
   font-family: 'Myriad Pro', Calibri, Helvetica, Arial, sans-serif;
 }

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -509,9 +509,9 @@ Custom Styles
   font-size: 18px;
   padding-left: 0;
 }
-.popular-tags li + li::before {
+.popular-tags li::before {
   content: ' ';
-  margin: 0 12px;
+  margin-right: 12px;
 }
 
 input, select, textarea, button {

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -409,7 +409,7 @@ Small Device Styles
   h6 {
     font-size: 12px;
   }
-  
+
   input, select {
 	font-size: 16px;
   }
@@ -419,7 +419,7 @@ Small Device Styles
     max-width: 480px;
     font-size: 11px;
   }
-  
+
   table.projects td {
     display: block;
   }

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -506,11 +506,11 @@ Custom Styles
 
 .popular-tags li {
   display: inline-block;
-  font-size: 32px;
+  font-size: 18px;
   padding-left: 0;
 }
 .popular-tags li + li::before {
-  content: '–';
+  content: ' ';
   margin: 0 12px;
 }
 


### PR DESCRIPTION
## Screenshot

![image](https://cloud.githubusercontent.com/assets/67798/8945578/3d68397a-354e-11e5-95e8-db58aa38209b.png)
## Usage

When links are clicked, it resets the filter to that tag. I chose 10 as a general fallback on the function, but for this layout, we'll want to show the top 4 most popular tags.
