### PR TITLE
[WIP] enforce some linting for JS

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,20 @@
+module.exports = {
+    "env": {
+        "browser": true
+    },
+    "extends": "eslint:recommended",
+    "rules": {
+        "indent": [
+            "error",
+            2
+        ],
+        "quotes": [
+            "error",
+            "single"
+        ],
+        "semi": [
+            "error",
+            "always"
+        ]
+    }
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 _site/
+node_modules/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,19 @@ rvm:
 sudo: false
 
 install:
+  # use a recent version of Node
+  - . $HOME/.nvm/nvm.sh
+  - nvm install stable
+  - nvm use stable
+  # and also ensure NPM is up to date
+  - npm install --global npm
+  - npm install
   - bundle install
 
 script:
   - bundle exec jekyll build
   - ruby scripts/cibuild.rb
+  - npm run lint
 
 branches:
   only:

--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -1,3 +1,5 @@
+/* global ProjectsService, projects, QUOTA_EXCEEDED_ERR, NS_ERROR_DOM_QUOTA_REACHED, _, jQuery */
+
 (function ($) {
 
   var projectsSvc = new ProjectsService(projects),
@@ -6,31 +8,31 @@
 
   var renderProjects = function (tags) {
     projectsPanel.html(compiledtemplateFn({
-      "projects": projectsSvc.get(tags),
-      "tags": projectsSvc.getTags(),
-      "popularTags": projectsSvc.getPopularTags(6),
-      "selectedTags": tags
+      'projects': projectsSvc.get(tags),
+      'tags': projectsSvc.getTags(),
+      'popularTags': projectsSvc.getPopularTags(6),
+      'selectedTags': tags
     }));
 
-    projectsPanel.find("select.tags-filter").chosen({
-      no_results_text: "No tags found by that name.",
-      width: "95%"
-    }).val(tags).trigger('chosen:updated').change(function (e) {
-      window.location.href = "#/tags/" + encodeURIComponent(($(this).val() || ""));
+    projectsPanel.find('select.tags-filter').chosen({
+      no_results_text: 'No tags found by that name.',
+      width: '95%'
+    }).val(tags).trigger('chosen:updated').change(function () {
+      window.location.href = '#/tags/' + encodeURIComponent(($(this).val() || ''));
     });
   };
 
   var app = $.sammy(function () {
-    this.get("#/", function (context) {
+    this.get('#/', function () {
       renderProjects();
     });
 
-    this.get("#/tags/", function (context) {
+    this.get('#/tags/', function () {
       renderProjects();
     });
 
-    this.get("#/tags/:tags", function (context) {
-      var tags = (this.params["tags"] || "").toLowerCase().split(",");
+    this.get('#/tags/:tags', function () {
+      var tags = (this.params['tags'] || '').toLowerCase().split(',');
       renderProjects(tags);
     });
   });
@@ -38,7 +40,7 @@
   var storage = (function (global) {
     function set(name, value) {
       try {
-        if (typeof (global.localStorage) !== "undefined") {
+        if (typeof (global.localStorage) !== 'undefined') {
           global.localStorage.setItem(name, JSON.stringify(value));
         }
       } catch (exception) {
@@ -47,14 +49,14 @@
           throw exception;
         }
       }
-    };
+    }
 
     function get(name) {
-      if (typeof (global.localStorage) !== "undefined") {
+      if (typeof (global.localStorage) !== 'undefined') {
         return JSON.parse(global.localStorage.getItem(name));
       }
       return undefined;
-    };
+    }
 
     return {
       set: set,
@@ -69,7 +71,7 @@
       url = gh && ('https://api.github.com/repos' + gh[1] + 'issues?labels=' + gh[2]),
       count = a.find('.count');
 
-    if (!!count.length) {
+    if (count.length === 0) {
       return;
     }
 
@@ -86,12 +88,12 @@
     }
 
     $.ajax(url)
-      .done(function (data, textStatus, jqXHR) {
+      .done(function (data) {
         var resultCount = data && typeof data.length === 'number' ? data.length.toString() : '?';
         count.html(resultCount);
         storage.set(gh[1], {
-          "count": resultCount,
-          "date": new Date()
+          'count': resultCount,
+          'date': new Date()
         });
       })
       .fail(function (jqXHR, textStatus, errorThrown) {
@@ -126,20 +128,20 @@
         });
     });
 
-    compiledtemplateFn = _.template($("#projects-panel-template").html());
-    projectsPanel = $("#projects-panel");
+    compiledtemplateFn = _.template($('#projects-panel-template').html());
+    projectsPanel = $('#projects-panel');
 
-    projectsPanel.on("click", "a.remove-tag", function (e) {
+    projectsPanel.on('click', 'a.remove-tag', function (e) {
       e.preventDefault();
       var tags = [];
-      projectsPanel.find("a.remove-tag").not(this).each(function () {
-        tags.push($(this).data("tag"));
+      projectsPanel.find('a.remove-tag').not(this).each(function () {
+        tags.push($(this).data('tag'));
       });
-      var tagsString = tags.join(",");
-      window.location.href = "#/tags/" + tagsString;
+      var tagsString = tags.join(',');
+      window.location.href = '#/tags/' + tagsString;
     });
 
     app.raise_errors = true;
-    app.run("#/");
+    app.run('#/');
   });
 })(jQuery);

--- a/javascripts/projectsService.js
+++ b/javascripts/projectsService.js
@@ -1,14 +1,16 @@
+/* global _ */
+
 (function (host, _) {
   var applyTagsFilter = function (projects, tagsMap, tags) {
-    if (typeof tags === "string") {
-      tags = tags.split(",");
+    if (typeof tags === 'string') {
+      tags = tags.split(',');
     }
 
     tags = _.map(tags, function (entry) {
-      return entry && entry.replace(/^\s+|\s+$/g, "");
+      return entry && entry.replace(/^\s+|\s+$/g, '');
     });
 
-    if (!tags || !tags.length || tags[0] == "") {
+    if (!tags || !tags.length || tags[0] == '') {
       return projects;
     }
 
@@ -26,13 +28,13 @@
     var _tagsMap = {},
       _orderedTagsMap = null;
 
-    var _addTag = function (tag, projectName) {
+    var _addTag = function (tag) {
       var tagLowerCase = tag.toLowerCase();
       if (!_.has(_tagsMap, tagLowerCase)) {
         _tagsMap[tagLowerCase] = {
-          "name": tag,
-          "frequency": 0,
-          "projects": []
+          'name': tag,
+          'frequency': 0,
+          'projects': []
         };
       }
       return _tagsMap[tagLowerCase];
@@ -40,12 +42,12 @@
 
 
     var _addProjectToTag = function (entry, projectName) {
-        entry.projects.push(projectName);
-        entry.frequency++;
+      entry.projects.push(projectName);
+      entry.frequency++;
     };
 
     this.addTag = function(tag, projectName) {
-      var _entry = _addTag(tag, projectName);
+      var _entry = _addTag(tag);
       // Skip updating projects and frequency for projects that tagged themselves
       if(tag.toLowerCase() !== projectName.toLowerCase()) {
         _addProjectToTag(_entry, projectName);
@@ -60,11 +62,11 @@
       //http://stackoverflow.com/questions/16426774/underscore-sortby-based-on-multiple-attributes
       return _orderedTagsMap = _orderedTagsMap || _(_tagsMap).chain().sortBy(function (tag, key) {
         return key;
-      }).sortBy(function (tag, key) {
+      }).sortBy(function (tag) {
         return tag.frequency * -1;
       }).value();
     };
-  }
+  };
 
   var extractTags = function (projectsData) {
     var tagBuilder = new TagBuilder();
@@ -80,8 +82,8 @@
 
   var extractProjectsAndTags = function (projectsData) {
     return {
-      "projects": projectsData,
-      "tags": extractTags(projectsData)
+      'projects': projectsData,
+      'tags': extractTags(projectsData)
     };
   };
 
@@ -93,7 +95,7 @@
       sessionStorage.setItem);
     var ordering = null;
     if (canStoreOrdering) {
-      ordering = sessionStorage.getItem("projectOrder");
+      ordering = sessionStorage.getItem('projectOrder');
       if (ordering) {
         ordering = JSON.parse(ordering);
 
@@ -107,7 +109,7 @@
     if (!ordering) {
       ordering = _.shuffle(_.range(_projectsData.projects.length));
       if (canStoreOrdering) {
-        sessionStorage.setItem("projectOrder", JSON.stringify(ordering));
+        sessionStorage.setItem('projectOrder', JSON.stringify(ordering));
       }
     }
 
@@ -130,7 +132,7 @@
 
     this.getPopularTags = function (popularTagCount) {
       return _.take(_.values(tagsMap), popularTagCount || 10);
-    }
+    };
   };
 
   host.ProjectsService = ProjectsService;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "up-for-grabs.net",
+  "version": "1.0.0",
+  "description": "client side tooling for the up-for-grabs website",
+  "scripts": {
+    "lint": "eslint javascripts/**/*.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/up-for-grabs/up-for-grabs.net.git"
+  },
+  "author": "Up-For-Grabs Contributors",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/up-for-grabs/up-for-grabs.net/issues"
+  },
+  "homepage": "https://github.com/up-for-grabs/up-for-grabs.net#readme",
+  "devDependencies": {
+
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
   },
   "homepage": "https://github.com/up-for-grabs/up-for-grabs.net#readme",
   "devDependencies": {
-
+    "eslint": "^3.19.0"
   }
 }


### PR DESCRIPTION
We made some changes in #550 but not everyone has this setup - and it only looks at the coding style instead of addressing structural issues.

This adds some basic `eslint` rules to the CI process to ensure things are okay:

 - [x] see the build fail - [example output](https://travis-ci.org/up-for-grabs/up-for-grabs.net/builds/222710371#L659)
 - [x] tidy up the JS and see it pass
 - [ ] merge active PRs that touch JS files rather than introduce more merge conflicts
 - [ ] tidy up JS again