### PR TITLE
Fixing non-standardized URLs in project YMLs

### DIFF
--- a/_data/projects/8080py.yml
+++ b/_data/projects/8080py.yml
@@ -12,4 +12,4 @@ tags:
 - cli
 upforgrabs:
   name: bitesize
-  link: https://github.com/sadboyzvone/8080py/issues?q=is%3Aopen+is%3Aissue+label%3Abitesize
+  link: https://github.com/sadboyzvone/8080py/labels/bitesize

--- a/_data/projects/Babel.yml
+++ b/_data/projects/Babel.yml
@@ -10,4 +10,4 @@ tags:
 - compiler
 upforgrabs:
   name: Help Wanted
-  link: https://github.com/babel/babel/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22
+  link: https://github.com/babel/babel/labels/help%20wanted

--- a/_data/projects/cpp-ethereum.yml
+++ b/_data/projects/cpp-ethereum.yml
@@ -9,4 +9,4 @@ tags:
 - p2p
 upforgrabs:
   name: up-for-grabs
-  link: https://github.com/ethereum/cpp-ethereum/issues?q=is%3Aissue+is%3Aopen+label%3Aup-for-grabs
+  link: https://github.com/ethereum/cpp-ethereum/labels/up-for-grabs

--- a/_data/projects/golem.yml
+++ b/_data/projects/golem.yml
@@ -13,4 +13,4 @@ tags:
 - distributed computing
 upforgrabs:
   name: up-for-grabs
-  link: https://github.com/golemfactory/golem/issues?q=is%3Aissue+is%3Aopen+label%3Aup-for-grabs
+  link: https://github.com/golemfactory/golem/labels/up-for-grabs

--- a/_data/projects/raiden.yml
+++ b/_data/projects/raiden.yml
@@ -9,4 +9,4 @@ tags:
 - state_channels
 upforgrabs:
   name: low_hanging_fruit
-  link: https://github.com/raiden-network/raiden/issues?q=is%3Aissue+is%3Aopen+label%3Alow_hanging_fruit
+  link: https://github.com/raiden-network/raiden/labels/low_hanging_fruit

--- a/_data/projects/resin.yml
+++ b/_data/projects/resin.yml
@@ -8,4 +8,4 @@ tags:
 - database
 upforgrabs:
   name: up-for-grabs
-  link: https://github.com/kreeben/resin/issues?q=is%3Aopen+is%3Aissue+label%3Aup-for-grabs
+  link: https://github.com/kreeben/resin/labels/up-for-grabs

--- a/_data/projects/server.yml
+++ b/_data/projects/server.yml
@@ -9,4 +9,4 @@ tags:
 - es7
 upforgrabs:
   name: up-for-grabs
-  link: https://github.com/franciscop/server/issues?q=is%3Aissue+is%3Aopen+label%3Aup-for-grabs
+  link: https://github.com/franciscop/server/labels/up-for-grabs


### PR DESCRIPTION
The patched YMLs were not able to be parsed by `issueCount`, which causes a "Issue count is only available for projects on GitHub" error. This changes the URL's format to an equivalent one, and restores the issue count for each project on the list.

See up-for-grabs/up-for-grabs.net#605 and up-for-grabs/up-for-grabs.net#607 for more information.
Closes #605.