### PR TITLE
The deepstream.io tag is actually help-wanted

### DIFF
--- a/_data/projects/deepstream.io.yml
+++ b/_data/projects/deepstream.io.yml
@@ -25,5 +25,5 @@ tags:
 - iOS
 
 upforgrabs:
-  name: help wanted
-  link: https://github.com/hoxton-one/deepstream.io/labels/help%20wanted
+  name: help-wanted
+  link: https://github.com/hoxton-one/deepstream.io/labels/help-wanted


### PR DESCRIPTION
(with a hyphen)