### PR TITLE
[WIP] add some automated feedback for the label name

### DIFF
--- a/_data/projects/Beavy.yml
+++ b/_data/projects/Beavy.yml
@@ -7,5 +7,5 @@ tags:
 - react
 - web
 upforgrabs:
-  name: help-wanted
+  name: help wanted
   link: https://github.com/beavyHQ/beavy/labels/help%20wanted

--- a/_data/projects/ClippyService.yml
+++ b/_data/projects/ClippyService.yml
@@ -7,5 +7,5 @@ tags:
 - linter
 - web
 upforgrabs:
-  name: help-wanted
+  name: help wanted
   link: https://github.com/ligthyear/clippy-service/labels/help%20wanted

--- a/_data/projects/Dive_into_Machine_Learning.yml
+++ b/_data/projects/Dive_into_Machine_Learning.yml
@@ -8,5 +8,5 @@ tags:
 - scikit-learn
 - data-science
 upforgrabs:
-  name: help-wanted
+  name: help wanted
   link: https://github.com/hangtwenty/dive-into-machine-learning/labels/help%20wanted

--- a/_data/projects/Free_Code_Camp.yml
+++ b/_data/projects/Free_Code_Camp.yml
@@ -9,5 +9,5 @@ tags:
 - react
 - node
 upforgrabs:
-  name: help-wanted
+  name: help wanted
   link: https://github.com/freecodecamp/freecodecamp/labels/help%20wanted

--- a/_data/projects/Homebrew.yml
+++ b/_data/projects/Homebrew.yml
@@ -8,5 +8,5 @@ tags:
 - terminal
 - packaging
 upforgrabs:
-  name: help-wanted
-  link: https://github.com/Homebrew/homebrew/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22
+  name: help wanted
+  link: https://github.com/Homebrew/homebrew/issues/labels/help%20wanted

--- a/_data/projects/OpenSynthesis.yml
+++ b/_data/projects/OpenSynthesis.yml
@@ -10,5 +10,5 @@ tags:
 - collaboration
 - analysis
 upforgrabs:
-  name: Help Wanted
+  name: help wanted
   link: https://github.com/twschiller/open-synthesis/labels/help%20wanted

--- a/_data/projects/SmallestDotNet.yml
+++ b/_data/projects/SmallestDotNet.yml
@@ -7,5 +7,5 @@ tags:
 - csharp
 - oss
 upforgrabs:
-  name: First Timers Only
+  name: first-timers-only
   link: https://github.com/shanselman/smallestdotnet/labels/first-timers-only

--- a/_data/projects/dotnetcorekoans.yml
+++ b/_data/projects/dotnetcorekoans.yml
@@ -7,5 +7,5 @@ tags:
 - TDD
 - "Cross Platform"
 upforgrabs:
-  name: up-for-grabs
+  name: "Up for Grabs"
   link: https://github.com/NotMyself/DotNetCoreKoans/labels/Up%20for%20Grabs

--- a/_data/projects/formo.yml
+++ b/_data/projects/formo.yml
@@ -9,4 +9,4 @@ tags:
 - dynamic
 upforgrabs:
   name: please contribute
-  link: https://github.com/ChrisMissal/Formo/labels/please+contribute
+  link: https://github.com/ChrisMissal/Formo/labels/please%20contribute

--- a/_data/projects/haywire.yml
+++ b/_data/projects/haywire.yml
@@ -9,4 +9,4 @@ tags:
 - C
 upforgrabs:
   name: help out!
-  link: https://github.com/kellabyte/Haywire/labels/help%20out!
+  link: https://github.com/kellabyte/Haywire/labels/help%20out%21

--- a/_data/projects/leaflet.yml
+++ b/_data/projects/leaflet.yml
@@ -6,5 +6,5 @@ tags:
 - Maps
 - GIS
 upforgrabs:
-  name: easy-fix
+  name: easy fix
   link: https://github.com/Leaflet/Leaflet/labels/easy%20fix

--- a/_data/projects/monument-cli.yml
+++ b/_data/projects/monument-cli.yml
@@ -7,5 +7,5 @@ tags:
 - cli
 - node
 upforgrabs:
-  name: "first contribution"
+  name: first-contribution
   link: https://github.com/ansble/monument-cli/labels/first-contribution

