### PR TITLE
update Hoodie to single repository

### DIFF
--- a/_data/projects/Hoodie.yml
+++ b/_data/projects/Hoodie.yml
@@ -8,4 +8,4 @@ tags:
 - nobackend
 upforgrabs:
   name: up for grabs
-  link: https://github.com/hoodiehq/camp/issues?utf8=%E2%9C%93&q=label%3A%22up+for+grabs%22
+  link: https://github.com/hoodiehq/camp/labels/up%20for%20grabs

--- a/_data/projects/Hoodie.yml
+++ b/_data/projects/Hoodie.yml
@@ -1,5 +1,5 @@
 name: Hoodie
-desc: Generic Backend for frontend Apps
+desc: Backend for Offline First Applications
 site: http://hood.ie
 tags:
 - javascript
@@ -7,5 +7,5 @@ tags:
 - offlinefirst
 - nobackend
 upforgrabs:
-  name: starter
-  link: http://go.hood.ie/hoodie-starter-issues
+  name: up for grabs
+  link: https://github.com/hoodiehq/camp/issues?utf8=%E2%9C%93&q=label%3A%22up+for+grabs%22


### PR DESCRIPTION
We used to have our starter issues spread across different repositories, but created a dedicated repository for contributors now:
https://github.com/hoodiehq/camp

Will the search for issues and the "up for grabs (123)" badge work now?
