### PR TITLE
Updated NUnit up-for-grabs label and tags

### DIFF
--- a/_data/projects/nunit.yml
+++ b/_data/projects/nunit.yml
@@ -8,5 +8,5 @@ tags:
 - TDD
 
 upforgrabs:
-  name: easyfix
-  link: https://github.com/nunit/nunit/labels/easyfix
+  name: up-for-grabs
+  link: https://github.com/nunit/nunit/labels/up-for-grabs

--- a/_data/projects/nunit.yml
+++ b/_data/projects/nunit.yml
@@ -2,10 +2,17 @@ name: NUnit
 desc: NUnit is the most popular and widely used unit test framework for .NET
 site: https://github.com/nunit/nunit
 tags:
+- NUnit
 - ".NET"
+- ".NET Core"
+- dotnet
+- dotnetcore
+- cross-platform
 - C#
-- Testing
+- testing
+- unit testing
 - TDD
+- OSS
 
 upforgrabs:
   name: up-for-grabs

--- a/_data/projects/nunit.yml
+++ b/_data/projects/nunit.yml
@@ -5,8 +5,6 @@ tags:
 - NUnit
 - ".NET"
 - ".NET Core"
-- dotnet
-- dotnetcore
 - cross-platform
 - C#
 - testing


### PR DESCRIPTION
We recently switched to using `up-for-grabs` to indicate up-for-grabsness and would also like to catch up with some tags.

/cc @rprouse @CharliePoole @ChrisMaddock