### PR TITLE
Add trae to projects

### DIFF
--- a/_data/projects/trae.yml
+++ b/_data/projects/trae.yml
@@ -1,0 +1,12 @@
+name: trae
+desc: Minimalistic Fetch based HTTP client for the browser
+site: https://github.com/Huemul/trae
+tags:
+- oss
+- web
+- fetch
+- http
+- javascript
+upforgrabs:
+  name: up-for-grabs
+  link: https://github.com/Huemul/trae/labels/up-for-grabs


### PR DESCRIPTION
This PR adds [`trae`](https://github.com/huemul/trae) to the projects.