### PR TITLE
Filter by name fix

### DIFF
--- a/javascripts/projectsService.js
+++ b/javascripts/projectsService.js
@@ -30,18 +30,20 @@
     names = _.map(names, function (entry) {
       return entry && entry.replace(/^\s+|\s+$/g, "");
     });
-    console.log(names);
-    console.log(projects[0]);
+
     if (!names || !names.length || names[0] == "") {
       return projects;
     }
 
-    var projectNames = _.uniq(_.flatten(_.map(names, function (name) {
-      var hit = namesMap[name.toLowerCase()];
-      return hit || [];
-    })));
-    console.log(projectNames);
-    return projectNames;
+    // Make sure the names are sorted first. Then return the found index in the passed names
+    return  _.filter(_.map(_.sortBy(namesMap, function(entry, key){return entry.name;}), function(entry, key) {
+      if (names.indexOf(String(key)) > -1) {
+        return entry;
+      }
+    }), function(entry) {
+      return entry ? entry : false;
+    });
+
   };
   var applyLabelsFilter = function (projects, labelsMap, labels) {
     if (typeof labels === "string") {


### PR DESCRIPTION
### Problem
Filter by name does not seem to be working on the live site, and that is due to incorrect filtering.
 
See this GIF
![issue-filter](https://user-images.githubusercontent.com/18662248/49685669-1539ba80-faf0-11e8-8cf0-f5b33ea59fa8.gif)


### Solution

This PR Fixes this issue by sorting the project names first just how it's rendered by `scripts.html`
Then mapping the passed names into the right project.

### Proof

![fix-to-filters](https://user-images.githubusercontent.com/18662248/49685695-87aa9a80-faf0-11e8-8e3a-c7753d7954b6.gif)

