### PR TITLE
Filter by names case insensitive

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -2,7 +2,7 @@
   <div class="filters-panel cf">
     <h5>Filter by name: </h5>
     <select class="names-filter" multiple data-placeholder="Select a project..." >
-      <% _.each(_.sortBy(names, function(entry, key){return entry.name;}), function(entry, key){ %>
+      <% _.each(names, function(entry, key){ %>
         <option value="<%-key%>"><%- entry.name%></option>
       <% }) %>
     </select>

--- a/javascripts/projectsService.js
+++ b/javascripts/projectsService.js
@@ -22,7 +22,16 @@
     });
   };
 
-  var applyNamesFilter = function (projects, namesMap, names) {
+  /*
+   * The function here is used for front end filtering when given 
+   * selecting certain projects. It ensures that only the selected projects
+   * are returned. If none of the names was added to the filter.
+   * Then it fallsback to show all the projects.
+   * @param Array projects : An array having all the Projects in _data
+   * @param Array projectsNameSorted : This is another array showing all the projects in a sorted order
+   * @param Array names : This is an array with the given name filters.
+   */
+  var applyNamesFilter = function (projects, projectNamesSorted, names) {
     if (typeof names === "string") {
       names = names.split(",");
     }
@@ -36,15 +45,15 @@
     }
 
     // Make sure the names are sorted first. Then return the found index in the passed names
-    return  _.filter(_.map(_.sortBy(namesMap, function(entry, key){return entry.name;}), function(entry, key) {
+    return  _.filter(_.map(projectNamesSorted, function(entry, key) {
       if (names.indexOf(String(key)) > -1) {
         return entry;
       }
     }), function(entry) {
       return entry ? entry : false;
     });
-
   };
+
   var applyLabelsFilter = function (projects, labelsMap, labels) {
     if (typeof labels === "string") {
       labels = labels.split(",");
@@ -165,7 +174,7 @@
 
     this.get = function (tags, names, labels) {
       if (names) {
-        return applyNamesFilter(projects, namesMap, names);
+        return applyNamesFilter(projects, this.getNames(), names);
       }
       else if(labels) {
         return applyLabelsFilter(projects, labelsMap, labels);
@@ -178,7 +187,7 @@
     };
 
     this.getNames = function () {
-      return namesMap;
+      return _.sortBy(namesMap, function(entry, key){return entry.name.toLowerCase();});
     };
 
     this.getLabels = function () {

--- a/tests/spec/ProjectsServiceSpec.js
+++ b/tests/spec/ProjectsServiceSpec.js
@@ -18,6 +18,14 @@ describe("ProjectsService", function() {
     expect(projectsService.getTags).toBeDefined();
   });
 
+  it("should return projects list when get method is called", function() {
+    expect(projectsService.get()).toBeDefined();
+  });
+
+  it("should return tags map when getTags method is called", function() {
+    expect(projectsService.getTags()).toBeDefined();
+  });
+
   describe("when instantiated with projects data", function(){
     it("should extract and create tags map from projects data", function() {
       var tags = _.toArray(projectsService.getTags());
@@ -36,16 +44,23 @@ describe("ProjectsService", function() {
       expect(tags[2].name).toBe("ASP.NET");
       
     });
-
   });
 
-  it("should return projects list when get method is called", function() {
-    expect(projectsService.get()).toBeDefined();
-  });
+  describe("When filtering by name", function() {
+    it("Should return the correct project given the correct index", function() {
+      var project = projectsService.get(null, ["1"], undefined);
+      expect(project).toBeDefined();
+      expect(project[0].name).toBe('LibGit2Sharp');
+      expect(project[1]).toBe(undefined);
+    });
 
-  it("should return tags map when getTags method is called", function() {
-    expect(projectsService.getTags()).toBeDefined();
-  });
+    it("Should return all projects if given falsy values", function() {
+      var projects = projectsService.get(null, true, undefined);
+      expect(projects).toBeDefined();
+      expect(projects[1].name).toBe('Glimpse');
+      expect(projects.length).toEqual(2);
+    })
+  })
 
   //Not sure how to test for randomness accurately, for now trusut underscore and ignore this. 
   xit("should return shuffled projects list  ", function() {


### PR DESCRIPTION
**Problem**
Fixes #1109 

Names are being ordered in a case sensitive way.

**Solution**

This PR refactors the sort method to be used `getNames`, which ensures the names are always sorted when it's called and ensures it's rendered in an ordered case insensitive way.

Also tests two tests were added to Filter By Name to maintain stability

### Proof

![fix-by-names](https://user-images.githubusercontent.com/18662248/49760421-20960d00-fccd-11e8-81a3-dca2005728ed.gif)

