### PR TITLE
Update nuget client project to point to github

### DIFF
--- a/_data/projects/nuget-client.yml
+++ b/_data/projects/nuget-client.yml
@@ -2,7 +2,7 @@ name: NuGet client
 desc: >
   The NuGet Client tools. Includes 'nuget.exe' and the NuGet extensions
   for Microsoft Visual Studio and Microsoft WebMatrix
-site: http://nuget.codeplex.com
+site: https://github.com/NuGet/Home
 tags:
 - nuget
 - visualstudio
@@ -10,4 +10,4 @@ tags:
 - package
 upforgrabs:
   name: Up For Grabs
-  link: http://nuget.codeplex.com/workitem/list/advanced?release=Up%20for%20Grabs
+  link: https://github.com/NuGet/Home/labels/Up%20for%20Grabs


### PR DESCRIPTION
NuGet has fully moved to github as seen on http://nuget.codeplex.com/ but the up for grabs still links to codeplex. This should fix this :)
