### PR TITLE
switching over to new way to declare this gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,3 @@
 source 'https://rubygems.org'
 
-require 'json'
-require 'open-uri'
-versions = JSON.parse(open('https://pages.github.com/versions.json').read)
-
-gem 'github-pages', versions['github-pages']
+gem 'github-pages', group: :jekyll_plugins

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,7 +252,7 @@ PLATFORMS
   x86-mingw32
 
 DEPENDENCIES
-  github-pages (= 188)
+  github-pages
 
 BUNDLED WITH
-   1.16.1
+   1.16.4


### PR DESCRIPTION
Looks like this changed recently: https://github.com/github/pages-gem#usage