### PR TITLE
adding Snowdrift.coop to up-for-grabs list

### DIFF
--- a/_data/projects/snowdrift
+++ b/_data/projects/snowdrift
@@ -1,0 +1,15 @@
+name: Snowdrift.coop
+desc: Sustainable funding platform for free/libre/open works
+site: https://snowdrift.coop/
+tags:
+- oss
+- floss
+- web
+- yesod
+- haskell
+- javascript
+- html
+- css
+upforgrabs:
+  name: newbie-friendly
+  link: https://snowdrift.coop/p/snowdrift/t?_hasdata=&f1=newbie-friendly


### PR DESCRIPTION
Using our homepage and aggregated ticket link although we also are on GitHub. We don't want to emphasize GitHub, but if there were a _separate_ way to link to both the homepage and to GitHub, we might do that.
