### PR TITLE
accept urls of the form github.com/user/repo/issues/labels/label

### DIFF
--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -63,8 +63,9 @@
   })(window);
 
   var issueCount = function(project) {
+
     var a = $(project).find('.label a')
-      , gh = a.attr('href').match(/github.com(\/[^\/]+\/[^\/]+\/)labels\/([^\/]+)$/)
+      , gh = a.attr('href').match(/github.com(\/[^\/]+\/[^\/]+\/)(?:issues\/)?labels\/([^\/]+)$/)
       , url = gh && ('https://api.github.com/repos' + gh[1] + 'issues?labels=' + gh[2])
       , count = a.find('.count');
 


### PR DESCRIPTION
... for github labels.

The same URL without `issues/` in the middle is currently accepted, but adding that in also works - github redirects to `github/com/user/repo/issues?q=label%3label`

I noticed this in #470, and thought it would be better to accept more versions of the URL than to require one in particular.

In my opinion, it would be better to explicitly say we're giving a github label in the YAML by writing a line `github-label: <label>` rather than `link: github.com/<user>/<repo>/labels/<label>`, and then construct the URL from the given label.
