### PR TITLE
ElasticElmah

### DIFF
--- a/_data/projects/ElasticElmah
+++ b/_data/projects/ElasticElmah
@@ -5,7 +5,7 @@ tags:
 - ".NET"
 - C#
 - Ruby
-- log
+- logging
 upforgrabs:
   name: up_for_grabs
   link: https://github.com/wallymathieu/ElasticElmah/labels/up_for_grabs

--- a/_data/projects/ElasticElmah
+++ b/_data/projects/ElasticElmah
@@ -1,5 +1,5 @@
 name: ElasticElmah
-desc: Logging log4net objects to elastic search from .net and log4r objects from ruby. The focus is on error logging, thus collecting as much information as possible when something is logged.
+desc: Logging log4net objects to ElasticSearch from .net and log4r objects from ruby. The focus is on error logging, thus collecting as much information as possible when something is logged.
 site: https://github.com/wallymathieu/ElasticElmah
 tags:
 - ".NET"

--- a/_data/projects/ElasticElmah
+++ b/_data/projects/ElasticElmah
@@ -1,0 +1,11 @@
+name: ElasticElmah
+desc: Logging log4net objects to elastic search from .net and log4r objects from ruby. The focus is on error logging, thus collecting as much information as possible when something is logged.
+site: https://github.com/wallymathieu/ElasticElmah
+tags:
+- ".NET"
+- C#
+- Ruby
+- log
+upforgrabs:
+  name: up_for_grabs
+  link: https://github.com/wallymathieu/ElasticElmah/labels/up_for_grabs


### PR DESCRIPTION
ElasticElmah is focused on ease of use. Mainly used for error logging (that's why synchronous requests rather than async or udp). It was made before kibana et.c. became popular (so it should be changed to log in that format instead). 
