### PR TITLE
fix multi-line string formatting

### DIFF
--- a/_data/projects/albacore.yml
+++ b/_data/projects/albacore.yml
@@ -1,6 +1,7 @@
 name: albacore
-desc: Albacore is a professional quality suite of Rake tasks for building .NET or
-  Mono based systems.
+desc: >
+  Albacore is a professional quality suite of Rake tasks for
+  building .NET or Mono based systems.
 site: http://albacorebuild.net/
 tags:
 - F#

--- a/_data/projects/albedo.yml
+++ b/_data/projects/albedo.yml
@@ -1,6 +1,7 @@
 name: Albedo
-desc: A .NET library targeted at making Reflection programming more consistent, using
-  a common set of abstractions and utilities.
+desc: >
+  A .NET library targeted at making Reflection programming more
+  consistent, using a common set of abstractions and utilities.
 site: https://github.com/ploeh/Albedo
 tags:
 - Reflection

--- a/_data/projects/arcgis.pcl.yml
+++ b/_data/projects/arcgis.pcl.yml
@@ -1,6 +1,7 @@
 name: ArcGIS.PCL
-desc: Use ArcGIS Server REST resources without an official SDK. You can also convert
-  between ArcGIS Features and GeoJSON.
+desc: >
+  Use ArcGIS Server REST resources without an official SDK.
+  You can also convert between ArcGIS Features and GeoJSON.
 site: https://github.com/davetimmins/ArcGIS.PCL
 tags:
 - ".NET"

--- a/_data/projects/array-slice-optimizer.yml
+++ b/_data/projects/array-slice-optimizer.yml
@@ -1,7 +1,8 @@
 name: Array Slice optimizer
-desc: ArraySlice allows to build shared memory array views without performance impact
-  (a replacement for ArraySegment<T>). It uses IL manipulation to achieve the fastest
-  implementation.
+desc: >
+  ArraySlice allows to build shared memory array views without
+  performance impact (a replacement for ArraySegment<T>). It
+  uses IL manipulation to achieve the fastest implementation.
 site: https://github.com/Codealike/arrayslice
 tags:
 - ".Net"

--- a/_data/projects/asp.net-mvc-6.yml
+++ b/_data/projects/asp.net-mvc-6.yml
@@ -1,6 +1,8 @@
 name: ASP.NET MVC 6
-desc: Model view controller framework for building dynamic web sites with clean separation
-  of concerns, including the merged MVC, Web API, and Web Pages w/ Razor.
+desc: >
+  Model view controller framework for building dynamic web sites
+  with clean separation of concerns, including the merged MVC, Web API,
+  and Web Pages w/ Razor.
 site: https://github.com/aspnet/Mvc
 tags:
 - Microsoft

--- a/_data/projects/autofixture.yml
+++ b/_data/projects/autofixture.yml
@@ -1,5 +1,6 @@
 name: AutoFixture
-desc: Write maintainable unit tests, faster. AutoFixture makes it easier for developers
+desc: >
+  Write maintainable unit tests, faster. AutoFixture makes it easier for developers
   to do Test-Driven Development by automating non-relevant Test Fixture Setup, allowing
   the Test Developer to focus on the essentials of each test case.
 site: https://github.com/AutoFixture/AutoFixture

--- a/_data/projects/bash-git-prompt.yml
+++ b/_data/projects/bash-git-prompt.yml
@@ -1,5 +1,6 @@
 name: Bash Git prompt
-desc: A bash prompt that displays information about the current git repository. In
+desc: >
+  A bash prompt that displays information about the current git repository. In
   particular the branch name, difference with remote branch, number of files staged,
   changed, etc.
 site: https://github.com/magicmonty/bash-git-prompt

--- a/_data/projects/bond.yml
+++ b/_data/projects/bond.yml
@@ -1,5 +1,6 @@
 name: Bond
