### PR TITLE
Add OpenDominion project

### DIFF
--- a/_data/projects/OpenDominion.yml
+++ b/_data/projects/OpenDominion.yml
@@ -1,0 +1,13 @@
+name: OpenDominion
+desc: A text-based, persistent browser-based strategy game (PBBG) in a fantasy war setting
+site: https://opendominion.net
+tags:
+- php
+- laravel
+- web
+- game
+- browser-game
+- pbbg
+upforgrabs:
+  name: up-for-grabs
+  link: https://github.com/WaveHack/OpenDominion/labels/up-for-grabs

--- a/_data/projects/OpenDominion.yml
+++ b/_data/projects/OpenDominion.yml
@@ -9,5 +9,5 @@ tags:
 - browser-game
 - pbbg
 upforgrabs:
-  name: up-for-grabs
-  link: https://github.com/WaveHack/OpenDominion/labels/up-for-grabs
+  name: good first issue
+  link: https://github.com/WaveHack/OpenDominion/labels/good%20first%20issue


### PR DESCRIPTION
OpenDominion is a text-based, persistent browser-based strategy game (PBBG) in a fantasy war setting.

https://github.com/WaveHack/OpenDominion/labels/good%20first%20issue
