### PR TITLE
Fix broken link to React-Bootstrap's 'help wanted' issues

### DIFF
--- a/_data/projects/reactjs-bootstrap.yml
+++ b/_data/projects/reactjs-bootstrap.yml
@@ -2,10 +2,10 @@ name: React Bootstrap
 desc: React-Bootstrap is a library of reuseable front-end components. You'll get the look-and-feel of Twitter Bootstrap, but with much cleaner code, via Facebook's React.js framework.
 site: https://react-bootstrap.github.io/
 tags:
-  - React
-  - oss
-  - javascript
-  - bootstrap
+- React
+- oss
+- javascript
+- bootstrap
 upforgrabs:
   name: help wanted
   link: https://github.com/react-bootstrap/react-bootstrap/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22

--- a/_data/projects/reactjs-bootstrap.yml
+++ b/_data/projects/reactjs-bootstrap.yml
@@ -2,10 +2,10 @@ name: React Bootstrap
 desc: React-Bootstrap is a library of reuseable front-end components. You'll get the look-and-feel of Twitter Bootstrap, but with much cleaner code, via Facebook's React.js framework.
 site: https://react-bootstrap.github.io/
 tags:
-- React
-- oss
-- javascript
-- bootstrap
+  - React
+  - oss
+  - javascript
+  - bootstrap
 upforgrabs:
   name: help wanted
-  link: https://github.com/react-bootstrap/react-bootstrap/issues/label/help%20wanted
+  link: https://github.com/react-bootstrap/react-bootstrap/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22

--- a/_data/projects/reactjs-bootstrap.yml
+++ b/_data/projects/reactjs-bootstrap.yml
@@ -8,4 +8,4 @@ tags:
 - bootstrap
 upforgrabs:
   name: help wanted
-  link: https://github.com/react-bootstrap/react-bootstrap/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22
+  link: https://github.com/react-bootstrap/react-bootstrap/labels/help%20wanted


### PR DESCRIPTION
Previous link was directing to a 404 page. 