### PR TITLE
Rename "beginner" to "good first issue"

### DIFF
--- a/_data/projects/jabref.yml
+++ b/_data/projects/jabref.yml
@@ -12,6 +12,6 @@ tags:
 - junit
 - gradle
 upforgrabs:
-  name: beginner
-  link: https://github.com/JabRef/jabref/labels/beginner
+  name: good first issue
+  link: https://github.com/JabRef/jabref/labels/good%20first%20issue
 contribute: https://github.com/JabRef/jabref/blob/master/CONTRIBUTING.md


### PR DESCRIPTION
I saw following popup on JabRef's GitHub repository:

![grafik](https://user-images.githubusercontent.com/1366654/31479535-2d2d1170-af18-11e7-9440-6af4b8765f7c.png)

Google did not find more about this movement, but I followed the suggestion by GitHub and renamed "beginner" to "good first issue". Thus, I also renamed it here in `jabref.yml` to ensure that the list of beginner issues is still correct.