### PR TITLE
Changing label for debugger.html project to be available

### DIFF
--- a/_data/projects/debugger.html.yml
+++ b/_data/projects/debugger.html.yml
@@ -1,5 +1,5 @@
 name: debugger.html
-desc: Next generation JS debugger built for the web and Firefox
+desc: The Firefox debugger that works anywhere
 site: https://github.com/devtools-html/debugger.html
 tags:
 - oss
@@ -10,5 +10,5 @@ tags:
 - debugger
 - mozilla
 upforgrabs:
-  name: up for grabs
-  link: https://github.com/devtools-html/debugger.html/labels/up%20for%20grabs
+  name: available
+  link: https://github.com/devtools-html/debugger.html/labels/available


### PR DESCRIPTION
We've received some feedback that "up for grabs" doesn't translate well beyond English so we've switched our local label to be `available`.  

Love this project, thanks for creating it.  Let us know how and if we can help.