### PR TITLE
Add wp-calypso

### DIFF
--- a/_data/projects/wp-calypso.yml
+++ b/_data/projects/wp-calypso.yml
@@ -1,0 +1,12 @@
+name: wp-calypso
+desc: >
+  The new JavaScript- and API-powered WordPress.com.
+site: https://developer.wordpress.com/calypso/
+tags:
+- javascript
+- wordpress
+- react
+- redux
+upforgrabs:
+  name: Good First Change
+  link: https://github.com/Automattic/wp-calypso/labels/%5BType%5D%20Good%20First%20Change


### PR DESCRIPTION
Calypso is the new API-powered, fully open-source WordPress.com front-end.