--- a/_data/projects/omnisharp-atom.yml
+++ b/_data/projects/omnisharp-atom.yml
@@ -11,5 +11,5 @@ tags:
 - typescript
 - C#
 upforgrabs:
-  name: Help Wanted
+  name: help wanted
   link: https://github.com/OmniSharp/omnisharp-atom/labels/help%20wanted

--- a/_data/projects/openra.yml
+++ b/_data/projects/openra.yml
@@ -16,4 +16,4 @@ tags:
 - A-Star
 upforgrabs:
   name: easy
-  link: https://github.com/OpenRA/OpenRA/labels/Easy
+  link: https://github.com/OpenRA/OpenRA/labels/easy

--- a/_data/projects/owl.js.yml
+++ b/_data/projects/owl.js.yml
@@ -8,4 +8,4 @@ tags:
 - REST
 upforgrabs:
   name: up for grabs
-  link: https://github.com/owljsorg/owl.js/issues?q=is%3Aissue+is%3Aopen+label%3A%22up+for+grabs%22
+  link: https://github.com/owljsorg/owl.js/issues/labels/up%20for%20grabs

--- a/_data/projects/ownCloud.yml
+++ b/_data/projects/ownCloud.yml
@@ -15,5 +15,5 @@ tags:
 - c++
 - qt
 upforgrabs:
-  name: junior-job
+  name: junior job
   link: https://github.com/owncloud/core/labels/junior%20job

--- a/_data/projects/phpdocumentor.yml
+++ b/_data/projects/phpdocumentor.yml
@@ -10,5 +10,5 @@ tags:
 - apidocs
 - phpdoc
 upforgrabs:
-  name: up-for-grabs
+  name: Up-for-grabs
   link: https://github.com/phpDocumentor/phpDocumentor2/labels/Up-for-grabs

--- a/_data/projects/reactjs-bootstrap.yml
+++ b/_data/projects/reactjs-bootstrap.yml
@@ -7,5 +7,5 @@ tags:
 - javascript
 - bootstrap
 upforgrabs:
-  name: Help Wanted
-  link: https://github.com/react-bootstrap/react-bootstrap/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22
+  name: help wanted
+  link: https://github.com/react-bootstrap/react-bootstrap/issues/label/help%20wanted

--- a/scripts/cibuild.rb
+++ b/scripts/cibuild.rb
@@ -20,7 +20,7 @@ def check_folder
 end
 
 def valid_url? (url)
-   begin
+  begin
     uri = URI.parse(url)
     uri.kind_of?(URI::HTTP) || uri.kind_of?(URI::HTTPS)
   rescue URI::InvalidURIError
@@ -86,17 +86,21 @@ def verify_file (f)
       return [f, error]
     end
 
-    if yaml["upforgrabs"]["name"].nil? then
+    name = yaml["upforgrabs"]["name"]
+
+    if name.nil? then
       error = "Required 'upforgrabs.name' attribute is not defined"
       return [f, error]
     end
 
-    if yaml["upforgrabs"]["link"].nil? then
+    link = yaml["upforgrabs"]["link"]
+
+    if link.nil? then
       error = "Required 'upforgrabs.link' attribute is not defined"
       return [f, error]
     end
 
-    if !valid_url?(yaml["upforgrabs"]["link"]) then
+    if !valid_url?(link) then
       error = "Required 'upforgrabs.link' attribute to be a valid url"
       return [f, error]
     end
@@ -105,7 +109,7 @@ def verify_file (f)
     error = "Unable to parse the contents of file - Line: #{e.line}, Offset: #{e.offset}, Problem: #{e.problem}"
     return [f, error]
   rescue
-    error = "Unknown exception for file: " + $!
+    error = "Unknown exception for file: " + $!.to_s
     return [f, error]
   end
 


### PR DESCRIPTION
🌵 **DON'T MERGE JUST YET** 🌵 

This automates a check that I do when reviewing new projects - see #473 for an example:
- the `upforgrabs.link` value should be encoded and appear in the `upforgrabs.url`
- for cases where we know it matches up to a GitHub repository, we should check it
- it's not a hard-and-fast rule

I might change this to be a suggestion rather than fail the build, but I don't have the infrastructure for that right now. 

I also cleaned up the projects which were caught by this check.
