### PR TITLE
Add support for launching the site using Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM starefossen/github-pages:onbuild
+
+RUN bundle install

--- a/README.md
+++ b/README.md
@@ -63,4 +63,10 @@ bundle install
 jekyll serve --watch
 ```
 
+Alternatively, the application can be run in a [Docker](https://docker.com) container:
+
+```
+docker-compose up
+```
+
 Then open your browser to `localhost:4000` to view the site.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+app:
+  build: .
+  ports:
+    - '4000:4000'
+  volumes:
+    - .:/usr/src/app


### PR DESCRIPTION
This PR creates a `Dockerfile` and `docker-compose.yml`, enabling it to be easily launched in a Docker container. I tested this using [Docker for Mac](https://docs.docker.com/docker-for-mac/) and [Docker for Windows](https://docs.docker.com/docker-for-windows/).
