### PR TITLE
Update up-for-grabs label in dotnet/CoreFX, dotnet/CoreFXLab and dotnet/Roslyn repos

### DIFF
--- a/_data/projects/dotnet-compiler-platform-roslyn.yml
+++ b/_data/projects/dotnet-compiler-platform-roslyn.yml
@@ -12,4 +12,4 @@ tags:
 - VB.NET
 upforgrabs:
   name: Up for Grabs
-  link: https://github.com/dotnet/roslyn/labels/Up%20for%20Grabs
+  link: https://github.com/dotnet/roslyn/labels/up-for-grabs

--- a/_data/projects/dotnet-core-framework-lab.yml
+++ b/_data/projects/dotnet-core-framework-lab.yml
@@ -11,4 +11,4 @@ tags:
 - "C#"
 upforgrabs:
   name: up for grabs
-  link: https://github.com/dotnet/corefxlab/labels/up%20for%20grabs
+  link: https://github.com/dotnet/corefxlab/labels/up-for-grabs

--- a/_data/projects/dotnet-core-framework.yml
+++ b/_data/projects/dotnet-core-framework.yml
@@ -7,4 +7,4 @@ tags:
 - ".NET"
 upforgrabs:
   name: up for grabs
-  link: https://github.com/dotnet/corefx/labels/up%20for%20grabs
+  link: https://github.com/dotnet/corefx/labels/up-for-grabs


### PR DESCRIPTION
Aligning the repos with recommended up-for-grabs label name.

See https://github.com/dotnet/corefx/issues/17533 tracking label alignment across 6 dotnet repos.