### PR TITLE
Change "starter issue" to "good first issue" for Nextcloud

### DIFF
--- a/_data/projects/Nextcloud.yml
+++ b/_data/projects/Nextcloud.yml
@@ -15,5 +15,5 @@ tags:
 - c++
 - qt
 upforgrabs:
-  name: starter issue
-  link: https://github.com/nextcloud/server/labels/starter%20issue
+  name: good first issue
+  link: https://github.com/nextcloud/server/labels/good%20first%20issue


### PR DESCRIPTION
We changed this to adapt the recommendation Github gives. :)
https://github.com/nextcloud/server/labels/good%20first%20issue