-desc: Bond is a cross-platform framework for working with schematized data. It supports
+desc: >
+  Bond is a cross-platform framework for working with schematized data. It supports
   cross-language de/serialization and powerful generic mechanisms for efficiently
   manipulating data.
 site: https://github.com/Microsoft/bond

--- a/_data/projects/bulk-writer.yml
+++ b/_data/projects/bulk-writer.yml
@@ -1,5 +1,6 @@
 name: bulk-writer
-desc: Provides guidance for fast ETL jobs, an IDataReader implementation for SqlBulkCopy
+desc: >
+  Provides guidance for fast ETL jobs, an IDataReader implementation for SqlBulkCopy
   (or the MySql or Oracle equivalents) that wraps an IEnumerable, and libraries for
   mapping entites to table columns.
 site: https://github.com/HeadspringLabs/bulk-writer

--- a/_data/projects/code-cracker.yml
+++ b/_data/projects/code-cracker.yml
@@ -1,6 +1,7 @@
 name: Code Cracker
-desc: An analyzer library for C# that uses Roslyn to produce refactorings, code analysis,
-  and other niceties.
+desc: >
+  An analyzer library for C# that uses Roslyn to produce refactorings,
+  code analysis, and other niceties.
 site: https://github.com/code-cracker/code-cracker
 tags:
 - roslyn

--- a/_data/projects/concordion-logging-tooltip-extension.yml
+++ b/_data/projects/concordion-logging-tooltip-extension.yml
@@ -1,6 +1,7 @@
 name: Concordion Logging Tooltip Extension
-desc: An extension to Concordion that adds tooltips to the output to display logging
-  information.
+desc: >
+  An extension to Concordion that adds tooltips to the output to
+  display logging information.
 site: https://github.com/concordion/concordion-logging-tooltip-extension
 tags:
 - Java

--- a/_data/projects/dotnet-compiler-platform-roslyn.yml
+++ b/_data/projects/dotnet-compiler-platform-roslyn.yml
@@ -1,6 +1,7 @@
 name: .NET Compiler Platform ("Roslyn")
-desc: The .NET Compiler Platform ("Roslyn") provides open-source C# and Visual Basic
-  compilers with rich code analysis APIs.
+desc: >
+  The .NET Compiler Platform ("Roslyn") provides open-source C# and
+  Visual Basic compilers with rich code analysis APIs.
 site: https://github.com/dotnet/roslyn
 tags:
 - roslyn

--- a/_data/projects/dotnet-core-clr.yml
+++ b/_data/projects/dotnet-core-clr.yml
@@ -1,5 +1,6 @@
 name: ".NET Core CLR"
-desc: Contains the .NET Core runtime, called CoreCLR, and the base library, called
+desc: >
+  Contains the .NET Core runtime, called CoreCLR, and the base library, called
   mscorlib. It includes the garbage collector, JIT compiler, base .NET data types
   and many low-level classes.
 site: https://github.com/dotnet/coreclr

--- a/_data/projects/dotnet-core-framework.yml
+++ b/_data/projects/dotnet-core-framework.yml
@@ -1,5 +1,6 @@
 name: ".NET Core Framework"
-desc: Contains the .NET Core foundational libraries, called CoreFX. It includes classes
+desc: >
+  Contains the .NET Core foundational libraries, called CoreFX. It includes classes
   for collections, file systems, console, XML, async and many others.
 site: https://github.com/dotnet/corefx/
 tags:

--- a/_data/projects/fake.yml
+++ b/_data/projects/fake.yml
@@ -1,6 +1,7 @@
 name: FAKE
-desc: FAKE - F# Make - is a build automation tool for .NET. Tasks and dependencies
-  are specified in a DSL which is integrated in F#.
+desc: >
+  FAKE - F# Make - is a build automation tool for .NET. Tasks and
+  dependencies are specified in a DSL which is integrated in F#.
 site: https://github.com/fsharp/fake
 tags:
 - ".NET"

--- a/_data/projects/formo.yml
+++ b/_data/projects/formo.yml
@@ -1,6 +1,7 @@
 name: Formo
