### PR TITLE
Add 'javascript' as a tag for Squirrelly

### DIFF
--- a/_data/projects/squirrelly.yml
+++ b/_data/projects/squirrelly.yml
@@ -7,6 +7,7 @@ tags:
 - template
 - engine
 - handlebars
+- javascript
 upforgrabs:
   name: up-for-grabs
   link: https://github.com/nebrelbug/squirrelly/labels/up-for-grabs


### PR DESCRIPTION
So people can see it when they sort by language. Thank you!