### PR TITLE
ChakraCore: Added tag 'compiler'

### DIFF
--- a/_data/projects/ChakraCore.yml
+++ b/_data/projects/ChakraCore.yml
@@ -9,6 +9,7 @@ tags:
 - ecmascript
 - chakra
 - chakracore
+- compiler
 upforgrabs:
   name: Accepting PRs
   link: https://github.com/Microsoft/ChakraCore/labels/Accepting%20PRs


### PR DESCRIPTION
Added tag `compiler` for ChakraCore, a Javascript Engine.
