### PR TITLE
Add dotnet-libyear project

### DIFF
--- a/_data/projects/dotnet-libyear.yml
+++ b/_data/projects/dotnet-libyear.yml
@@ -1,0 +1,12 @@
+name: dotnet-libyear
+desc: A simple measure of dependency freshness
+site: https://github.com/stevedesmond-ca/dotnet-libyear
+tags:
+- C#
+- ".NET"
+- dependencies
+- CLI
+- NuGet
+upforgrabs:
+  name: up-for-grabs
+  link: https://github.com/stevedesmond-ca/dotnet-libyear/labels/up-for-grabs


### PR DESCRIPTION
Add a project for `dotnet-libyear`, a .NET Core dependency management tool