-desc: Formo allows you to use your configuration file as a dynamic object. Turn your
-  web.config or application settings into a rich, dynamic object.
+desc: >
+  Formo allows you to use your configuration file as a dynamic object.
+  Turn your web.config or application settings into a rich, dynamic object.
 site: http://github.com/ChrisMissal/Formo
 tags:
 - C#

--- a/_data/projects/fsharp.configuration.yml
+++ b/_data/projects/fsharp.configuration.yml
@@ -1,6 +1,7 @@
 name: FSharp.Configuration
-desc: The FSharp.Configuration project contains type providers for the configuration
-  of .NET projects.
+desc: >
+  The FSharp.Configuration project contains type providers for the
+  configuration of .NET projects.
 site: https://github.com/fsprojects/FSharp.Configuration
 tags:
 - ".NET"

--- a/_data/projects/fsharp.data.yml
+++ b/_data/projects/fsharp.data.yml
@@ -1,5 +1,6 @@
 name: FSharp.Data
-desc: The F# Data library implements type providers for working with structured file
+desc: >
+  The F# Data library implements type providers for working with structured file
   formats (CSV, JSON and XML) and for accessing the WorldBank and Freebase data. It
   also includes helpers for parsing JSON and CSV files and for sending HTTP requests.
 site: https://github.com/fsharp/FSharp.Data

--- a/_data/projects/fsharp.formatting.yml
+++ b/_data/projects/fsharp.formatting.yml
@@ -1,5 +1,6 @@
 name: FSharp.Formatting
-desc: F# tools for generating documentation using literate F# scripts and inline Markdown
+desc: >
+  F# tools for generating documentation using literate F# scripts and inline Markdown
   comments for libraries (Also includes stand-alone Markdown processor and F# code
   formatter)
 site: https://github.com/tpetricek/FSharp.Formatting

--- a/_data/projects/fsharp.management.yml
+++ b/_data/projects/fsharp.management.yml
@@ -1,5 +1,6 @@
 name: FSharp.Management
-desc: The FSharp.Management project contains various type providers for the management
+desc: >
+  The FSharp.Management project contains various type providers for the management
   of the machine.
 site: https://github.com/fsprojects/FSharp.Management
 tags:

--- a/_data/projects/gitversion.yml
+++ b/_data/projects/gitversion.yml
@@ -1,6 +1,7 @@
 name: GitVersion
-desc: Easy Semantic Versioning (<a href="http://semver.org">SemVer.org</a>) for projects
-  using Git
+desc: >
+  Easy Semantic Versioning (<a href="http://semver.org">SemVer.org</a>)
+  for projects using Git
 site: https://github.com/GitTools/GitVersion
 tags:
 - Git

--- a/_data/projects/glimpse.yml
+++ b/_data/projects/glimpse.yml
@@ -1,5 +1,6 @@
 name: Glimpse
-desc: Glimpse is a web debugging and diagnostics tool used to gain a better understanding
+desc: >
+  Glimpse is a web debugging and diagnostics tool used to gain a better understanding
   of whats happening inside of your ASP.NET application.
 site: https://github.com/Glimpse/Glimpse
 tags:

--- a/_data/projects/haywire.yml
+++ b/_data/projects/haywire.yml
@@ -1,5 +1,6 @@
 name: Haywire
-desc: Haywire is an asynchronous HTTP server framework written in C that's built using
+desc: >
+  Haywire is an asynchronous HTTP server framework written in C that's built using
   the event loop based libuv platform layer that node.js is built on top of.
 site: https://github.com/kellabyte/Haywire
 tags:

--- a/_data/projects/humanizer.yml
+++ b/_data/projects/humanizer.yml
@@ -1,5 +1,6 @@
 name: Humanizer
-desc: Humanizer meets all your .NET needs for manipulating and displaying strings,
+desc: >
+  Humanizer meets all your .NET needs for manipulating and displaying strings,
   enums, dates, times, timespans, numbers and quantities
 site: https://github.com/MehdiK/Humanizer
 tags:

