### PR TITLE
when encountering a YAML error, report where the parsing fails

### DIFF
--- a/scripts/cibuild.rb
+++ b/scripts/cibuild.rb
@@ -82,8 +82,8 @@ def verify_file (f)
       return [f, error]
     end
 
-  rescue Psych::SyntaxError
-    error = "Unable to parse the contents of file"
+  rescue Psych::SyntaxError => e
+    error = "Unable to parse the contents of file - Line: #{e.line}, Offset: #{e.offset}, Problem: #{e.problem}"
     return [f, error]
   rescue
     error = "Unknown exception for file: " + $!


### PR DESCRIPTION
Before:

> $ ruby scripts/cibuild.rb 
> 188 files processed - 1 errors found:
> /Users/shiftkey/src/up-for-grabs.net/_data/projects/angular2.yml - Unable to parse the contents of file

After:

> $ ruby scripts/cibuild.rb 
> 188 files processed - 1 errors found:
> /Users/shiftkey/src/up-for-grabs.net/_data/projects/angular2.yml - Unable to parse the contents of file - Line: 9, Offset: 0, Problem: mapping values are not allowed in this context
