### PR TITLE
Add CoderDojo charity open source project

### DIFF
--- a/_data/projects/coderdojo.yml
+++ b/_data/projects/coderdojo.yml
@@ -1,0 +1,11 @@
+name: CoderDojo Community Platform
+desc: The global community site for CoderDojo - a network of free computer programming clubs for children
+site: http://zen.coderdojo.com
+tags:
+- node
+- node.js
+- mozilla
+- javascript
+upforgrabs:
+  name: up-for-grabs
+  link: https://github.com/CoderDojo/community-platform/labels/up-for-grabs


### PR DESCRIPTION
CoderDojo is a network of free programming clubs for youths aged 7 - 17. We have over 860 clubs worldwide in over 60 countries.

Our new community platform, "Zen", was launched last year and includes:
- Ability to search for a Dojo (coding club) and join the club
- A bespoke ticketing system where parents and mentors can book tickets for their local club
- Profile pages for parents, mentors and youths
- Two forums (Over 13 and community forum), running on NodeBB
- Mozilla Open Badges integration

It would be great to see this added to up-for-grabs.net as it is a great cause! 
