### PR TITLE
Correct site of Mutability Detector

### DIFF
--- a/_data/projects/mutabilitydetector.yml
+++ b/_data/projects/mutabilitydetector.yml
@@ -1,6 +1,6 @@
 name: Mutability Detector
 desc: Lightweight analysis tool for detecting mutability in Java classes
-site: mutabilitydetector.org
+site: http://mutabilitydetector.org
 tags:
 - java
 - immutability


### PR DESCRIPTION
Without the `http://` prefix it looks like the value for site is generated relative to up-for-grabs.net, and of course, not resolving.
