### PR TITLE
Add Charcoal projects

### DIFF
--- a/_data/projects/SmokeDetector.yml
+++ b/_data/projects/SmokeDetector.yml
@@ -1,0 +1,10 @@
+name: SmokeDetector
+desc: Community-maintained bot to detect spam on Stack Exchange and get it deleted
+site: https://charcoal-se.org/
+tags:
+  - python
+  - stack-exchange
+  - regex
+upforgrabs:
+  name: "type: up-for-grabs"
+  link: https://github.com/Charcoal-SE/SmokeDetector/labels/type%3A%20up-for-grabs

--- a/_data/projects/SmokeDetector.yml
+++ b/_data/projects/SmokeDetector.yml
@@ -2,9 +2,9 @@ name: SmokeDetector
 desc: Community-maintained bot to detect spam on Stack Exchange and get it deleted
 site: https://charcoal-se.org/
 tags:
-  - python
-  - stack-exchange
-  - regex
+- python
+- stack-exchange
+- regex
 upforgrabs:
   name: "type: up-for-grabs"
   link: https://github.com/Charcoal-SE/SmokeDetector/labels/type%3A%20up-for-grabs

--- a/_data/projects/metasmoke.yml
+++ b/_data/projects/metasmoke.yml
@@ -1,6 +1,6 @@
 name: metasmoke
 desc: Web dashboard and back end for SmokeDetector, a spam-detecting bot
-site: *https://metasmoke.erwaysoftware.com/
+site: https://metasmoke.erwaysoftware.com/
 tags:
 - ruby
 - ruby-on-rails

--- a/_data/projects/metasmoke.yml
+++ b/_data/projects/metasmoke.yml
@@ -2,12 +2,12 @@ name: metasmoke
 desc: Web dashboard and back end for SmokeDetector, a spam-detecting bot
 site: *https://metasmoke.erwaysoftware.com/
 tags:
-  - ruby
-  - ruby-on-rails
-  - scss
-  - es6
-  - javascript
-  - mysql
+- ruby
+- ruby-on-rails
+- scss
+- es6
+- javascript
+- mysql
 upforgrabs:
   name: "type: up-for-grabs"
   link: https://github.com/Charcoal-SE/metasmoke/labels/type%3A%20up-for-grabs

--- a/_data/projects/metasmoke.yml
+++ b/_data/projects/metasmoke.yml
@@ -1,0 +1,13 @@
+name: metasmoke
+desc: Web dashboard and back end for SmokeDetector, a spam-detecting bot
+site: *https://metasmoke.erwaysoftware.com/
+tags:
+  - ruby
+  - ruby-on-rails
+  - scss
+  - es6
+  - javascript
+  - mysql
+upforgrabs:
+  name: "type: up-for-grabs"
+  link: https://github.com/Charcoal-SE/metasmoke/labels/type%3A%20up-for-grabs


### PR DESCRIPTION
Adds both [SmokeDetector](https://github.com/Charcoal-SE/SmokeDetector) and [metasmoke](https://github.com/Charcoal-SE/metasmoke). Both currently have [hacktoberfest] tasks, which I'll be adding the up-for-grabs label to, and the Charcoal team will monitor incoming issues for other suitable tasks.