### PR TITLE
add script to validate existing GitHub projects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
 gem 'github-pages', group: :jekyll_plugins
+
+gem 'octokit', group: :scripts

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,6 +253,7 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
+  octokit
 
 BUNDLED WITH
    1.16.4

--- a/scripts/validate-projects.rb
+++ b/scripts/validate-projects.rb
@@ -1,0 +1,120 @@
+require 'safe_yaml'
+require 'uri'
+require 'octokit'
+
+def valid_url? (url)
+    begin
+     uri = URI.parse(url)
+     uri.kind_of?(URI::HTTP) || uri.kind_of?(URI::HTTPS)
+   rescue URI::InvalidURIError
+     false
+   end
+end
+
+def try_read_owner_repo (url)
+    # path semgent in Ruby looks like /{owner}/repo so we drop the
+    # first array value (which should be an empty string) and then
+    # combine the next two elements
+
+    pathSegments = url.path.split('/')
+
+    if pathSegments.length < 3 then
+        # this likely means the URL points to a filtered search URL
+        return nil
+    else
+        values = pathSegments.drop(1).take(2)
+
+        if  values[0].casecmp("orgs") == 0 then
+            # points to a project board for the organization
+            return nil
+        end
+
+        return values.join('/')
+    end
+end
+
+def find_github_url (url)
+    if !valid_url?(url) then
+      return nil
+    end
+
+    uri = URI.parse(url)
+
+    if uri.host.casecmp("github.com") != 0 then
+        return nil
+    else
+        return try_read_owner_repo(uri)
+    end
+end
+
+def find_owner_repo_pair (yaml)
+    site = yaml["site"]
+    owner_and_repo = find_github_url(site)
+
+    if owner_and_repo then
+        return owner_and_repo
+    end
+
+    upforgrabs = yaml["upforgrabs"]["link"]
+    owner_and_repo = find_github_url(upforgrabs)
+    if owner_and_repo then
+        return owner_and_repo
+    end
+
+    return nil
+end
+
+def verify_file (f)
+    begin
+      contents = File.read(f)
+      yaml = YAML.load(contents, :safe => true)
+      ownerAndRepo = find_owner_repo_pair(yaml)
+
+      if ownerAndRepo == nil then
+        # ignoring entry as we could not find a valid GitHub URL
+        # this likely means it's hosted elsewhere
+        return [f, nil]
+      end
+
+      client = Octokit::Client.new(:access_token => ENV['GITHUB_ACCESS_TOKEN'])
+
+      repo = client.repo ownerAndRepo
+
+      archived = repo.archived
+
+      if archived then
+        error = "Repository has been marked as archived through the GitHub API"
+        return [f, error]
+      end
+
+    rescue Psych::SyntaxError => e
+      error = "Unable to parse the contents of file - Line: #{e.line}, Offset: #{e.offset}, Problem: #{e.problem}"
+      return [f, error]
+    rescue Octokit::NotFound
+        error = "The repository no longer exists on the GitHub API"
+        return [f, error]
+    rescue
+      error = "Unknown exception for file: " + $!.to_s
+      return [f, error]
+    end
+
+    return [f, nil]
+  end
+
+
+root = File.expand_path("..", __dir__)
+
+results = Dir[root + "/_data/projects/*.yml"].map { |f| verify_file(f) }
+
+files_with_errors = results.select { |file, error| error != nil }
+error_count = files_with_errors.count
+
+success = results.select { |file, error| error.nil? }.count
+
+if (error_count > 0) then
+  puts "#{success} files processed - #{error_count} errors found:"
+  files_with_errors.each { |path, error| puts path + " - " + error }
+  exit -1
+else
+  puts "#{success} files processed - no errors found!"
+end


### PR DESCRIPTION
Fixes #1024 by using the GitHub API to see if the repository has been marked as archived:

```sh
$ GITHUB_ACCESS_TOKEN=[token] ruby ./scripts/validate-projects.rb
668 files processed - 11 errors found:
/Users/shiftkey/Documents/GitHub/shiftkey-desktop/up-for-grabs.net/_data/projects/Distri-JS.yml - Repository has been marked as archived through the GitHub API
/Users/shiftkey/Documents/GitHub/shiftkey-desktop/up-for-grabs.net/_data/projects/jscs.yml - Repository has been marked as archived through the GitHub API
/Users/shiftkey/Documents/GitHub/shiftkey-desktop/up-for-grabs.net/_data/projects/room-sprawl.yml - Repository has been marked as archived through the GitHub API
/Users/shiftkey/Documents/GitHub/shiftkey-desktop/up-for-grabs.net/_data/projects/thinktecture-identityserver-access-token-validation.yml - Repository has been marked as archived through the GitHub API
/Users/shiftkey/Documents/GitHub/shiftkey-desktop/up-for-grabs.net/_data/projects/emberjs.yml - Repository has been marked as archived through the GitHub API
/Users/shiftkey/Documents/GitHub/shiftkey-desktop/up-for-grabs.net/_data/projects/restful-routing.yml - Repository has been marked as archived through the GitHub API
/Users/shiftkey/Documents/GitHub/shiftkey-desktop/up-for-grabs.net/_data/projects/frontkit.yml - Repository has been marked as archived through the GitHub API
/Users/shiftkey/Documents/GitHub/shiftkey-desktop/up-for-grabs.net/_data/projects/arcgis.pcl.yml - Repository has been marked as archived through the GitHub API
/Users/shiftkey/Documents/GitHub/shiftkey-desktop/up-for-grabs.net/_data/projects/opacapp.yml - The repository no longer exists on the GitHub API
/Users/shiftkey/Documents/GitHub/shiftkey-desktop/up-for-grabs.net/_data/projects/thinktecture-identityserver.yml - Repository has been marked as archived through the GitHub API
/Users/shiftkey/Documents/GitHub/shiftkey-desktop/up-for-grabs.net/_data/projects/xamarin-forms-labs.yml - Repository has been marked as archived through the GitHub API
```

It tries either the `site` or `upforgrabs.link` entry in each project file to extract a `{owner}/{repo}` key that we can use to query the API. I'm fine with leaving it out of the CI build for now, as the files outstanding represent 1.6% of projects on the site and I don't want to block all builds. 