### PR TITLE
Adding Hoodie

### DIFF
--- a/_data/projects/Hoodie.yml
+++ b/_data/projects/Hoodie.yml
@@ -1,6 +1,6 @@
 name: Hoodie
 desc: Generic Backend for frontend Apps
-site: https://github.com/dahlbyk/up-for-grabs.net
+site: http://hood.ie
 tags:
 - javascript
 - web

--- a/_data/projects/Hoodie.yml
+++ b/_data/projects/Hoodie.yml
@@ -1,0 +1,11 @@
+name: Hoodie
+desc: Generic Backend for frontend Apps
+site: https://github.com/dahlbyk/up-for-grabs.net
+tags:
+- javascript
+- web
+- offlinefirst
+- nobackend
+upforgrabs:
+  name: starter
+  link: http://go.hood.ie/hoodie-starter-issues


### PR DESCRIPTION
I hope I did this right :) We love new contributors and put a lot of efforts to maintain a list of starter issues at all times.

Question: Is it possible to set two labels? `starter` is the label we add to issues that are perfect for new contributors. `ready` is an additional label which means it's up for grab. Once we remove `ready` it’s assigned to someone.
