### PR TITLE
render project links in index.html

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -13,34 +13,6 @@
     <% }) %>
     </ul>
   </div>
-  <table class="projects">
-   <% _.each(projects, function(project){ %>
-    <tbody>
-    <tr>
-       <td colspan="2" class="title">
-           <span class="proj"><a href="<%-project.site %>"><%-project.name %></a></span>
-       </td>
-    </tr>
-    <tr>
-       <td class="details">
-        <p class="label"><a href="<%- project.upforgrabs.link %>" title="View open issues for <%-project.name %>"><%-project.upforgrabs.name %></a></p>
-       </td>
-       <td class="details">
-           <% if (project.desc) { %>
-           <span class="desc"><%=project.desc%></span>
-           <% } %>
-           <% if (project.tags) { %>
-           <p class="tags">
-               <% _.each(project.tags, function(tag, i) { %>
-                   <a href="#/tags/<%-encodeURIComponent(tag)%>"><%-tag%></a><%- i != project.tags.length-1 ? "," : "" %>
-               <% }) %>
-           </p>
-           <% } %>
-       </td>
-    </tr>
-    </tbody>
-   <% }) %>
-   </table>
 </script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/showdown/1.3.0/showdown.min.js"></script>
 <script type="text/javascript">

--- a/index.html
+++ b/index.html
@@ -8,6 +8,35 @@ layout: default
 <div class="block">
   <h1><span class="header-inside">Projects</span></h1>
   <div id="projects-panel">
+    <div id="filter-panel"></div>
+    <table class="projects">
+      {% for pdata in site.data.projects %}
+      {% assign project = pdata[1] %}
+      <tbody class="project visible" data-name="{{project.name|escape}}">
+        <tr>
+          <td colspan="2" class="title">
+            <span class="proj"><a href="{{project.site}}">{{project.name}}</a></span>
+          </td>
+        </tr>
+        <tr>
+          <td class="details">
+            <p class="label"><a href="{{project.upforgrabs.link}}" title="View open issues for {{project.name}}">{{project.upforgrabs.name}}</a></p>
+          </td>
+          <td class="details">
+            {% if project.desc  %}
+            <span class="desc">{{project.desc}}</span>
+            {% endif %}
+            {% if project.tags %}
+            <p class="tags">
+            {% assign numtags = project.tags|size %}
+            {% for tag in project.tags %}{% if forloop.index > 1 and numtags>1 %}, {% endif %}<a href="#/tags/{{tag}}>">{{tag}}</a>{% endfor %}
+            </p>
+            {% endif %}
+          </td>
+        </tr>
+      </tbody>
+      {% endfor %}
+    </table>
   </div>
 </div>
 <div class="block">

--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -5,12 +5,20 @@
     projectsPanel = null;
 
   var renderProjects = function (tags) {
-    projectsPanel.html(compiledtemplateFn({
-      "projects": projectsSvc.get(tags),
+    var included_projects = projectsSvc.get(tags);
+    $('#filter-panel').html(compiledtemplateFn({
+      "projects": included_projects,
       "tags": projectsSvc.getTags(),
       "popularTags": projectsSvc.getPopularTags(6),
       "selectedTags": tags
     }));
+
+    $('.project').hide();
+    _.each(included_projects,function(project,i) {
+      var elem = $('.project[data-name="'+project.name+'"]');
+      $('.projects').append(elem);
+      $(elem).show();
+    });
 
     projectsPanel.find("select.tags-filter").chosen({
       no_results_text: "No tags found by that name.",


### PR DESCRIPTION
At the moment, the project data is held in JSON and the list is created
in javascript after the page loads. This breaks the site for users
without JS.

This moves the rendering of the project list to index.html, so it's
included in the static page, and then the renderProjects() function
shows/hides and reorders the projects as necessary.

If the JS doesn't run, you just see the complete list of projects in the
default order, without the filter interface.

This somewhat conflicts with #525, which assumes that the page is unusable if JS isn't supported.