### PR TITLE
Modify up-for-grabs label for Algos

### DIFF
--- a/_data/projects/Faheel_Algos.yml
+++ b/_data/projects/Faheel_Algos.yml
@@ -6,5 +6,5 @@ tags:
 - Data Structures
 - C++
 upforgrabs:
-  name: up-for-grabs
-  link: https://github.com/faheel/Algos/issues?q=is%3Aissue+is%3Aopen+label%3Aup-for-grabs
+  name: Up for grabs
+  link: https://github.com/faheel/Algos/issues?q=is%3Aopen+is%3Aissue+label%3A%22Up+for+grabs%22


### PR DESCRIPTION
Renamed the `up-for-grabs` label name to `Up for grabs` for the Algos project.