### PR TITLE
Updated help wanted label

### DIFF
--- a/_data/projects/ipfs.yml
+++ b/_data/projects/ipfs.yml
@@ -15,4 +15,4 @@ tags:
 - distributed
 upforgrabs:
   name: help wanted
-  link: https://github.com/search?utf8=%E2%9C%93&q=label%3A%22difficulty%3A+easy%22+user%3AIPFS+is%3Aopen&type=Issues&ref=searchresults
+  link: https://github.com/search?utf8=%E2%9C%93&q=label%3A%22help+wanted%22+user%3AIPFS+is%3Aopen&type=Issues&ref=searchresults


### PR DESCRIPTION
The search for "difficult: easy" was not correct. This fixes the link to go for the "help wanted" label, making the pipeline work much better.
