### PR TITLE
Fix #317: Add warning for implicit multi-line strings 

### DIFF
--- a/_data/projects/Virtual-Assistant.yml
+++ b/_data/projects/Virtual-Assistant.yml
@@ -1,6 +1,7 @@
 name: Virtual Assistant
-desc: A linux based Virtual assistant on Artificial Intelligence in C. 
-      Find restaurants in an area, Fetch weather information of any place, Google search, Youtube search, Play media files, Show calendar, etc.  
+desc: >
+  A linux based Virtual assistant on Artificial Intelligence in C. 
+  Find restaurants in an area, Fetch weather information of any place, Google search, Youtube search, Play media files, Show calendar, etc.  
 site: https://github.com/ritwik12/Virtual-Assistant
 tags:
 - C

--- a/_data/projects/shogun.yml
+++ b/_data/projects/shogun.yml
@@ -1,6 +1,7 @@
 name: Shogun Machine Learning Toolbox
-desc: Shogun is a unified and efficient machine learning library. 
-      We support multiple languages and platforms, have an efficient core in C++ and a great community.
+desc: >
+  Shogun is a unified and efficient machine learning library. 
+  We support multiple languages and platforms, have an efficient core in C++ and a great community.
 site: http://shogun.ml/
 tags:
 - machine-learning

--- a/scripts/cibuild.rb
+++ b/scripts/cibuild.rb
@@ -1,6 +1,26 @@
 require 'safe_yaml'
 require 'uri'
 
+def strip_or_self!(str)
+  str.strip! || str if str
+end
+
+def sanitize_yaml_string!(str, name)
+  sanatized = strip_or_self!(str)
+  sanatized = sanatized.sub(name + ": ", "")
+                       .sub(name + " : ", "")
+
+  if (sanatized.start_with?("\"") && sanatized.end_with?("\"")) ||
+    (sanatized.start_with?("'") && sanatized.end_with?("'")) then
+    sanatized = sanatized.sub(/^\"/, "")
+             .sub(/\"$/, "")
+             .sub(/^'/, "")
+             .sub(/\'$/, "")
+  end
+
+  strip_or_self!(sanatized)
+end
+
 def check_folder
   # i'm lazy
   root = File.expand_path("..", __dir__)
@@ -99,6 +119,23 @@ def verify_file (f)
     if !valid_url?(yaml["upforgrabs"]["link"]) then
       error = "Required 'upforgrabs.link' attribute to be a valid url"
       return [f, error]
+    end
+
+    yaml.each do |attr_name, attr_value|
+      if attr_value.is_a? String
+        line_content = contents[/#{attr_name}\s?:.+\n/]
+        striped_line = sanitize_yaml_string!(line_content, attr_name)
+        striped_value = strip_or_self!(attr_value)
+
+        content_contains_new_line = striped_line != striped_value
+        has_fold_arrow = line_content == attr_name + ": >"
+        has_multi_line_pipe = line_content == attr_name + ": |"
+
+        if content_contains_new_line && !has_fold_arrow && !has_multi_line_pipe then
+          error = "Multi-line strings must be specified using '>' or '|' for '" + attr_name + "' attribute"
+          return [f, error]
+        end
+      end
     end
 
   rescue Psych::SyntaxError => e


### PR DESCRIPTION
At first I searched for a yaml linter, but the only ruby ones I found either wouldn't catch this issue or relied on now-deprecated gems.

This PR adds a minimal parser for yaml string lines, that is used if the values obtained by the real parser was a string, and works out if the original pre-parsed string from the file had a new line but did not have either of the `>` or `|` multi-line string tokens present.

This PR also fixes two yaml files that do not pass this new linting.