### PR TITLE
Speed up build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 rvm:
   - 2.4.3
 


### PR DESCRIPTION
Enable Travis' bundler caching. Should speed up the build fairly significantly by making it not have to install gems every time.