### PR TITLE
Use to github ETags to reduce rate limiting

### DIFF
--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -82,21 +82,57 @@
         count.html(cached.count);
         return;
     }
-
-    $.ajax(url)
-      .done(function(data, textStatus, jqXHR) {
-        var resultCount = data && typeof data.length === 'number' ? data.length.toString() : '?';
-        count.html(resultCount);
-        storage.set(gh[1], { "count": resultCount, "date": new Date() });
-      })
-      .fail(function(jqXHR, textStatus, errorThrown) {
-        var rateLimited = jqXHR.getResponseHeader('X-RateLimit-Remaining') === '0'
-          , rateLimitReset = rateLimited && new Date(1000 * +jqXHR.getResponseHeader('X-RateLimit-Reset'))
-          , message = rateLimitReset ? 'GitHub rate limit met. Reset at ' + rateLimitReset.toLocaleTimeString() + '.' :
-                      'Could not get issue count from GitHub: ' + ((jqXHR.responseJSON && jqXHR.responseJSON.message) || errorThrown) + '.';
-        count.html('?!');
-        count.attr('title', message);
+    if (cached && cached.ETag) {
+      $.ajax({
+        url: url,
+        headers: {
+          'If-None-Match': cached.ETag
+        }
+      }).done(function(data, textStatus, jqXHR) {
+        if (textStatus == 'notmodified') {
+          var cached = storage.get(gh[1]);
+          count.html(cached.count);
+        } else {
+          $.ajax(url).done(function(data, textStatus, jqXHR) {
+            getUrl(data, jqXHR, count, storage, gh[1]);
+          }).fail(function(jqXHR, textStatus, errorThrown) {
+            rateLimited(jqXHR, count, errorThrown);
+          });
+        }
+      }).fail(function(jqXHR, textStatus, errorThrown) {
+        rateLimited(jqXHR, count, errorThrown);
       });
+      return;
+    }
+    $.ajax(url).done(function(data, textStatus, jqXHR) {
+      getUrl(data, jqXHR, count, storage, gh[1]);
+    }).fail(function(jqXHR, textStatus, errorThrown) {
+      rateLimited(jqXHR, count, errorThrown);
+    });
+  };
+
+  function rateLimited(jqXHR, count, errorThrown) {
+    if (jqXHR.statusText == 'error') {
+      count.html('?!');
+      count.attr('title', 'AJAX error');
+      return;
+    }
+    var rateLimited = jqXHR.getResponseHeader('X-RateLimit-Remaining') === '0',
+      rateLimitReset = rateLimited && new Date(1000 * +jqXHR.getResponseHeader('X-RateLimit-Reset')),
+      message = rateLimitReset ? 'GitHub rate limit met. Reset at ' + rateLimitReset.toLocaleTimeString() + '.' : 'Could not get issue count from GitHub: ' + ((jqXHR.responseJSON && jqXHR.responseJSON.message) || errorThrown) + '.';
+    count.html('?!');
+    count.attr('title', message);
+  };
+
+  function getUrl(data, jqXHR, count, storage, projectName) {
+    var resultCount = data && typeof data.length === 'number' ? data.length.toString() : '?';
+    count.html(resultCount);
+    storage.set(projectName, {
+      "count": resultCount,
+      "date": new Date(),
+      "ETag": jqXHR.getResponseHeader('ETag')
+    });
+    console.log('X-RateLimit-Remaining = ' + jqXHR.getResponseHeader('X-RateLimit-Remaining'));
   };
 
   $(function() {


### PR DESCRIPTION
#261 Use the Github [conditional request functionality](https://developer.github.com/v3/#conditional-requests) so that even when the local cache has expired you don't use some of the limited (60) requests allowed.

I'm not a JavaScript/JQuery programmer, so I'm happy to hear about any improvements to this.