### PR TITLE
Fix Docker-based dev environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
 FROM starefossen/github-pages:onbuild
 
+RUN apk update && apk add libc-dev gcc g++ make
+
 RUN bundle install

--- a/_config.yml
+++ b/_config.yml
@@ -7,3 +7,4 @@ exclude:
   - README.md
   - scripts
   - .travis.yml
+  - vendor


### PR DESCRIPTION
Hi, I've been wanting to add some projects that I lead (or know the leaders
of), but I noticed that deploying the current Docker-based dev environment
locally didn't quite work due to some compilation failures when building native
extensions to some of the dependencies.

I also found some error with the vendored contents:

```
  could not read file /usr/src/app/vendor/bundle/ruby/2.5.0/gems/jekyll-3.7.3/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb: Invalid date '<%= Time.now.strftime('%Y-%m-%d %H:%M:%S %z') %>': Document 'vendor/bundle/ruby/2.5.0/gems/jekyll-3.7.3/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb' does not have a valid date in the YAML front matter
```

I'm not quite a versed jekyll-ologist, but I found a fix
[here](https://github.com/jekyll/jekyll/issues/5267), which I assume translates
properly to this project (at least from what I could see after running
`docker-compose up`)

Hope this helps!