### PR TITLE
Update AutoFixture label info

### DIFF
--- a/_data/projects/autofixture.yml
+++ b/_data/projects/autofixture.yml
@@ -12,5 +12,5 @@ tags:
 - C#
 - F#
 upforgrabs:
-  name: jump in
-  link: https://github.com/AutoFixture/AutoFixture/labels/jump%20in
+  name: good first issue
+  link: https://github.com/AutoFixture/AutoFixture/labels/good%20first%20issue


### PR DESCRIPTION
Recently AutoFixture [renamed](https://github.com/AutoFixture/AutoFixture/issues/914) `jump in` label to `good first issue` to align that with the latest GitHub recommendations. In this PR I'm changing info about that label.