### PR TITLE
Fixed popular tags not working

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-up-for-grabs.net
+www.jktestsuite.com

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-project.juliankrieger.com

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-www.jktestsuite.com
+project.juliankrieger.com

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -25,7 +25,7 @@
     <h5>Popular tags: </h5>
     <ul class="popular-tags">
     <% _.each(popularTags, function(entry, key){ %>
-      <li><a href="#/tags/<%-encodeURIComponent(entry.name)%>"><%-entry.name%></a> (<%-entry.frequency%>)</li>
+      <li><a><%-entry.name%></a> (<%-entry.frequency%>)</li>
     <% }) %>
     </ul>
   </div>

--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -43,11 +43,13 @@
     });
 
     projectsPanel.find("ul.popular-tags").children().each(function(i, elem){
-        //elem.firstElementChild.innerText.toLowerCase()
-        console.log(elem);
         $(elem).on("click", function(){
-            location.href = updateQueryStringParameter(
-                getFilterUrl(), 'tags', encodeURIComponent((preparePopTagName($(this).text()) || ""))); 
+            let selTags = ($('.tags-filter').val() || [])
+            const selectedTag = preparePopTagName($(this).text() || "");
+            if (selectedTag){
+                location.href = updateQueryStringParameter(
+                    getFilterUrl(), 'tags', encodeURIComponent((selTags))); 
+            }
         });
     });
 
@@ -59,6 +61,7 @@
     @return string - The value of the Name
   */
   var preparePopTagName = function(name) {
+      if (name === "") return "";
       return name.toLowerCase().split(" ")[0];
   }
 

--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -47,6 +47,7 @@
             let selTags = ($('.tags-filter').val() || [])
             const selectedTag = preparePopTagName($(this).text() || "");
             if (selectedTag){
+                selTags.push(selectedTag)
                 location.href = updateQueryStringParameter(
                     getFilterUrl(), 'tags', encodeURIComponent((selTags))); 
             }

--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -41,8 +41,26 @@
     }).val(labels).trigger('chosen:updated').change(function (e) {
       location.href = updateQueryStringParameter(getFilterUrl(), 'labels', encodeURIComponent(($(this).val() || "")));
     });
+
+    projectsPanel.find("ul.popular-tags").children().each(function(i, elem){
+        //elem.firstElementChild.innerText.toLowerCase()
+        console.log(elem);
+        $(elem).on("click", function(){
+            location.href = updateQueryStringParameter(
+                getFilterUrl(), 'tags', encodeURIComponent((preparePopTagName($(this).text()) || ""))); 
+        });
+    });
+
   };
 
+  /*
+    This is a utility method to help update a list items Name parameter to make
+    it fit URL specification
+    @return string - The value of the Name
+  */
+  var preparePopTagName = function(name) {
+      return name.toLowerCase().split(" ")[0];
+  }
 
   /**
    * This is a utility method to help update URL Query Parameters

--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -44,8 +44,8 @@
 
     projectsPanel.find("ul.popular-tags").children().each(function(i, elem){
         $(elem).on("click", function(){
-            let selTags = ($('.tags-filter').val() || [])
-            const selectedTag = preparePopTagName($(this).text() || "");
+            selTags = ($('.tags-filter').val() || [])
+            selectedTag = preparePopTagName($(this).text() || "");
             if (selectedTag){
                 selTags.push(selectedTag)
                 location.href = updateQueryStringParameter(


### PR DESCRIPTION
I fixed the popular tags not working by adding an on("click") eventHandler that changes the location.href according to the tag clicked. I'd be glad if it could be reviewed by either @ritwik12 or @Zarad1993 

Fixes #1116 in a clean and readable way.
~However, currently only one popular tag works at a time. I'll look into this this evening~

However, I'm not sure if it's enough to generate the correct link and change it accordingly, or if I should push the new tag to the projectServices "tags" array, too.