### PR TITLE
Peek now uses "good first issue" tag

### DIFF
--- a/_data/projects/Peek.yml
+++ b/_data/projects/Peek.yml
@@ -9,5 +9,5 @@ tags:
 - screencast
 - animated-gifs
 upforgrabs:
-  name: up-for-grabs
-  link: https://github.com/phw/peek/labels/up-for-grabs
+  name: good first issue
+  link: https://github.com/phw/peek/labels/good%20first%20issue


### PR DESCRIPTION
This seems to emerge as a standard on Github and is advertised by them.