### PR TITLE
Update contrast of footer text for a11y

### DIFF
--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -221,7 +221,7 @@ footer {
   padding-bottom: 30px;
   text-align: center; }
   footer * {
-    color: #797979; }
+    color: #737373; }
 
 .container {
   *zoom: 1;


### PR DESCRIPTION
### Issue

Currently the colour contrast ratio of the footer text is below the standard of [WCAG colour contrast](https://www.w3.org/TR/WCAG21/#contrast-minimum) where it should be __at least__ `4.5:1`. As you can see below it is currently at `4.13:1` which is below the standard.

This is a problem for someone that is visually impaired and accessing this site where they might not be able to see the text correctly.

<img width="456" alt="image" src="https://user-images.githubusercontent.com/9055413/46387113-2ea72c00-c693-11e8-8773-b15b41805ed6.png">
<img width="725" alt="image" src="https://user-images.githubusercontent.com/9055413/46386991-9f9a1400-c692-11e8-996b-0a0298e716b9.png">

### Solution

I propose updating the contrast ratio up to `4.5:1` which is the minimum to satisfy WCAG AA requirements.

<img width="463" alt="image" src="https://user-images.githubusercontent.com/9055413/46387122-3c5cb180-c693-11e8-8aab-23288d12c2ec.png">
<img width="725" alt="image" src="https://user-images.githubusercontent.com/9055413/46387134-4c749100-c693-11e8-8070-502d327c6824.png">