--- a/_data/projects/hyprlinkr.yml
+++ b/_data/projects/hyprlinkr.yml
@@ -1,5 +1,6 @@
 name: Hyprlinkr
-desc: Hyprlinkr is a small and very focused helper library for the ASP.NET Web API.
+desc: >
+  Hyprlinkr is a small and very focused helper library for the ASP.NET Web API.
   It does one thing only - it creates URIs according to the applications route configuration
   in a type-safe manner
 site: https://github.com/ploeh/Hyprlinkr

--- a/_data/projects/libgit2.yml
+++ b/_data/projects/libgit2.yml
@@ -1,5 +1,6 @@
 name: libgit2
-desc: libgit2 is a portable, pure C implementation of the Git core methods provided
+desc: >
+  libgit2 is a portable, pure C implementation of the Git core methods provided
   as a re-entrant linkable library with a solid API, allowing you to write native
   speed custom Git applications in any language which supports C bindings.
 site: https://github.com/libgit2/libgit2

--- a/_data/projects/libgit2sharp.yml
+++ b/_data/projects/libgit2sharp.yml
@@ -1,5 +1,6 @@
 name: LibGit2Sharp
-desc: LibGit2Sharp brings all the might and speed of libgit2, a native Git implementation,
+desc: >
+  LibGit2Sharp brings all the might and speed of libgit2, a native Git implementation,
   to the managed world of .Net and Mono.
 site: https://github.com/libgit2/libgit2sharp
 tags:

--- a/_data/projects/msbuild.yml
+++ b/_data/projects/msbuild.yml
@@ -1,6 +1,7 @@
 name: MSBuild
-desc: The Microsoft Build Engine (MSBuild) is the build platform for .NET and Visual
-  Studio.
+desc: >
+ The Microsoft Build Engine (MSBuild) is the build platform for
+ .NET and Visual Studio.
 site: https://github.com/Microsoft/msbuild
 tags:
 - ".NET"

--- a/_data/projects/nancy.yml
+++ b/_data/projects/nancy.yml
@@ -1,6 +1,7 @@
 name: Nancy
-desc: Lightweight, low-ceremony, framework for building HTTP based services on .Net
-  and Mono
+desc: >
+  Lightweight, low-ceremony, framework for building HTTP based services
+  on .Net and Mono
 site: https://github.com/NancyFx/Nancy
 tags:
 - ".net"

--- a/_data/projects/nuget-client.yml
+++ b/_data/projects/nuget-client.yml
@@ -1,6 +1,7 @@
 name: NuGet client
-desc: The NuGet Client tools. Includes 'nuget.exe' and the NuGet extensions for Microsoft
-  Visual Studio and Microsoft WebMatrix
+desc: >
+  The NuGet Client tools. Includes 'nuget.exe' and the NuGet extensions
+  for Microsoft Visual Studio and Microsoft WebMatrix
 site: http://nuget.codeplex.com
 tags:
 - nuget

--- a/_data/projects/nuget-gallery.yml
+++ b/_data/projects/nuget-gallery.yml
@@ -1,6 +1,7 @@
 name: NuGet gallery
-desc: The NuGet Gallery. Powers the "NuGet.org" website, as well as other NuGet package
-  galleries.
+desc: >
+  The NuGet Gallery. Powers the "NuGet.org" website, as well as
+  other NuGet package galleries.
 site: https://github.com/NuGet/NuGetGallery
 tags:
 - nuget

--- a/_data/projects/oak-mvc.yml
+++ b/_data/projects/oak-mvc.yml
@@ -1,6 +1,7 @@
 name: Oak MVC
-desc: Frictionless development for ASP.NET MVC single page web apps. Prototypical
-  and dynamic capabilities brought to C#.
+desc: >
+  Frictionless development for ASP.NET MVC single page web apps.
+  Prototypical and dynamic capabilities brought to C#.
 site: https://amirrajan.github.com/Oak
 tags:
 - SPA

