### PR TITLE
Change label to `up-for-grabs`

### DIFF
--- a/_data/projects/axelrod.yml
+++ b/_data/projects/axelrod.yml
@@ -6,5 +6,5 @@ tags:
 - python
 - gametheory
 upforgrabs:
-  name: easy_pull_request
-  link: https://github.com/Axelrod-Python/Axelrod/labels/Easy_pull_request 
+  name: up-for-grabs
+  link: https://github.com/Axelrod-Python/Axelrod/labels/up-for-grabs


### PR DESCRIPTION
We currently have `Easy_pull_request` but would prefer to avoid the word `Easy`.