### PR TITLE
Update freeCodeCamp Project

### DIFF
--- a/_data/projects/freeCodeCamp.yml
+++ b/_data/projects/freeCodeCamp.yml
@@ -1,5 +1,5 @@
-name: Free Code Camp
-desc: The http://FreeCodeCamp.com open source codebase and curriculum. Learn to code and help nonprofits.
+name: freeCodeCamp
+desc: The http://freeCodeCamp.com open source codebase and curriculum. Learn to code and help nonprofits.
 site: https://github.com/freecodecamp/freecodecamp
 tags:
 - javascript


### PR DESCRIPTION
freeCodeCamp is switching its naming convention to use lowerCamelCase - freeCodeCamp, so this PR is to help with that process. Feel free to check out the issue on freeCodeCamp [here](https://github.com/freeCodeCamp/freeCodeCamp/issues/12472)!