### PR TITLE
Add libvirt project

### DIFF
--- a/_data/projects/libvirt.yml
+++ b/_data/projects/libvirt.yml
@@ -1,0 +1,13 @@
+name: libvirt
+desc: The virtualization API
+site: https://libvirt.org/
+tags:
+- api
+- c
+- cross-platform
+- library
+- oss
+- virtualization
+upforgrabs:
+  name: up-for-grabs
+  link: http://wiki.libvirt.org/page/BiteSizedTasks


### PR DESCRIPTION
libvirt uses GitHub as a read-only mirror, and in particular
doesn't track issues there. Hence, the URL points to a wiki
page where the available "bite-sized tasks" are listed.
