### PR TITLE
Added Duality Docs Repo

### DIFF
--- a/_data/projects/duality-docs.yml
+++ b/_data/projects/duality-docs.yml
@@ -1,0 +1,23 @@
+name: Duality Docs
+desc: >
+  A GitHub pages repo for the Duality projects developer manual. If you 
+  have a thing for technical writing and an affinity for game development, 
+  we could use your help!
+  Duality is a modular 2D game engine that provides its own visual editor. 
+  It's highly extensible, written entirely in C# and backed by OpenGL.
+site: http://dualitydocs.adamslair.net/
+tags:
+- markdown
+- documentation
+- ".NET"
+- C#
+- OpenGL
+- gamedev
+- games
+- 2d
+- engine
+- editor
+- framework
+upforgrabs:
+  name: Help Wanted
+  link: https://github.com/AdamsLair/duality-docs/labels/Help%20Wanted

--- a/_data/projects/duality-docs.yml
+++ b/_data/projects/duality-docs.yml
@@ -1,10 +1,5 @@
 name: Duality Docs
-desc: >
-  A GitHub pages repo for the Duality projects developer manual. If you 
-  have a thing for technical writing and an affinity for game development, 
-  we could use your help!
-  Duality is a modular 2D game engine that provides its own visual editor. 
-  It's highly extensible, written entirely in C# and backed by OpenGL.
+desc: Documentation for Duality, a modular 2D game engine written entirely in C#
 site: http://dualitydocs.adamslair.net/
 tags:
 - markdown

--- a/_data/projects/duality.yml
+++ b/_data/projects/duality.yml
@@ -1,7 +1,5 @@
 name: Duality
-desc: >
-  Duality is a modular 2D game engine that provides its own visual editor. 
-  It's highly extensible, written entirely in C# and backed by OpenGL.
+desc: Documentation for Duality, a modular 2D game engine written entirely in C#
 site: http://duality.adamslair.net/
 tags:
 - ".NET"

--- a/_data/projects/duality.yml
+++ b/_data/projects/duality.yml
@@ -1,5 +1,5 @@
 name: Duality
-desc: Documentation for Duality, a modular 2D game engine written entirely in C#
+desc: A modular 2D game engine written entirely in C#
 site: http://duality.adamslair.net/
 tags:
 - ".NET"


### PR DESCRIPTION
Duality is a 2D game development framework that's [already part of upforgrabs](https://github.com/up-for-grabs/up-for-grabs.net/blob/gh-pages/_data/projects/duality.yml) for a few years. We recently split up our documentation, so it's now in a separate project, along with all issues related to the docs themselves. To get them listed again, I've added the docs project to upforgrabs separately, as we appreciate contributions to documentation as much as to the project core.

Let me know whether you think this makes sense for upforgrabs - not sure if tech writing should be a part of it, or whether the focus should be just coding itself, in which case just let me know and close the PR unmerged.