### PR TITLE
Update link to Drupal Novice issues queue

### DIFF
--- a/_data/projects/drupal.yml
+++ b/_data/projects/drupal.yml
@@ -8,4 +8,4 @@ tags:
 - Drupal
 upforgrabs:
   name: Novice Issues
-  link: http://tinyurl.com/80xNovice
+  link: http://tinyurl.com/7x-8xNovice


### PR DESCRIPTION
Existing link brings the user to the Drupal 8.0.x Novice issues queue, which returns empty results as the selected version ( Drupal 8.0.* ) is now outdated.

In order to always pull fresh issues the new link brings the user to Drupal core 7.x and 8.x Novice issues queue.