### PR TITLE
Update CiviWiki project details/issues link

### DIFF
--- a/_data/projects/CiviWiki.yml
+++ b/_data/projects/CiviWiki.yml
@@ -7,6 +7,8 @@ tags:
 - Django
 - democracy
 - government
+- HTML
+- JavaScript
 upforgrabs:
-  name: Good for New Contributors
-  link: https://github.com/CiviWiki/OpenCiviWiki/labels/Good%20for%20New%20Contributors
+  name: good first issue
+  link: https://github.com/CiviWiki/OpenCiviWiki/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22


### PR DESCRIPTION
We have changed our issue label, as per GitHub recommendation, to 'good first issue'. Updated the link and label title. Added a couple of tech. tags.