--- a/_data/projects/openra.yml
+++ b/_data/projects/openra.yml
@@ -1,6 +1,7 @@
 name: OpenRA
-desc: A modern Open Source cross-platform reimplementation of the Command & Conquer
-  Red Alert engine written in C# using OpenGL.
+desc: >
+  A modern Open Source cross-platform reimplementation of the
+  Command & Conquer Red Alert engine written in C# using OpenGL.
 site: http://www.openra.net
 tags:
 - ".NET"

--- a/_data/projects/scala-poker.yml
+++ b/_data/projects/scala-poker.yml
@@ -1,6 +1,7 @@
 name: Scala Poker
-desc: Scala Poker aims to be a whole online poker platform solution looking like attractive
-  stuff to serious online poker businesses.
+desc: >
+  Scala Poker aims to be a whole online poker platform solution
+  looking like attractive stuff to serious online poker businesses.
 site: https://github.com/rafanoronha/scala-poker
 tags:
 - scala

--- a/_data/projects/sqlprovider.yml
+++ b/_data/projects/sqlprovider.yml
@@ -1,6 +1,7 @@
 name: SQLProvider
-desc: A general F# SQL database type provider, supporting LINQ queries, schema exploration,
-  individuals and much more besides.
+desc: >
+  A general F# SQL database type provider, supporting LINQ queries,
+  schema exploration, individuals and much more besides.
 site: https://github.com/fsprojects/SQLProvider
 tags:
 - ".NET"

--- a/_data/projects/suave.yml
+++ b/_data/projects/suave.yml
@@ -1,6 +1,8 @@
 name: Suave
-desc: Suave is a simple web development F# library providing a lightweight web server
-  and a set of combinators to manipulate route flow and task composition.
+desc: >
+  Suave is a simple web development F# library providing a lightweight
+  web server and a set of combinators to manipulate route flow and
+  task composition.
 site: https://github.com/SuaveIO/suave
 tags:
 - ".NET"

--- a/_data/projects/teststack.seleno.yml
+++ b/_data/projects/teststack.seleno.yml
@@ -1,7 +1,8 @@
 name: TestStack.Seleno
-desc: Seleno helps you write automated UI tests in the right way by implementing Page
-  Objects and Page Components and by reading from and writing to web pages using strongly
-  typed view models.
+desc: >
+  Seleno helps you write automated UI tests in the right way by
+  implementing Page Objects and Page Components and by reading from
+  and writing to web pages using strongly typed view models.
 site: https://github.com/TestStack/TestStack.Seleno
 tags:
 - ".NET"

--- a/_data/projects/xamarin-forms-labs.yml
+++ b/_data/projects/xamarin-forms-labs.yml
@@ -1,6 +1,8 @@
 name: Xamarin Forms Labs
-desc: Xamarin Forms Labs is a open source project that aims to provide a powerfull
-  and cross platform set of controls and helpers tailored to work with Xamarin Forms
+desc: >
+  Xamarin Forms Labs is a open source project that aims to provide a
+  powerfull and cross platform set of controls and helpers tailored
+  to work with Xamarin Forms
 site: https://github.com/XLabs/Xamarin-Forms-Labs
 tags:
 - ".NET"


### PR DESCRIPTION
I tried importing the projects YAML into `yamljs` and hit some parsing errors...

From [some documentation](http://symfony.com/doc/current/components/yaml/yaml_format.html) about YAML:

> When a string contains line breaks, you can use the literal style, indicated by the pipe (`|`), to indicate that the string will span several lines. In literals, newlines are preserved:

```
|
  \/ /| |\/| |
  / / | |  | |__
```

> Alternatively, strings can be written with the folded style, denoted by `>`, where each line break is replaced by a space:

```
>
  This is a very long sentence
  that spans several lines in the YAML
  but which will be rendered as a string
  without carriage returns.
```

This addresses the problem entries - I'll also do a deploy to my fork to indicate everything is fine with the existing site...
