### PR TITLE
Fix searching for project names with whitespace not returning results.

### DIFF
--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -22,6 +22,7 @@
     });
 
     projectsPanel.find("select.names-filter").chosen({
+      search_contains: true,
       no_results_text: "No project found by that name.",
       width: "95%"
     }).val(names).trigger('chosen:updated').change(function (e) {


### PR DESCRIPTION
Howdy,

I noticed while using your site that some searches weren't working as expected. If I typed "visual" then it showed me a few "Visual Studio" plugin projects, but if I typed "Visual Studio", nothing came up. Enabling chosen.js's `search_contains` flag gives the expected results.

https://harvesthq.github.io/chosen/options.html
https://stackoverflow.com/questions/19061947/chosen-jquery-plugin-search-with-spaces

Evan