### PR TITLE
Filters > Allow multiple filters at a time

### DIFF
--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -90,32 +90,6 @@
       renderProjects();
     });
 
-    // this.get("#/tags/", function (context) {
-    //   renderProjects();
-    // });
-
-    // this.get("#/tags/:tags", function (context) {
-    //   var tags = (this.params["tags"] || "").toLowerCase().split(",");
-    //   renderProjects(tags);
-    // });
-
-    // this.get("#/names/", function (context) {
-    //   renderProjects();
-    // });
-
-    // this.get("#/names/:names", function (context) {
-    //   var names = (this.params["names"] || "").toLowerCase().split(",");
-    //   renderProjects(null, names);
-    // });
-  
-    // this.get("#/labels/", function (context) {
-    //   renderProjects();
-    // });
-
-    // this.get("#/labels/:labels", function (context) {
-    //   var labels = (this.params["labels"] || "").toLowerCase().split(",");
-    //   renderProjects(null, null, labels);
-    // });
   });
 
   var storage = (function (global) {

--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -4,6 +4,10 @@
     compiledtemplateFn = null,
     projectsPanel = null;
 
+  var getFilterUrl = function() {
+    return location.href.indexOf('/#/filters') > -1 ? location.href : location.href+ 'filters';
+  }
+
   var renderProjects = function (tags, names, labels) {
     projectsPanel.html(compiledtemplateFn({
       "projects": projectsSvc.get(tags, names, labels),
@@ -20,7 +24,7 @@
       no_results_text: "No tags found by that name.",
       width: "95%"
     }).val(tags).trigger('chosen:updated').change(function (e) {
-      window.location.href = "#/tags/" + encodeURIComponent(($(this).val() || ""));
+      location.href = updateQueryStringParameter(getFilterUrl(), 'tags', encodeURIComponent(($(this).val() || "")));
     });
 
     projectsPanel.find("select.names-filter").chosen({
@@ -28,49 +32,90 @@
       no_results_text: "No project found by that name.",
       width: "95%"
     }).val(names).trigger('chosen:updated').change(function (e) {
-      window.location.href = "#/names/" + encodeURIComponent(($(this).val() || ""));
+      location.href = updateQueryStringParameter(getFilterUrl(), 'names', encodeURIComponent(($(this).val() || "")))
     });
 
     projectsPanel.find("select.labels-filter").chosen({
       no_results_text: "No project found by that label.",
       width: "95%"
     }).val(labels).trigger('chosen:updated').change(function (e) {
-      window.location.href = "#/labels/" + encodeURIComponent(($(this).val() || ""));
-
+      location.href = updateQueryStringParameter(getFilterUrl(), 'labels', encodeURIComponent(($(this).val() || "")));
     });
   };
 
+
+  /**
+   * This is a utility method to help update URL Query Parameters
+   * @return string - The value of the URL when adding/removing values to it.
+   */
+  var updateQueryStringParameter = function(uri, key, value) {
+    var re = new RegExp("([?&])" + key + "=.*?(&|$)", "i");
+    var separator = uri.indexOf('?') !== -1 ? "&" : "?";
+    if (uri.match(re)) {
+      return uri.replace(re, '$1' + key + "=" + value + '$2');
+    }
+    else {
+      return uri + separator + key + "=" + value;
+    }
+}
+
+  /**
+  * This function help getting all params in url queryString
+  * Taken from here
+  * https://stackoverflow.com/questions/901115/how-can-i-get-query-string-values-in-javascript
+  *
+  * @return string - value of url params
+  */
+  var getParameterByName = function(name, url) {
+      if (!url) url = window.location.href;
+      name = name.replace(/[\[\]]/g, "\\$&");
+      var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+          results = regex.exec(url);
+      if (!results) return null;
+      if (!results[2]) return '';
+      return decodeURIComponent(results[2].replace(/\+/g, " "));
+  };
+
   var app = $.sammy(function () {
+
+    this.get('#/filters', function(context) {
+      var labels = getParameterByName('labels');
+      var names = getParameterByName('names');
+      var tags = getParameterByName('tags');
+      renderProjects(tags, names, labels)
+    });
+
+
     this.get("#/", function (context) {
       renderProjects();
     });
 
-    this.get("#/tags/", function (context) {
-      renderProjects();
-    });
+    // this.get("#/tags/", function (context) {
+    //   renderProjects();
+    // });
 
-    this.get("#/tags/:tags", function (context) {
-      var tags = (this.params["tags"] || "").toLowerCase().split(",");
-      renderProjects(tags);
-    });
+    // this.get("#/tags/:tags", function (context) {
+    //   var tags = (this.params["tags"] || "").toLowerCase().split(",");
+    //   renderProjects(tags);
+    // });
 
-    this.get("#/names/", function (context) {
-      renderProjects();
-    });
+    // this.get("#/names/", function (context) {
+    //   renderProjects();
+    // });
 
-    this.get("#/names/:names", function (context) {
-      var names = (this.params["names"] || "").toLowerCase().split(",");
-      renderProjects(null, names);
-    });
+    // this.get("#/names/:names", function (context) {
+    //   var names = (this.params["names"] || "").toLowerCase().split(",");
+    //   renderProjects(null, names);
+    // });
   
-    this.get("#/labels/", function (context) {
-      renderProjects();
-    });
+    // this.get("#/labels/", function (context) {
+    //   renderProjects();
+    // });
 
-    this.get("#/labels/:labels", function (context) {
-      var labels = (this.params["labels"] || "").toLowerCase().split(",");
-      renderProjects(null, null, labels);
-    });
+    // this.get("#/labels/:labels", function (context) {
+    //   var labels = (this.params["labels"] || "").toLowerCase().split(",");
+    //   renderProjects(null, null, labels);
+    // });
   });
 
   var storage = (function (global) {

--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -76,15 +76,29 @@
       return decodeURIComponent(results[2].replace(/\+/g, " "));
   };
 
+  /*
+   * This is a helper method that prepares the chosen labels/tags/names
+   * For HTML and helps display the selected values of each
+   * @params String text - The text given, indices or names. As long as it is a string
+   * @return Array - Returns an array of splitted values if given a text. Otherwise undefined
+   */
+  var prepareForHTML = function(text) {
+    return text ? text.toLowerCase().split(',') : text;
+  }
+
   var app = $.sammy(function () {
 
-    this.get('#/filters', function(context) {
-      var labels = getParameterByName('labels');
-      var names = getParameterByName('names');
-      var tags = getParameterByName('tags');
+    /*
+     * This is the route used to filter by tags/names/labels
+     * It ensures to read values from the URI query param and perform actions
+     * based on that. NOTE: It has major side effects on the browser.
+     */
+    this.get('#/filters', function() {
+      var labels = prepareForHTML(getParameterByName('labels'));
+      var names = prepareForHTML(getParameterByName('names'));
+      var tags = prepareForHTML(getParameterByName('tags'));
       renderProjects(tags, names, labels)
     });
-
 
     this.get("#/", function (context) {
       renderProjects();

--- a/javascripts/projectsService.js
+++ b/javascripts/projectsService.js
@@ -197,13 +197,14 @@
     });
 
     this.get = function (tags, names, labels) {
-      if (names) {
-        return applyNamesFilter(projects, this.getNames(), names);
-      }
-      else if(labels) {
-        return applyLabelsFilter(projects, this.getLabels(), labels);
-      }
-      return applyTagsFilter(projects, tagsMap, tags);
+      var filtered_projects = projects;
+      filtered_projects = applyNamesFilter(filtered_projects, this.getNames(), names);
+      console.log('After Name Filters', filtered_projects)
+      filtered_projects = applyLabelsFilter(filtered_projects, labelsMap, labels);
+      console.log('After Label Filters', filtered_projects)
+      filtered_projects = applyTagsFilter(filtered_projects, tagsMap, tags);
+      console.log('After Tag Filters', filtered_projects)
+      return filtered_projects
     };
 
     this.getTags = function () {

--- a/javascripts/projectsService.js
+++ b/javascripts/projectsService.js
@@ -95,7 +95,7 @@
 
     //find all projects with the given labels via OR
     results = _.map(label_names, name => {
-      return _.filter(projects, project => String(project.upforgrabs.name) === name);
+      return _.filter(projects, project => String(project.upforgrabs.name).toLowerCase() === name);
     });
 
     //the above statements returns n arrays in an array, which we flatten here and return then
@@ -103,6 +103,7 @@
 
 
   };
+
   var TagBuilder = function () {
     var _tagsMap = {},
       _orderedTagsMap = null;
@@ -198,12 +199,15 @@
 
     this.get = function (tags, names, labels) {
       var filtered_projects = projects;
-      filtered_projects = applyNamesFilter(filtered_projects, this.getNames(), names);
-      console.log('After Name Filters', filtered_projects)
-      filtered_projects = applyLabelsFilter(filtered_projects, labelsMap, labels);
-      console.log('After Label Filters', filtered_projects)
-      filtered_projects = applyTagsFilter(filtered_projects, tagsMap, tags);
-      console.log('After Tag Filters', filtered_projects)
+      if (names && names.length) {
+        filtered_projects = applyNamesFilter(filtered_projects, this.getNames(), names);
+      }
+      if (labels && labels.length) {
+        filtered_projects = applyLabelsFilter(filtered_projects, this.getLabels(), labels);
+      }
+      if (tags && tags.length) {
+        filtered_projects = applyTagsFilter(filtered_projects, tagsMap, tags);
+      }
       return filtered_projects
     };
 

--- a/javascripts/projectsService.js
+++ b/javascripts/projectsService.js
@@ -55,7 +55,6 @@
   };
 
   /*
-  /*
    * The function here is used for front end filtering when given
    * selecting certain projects. It ensures that only the selected projects
    * are returned. If none of the labels was added to the filter,
@@ -64,7 +63,6 @@
    * @param Array projectLabelsSorted : This is another array showing all the labels in a sorted order
    * @param Array labels : This is an array with the given label filters.
    */
-
   var applyLabelsFilter = function (projects, projectLabelsSorted, labels) {
 
     label_indices = labels;
@@ -91,18 +89,19 @@
     });
 
     //collect the names of all labels into a list
-    label_names = _.collect(labels, label => label.name);
+    label_names = _.collect(labels, function(label){ return label.name });
 
     //find all projects with the given labels via OR
-    results = _.map(label_names, name => {
-      return _.filter(projects, project => String(project.upforgrabs.name).toLowerCase() === name);
+    results = _.map(label_names, function(name) {
+      return _.filter(projects, function(project) {
+        return String(project.upforgrabs.name).toLowerCase() === name.toLowerCase()
+      });
     });
 
     //the above statements returns n arrays in an array, which we flatten here and return then
-    return _.flatten(results, (arr1, arr2) => arr1.append(arr2));
-
-
+    return _.flatten(results, function(arr1, arr2) { return arr1.append(arr2) });
   };
+
 
   var TagBuilder = function () {
     var _tagsMap = {},

--- a/tests/spec/ProjectsServiceSpec.js
+++ b/tests/spec/ProjectsServiceSpec.js
@@ -57,7 +57,7 @@ describe("ProjectsService", function() {
     it("Should return all projects if given falsy values", function() {
       var projects = projectsService.get(null, true, undefined);
       expect(projects).toBeDefined();
-      expect(projects[1].name).toBe('Glimpse');
+      expect(projects[1].name).toBe('LibGit2Sharp');
       expect(projects.length).toEqual(2);
     })
   })
@@ -118,5 +118,38 @@ describe("ProjectsService", function() {
       var projects = projectsService.get(["c#", "D'oh"]);
       expect(projects.length).toBe(2);
     });
+  });
+
+  describe("Expect multiple filters to work tremendously good", function() {
+
+    it("If it doesn't take any filters then it should return projects", function() {
+      var projects = projectsService.get(undefined, undefined, undefined);
+      expect(projects.length).toBe(2);
+    });
+
+    it("Should take a name filter and tag filter with no issues", function() {
+      var projects = projectsService.get(['c#'], ['0'], undefined);
+      expect(projects.length).toBe(1);
+    });
+
+    it("Should take a name filter and wrong tag filter and expect nothing", function() {
+      var projects = projectsService.get(['web'], ['1'], undefined);
+      expect(projects.length).toBe(0);
+    });
+
+    it("Should take a name filter and label filter with no issues", function() {
+      var projects = projectsService.get(undefined, ['1'], ['1']);
+      expect(projects.length).toBe(1);
+    });
+
+    it("Should take a tag filter and label filter with no issues", function() {
+      var projects = projectsService.get(['c#'], undefined, ['1']);
+      expect(projects.length).toBe(1);
+    });
+
+    it("Should take all three filters and return a project", function() {
+      var projects = projectsService.get(['c#'], ['1'], ['1']);
+      expect(projects.length).toBe(1);
+    })
   });
 });


### PR DESCRIPTION
**Problem**
Fixes #1070, We are utilizing filters in the front end, but each input is decoupled from the other and doesn't allow multiple filtering at the same time.

**Solution**
This PR utilizes this update and allows multiple filters under a new route `filters` with adding the filter types as Query Parameters.

**Tests**
New test suite added to cover this feature
<img width="516" alt="screen shot 2018-12-13 at 10 34 50 pm" src="https://user-images.githubusercontent.com/18662248/49966183-f9874780-ff27-11e8-8f2b-2409747537f7.png">

### Proof of functionality

![new-filters](https://user-images.githubusercontent.com/18662248/49966201-03a94600-ff28-11e8-9b87-be3fd00606bc.gif)
