### PR TITLE
remove rogue character to restore fork button

### DIFF
--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -138,7 +138,7 @@ img {
     background-color: #DDF;
     color: #000;
 }
-s
+
 #forkme_banner {
   display: block;
   position: absolute;


### PR DESCRIPTION
The current website has an issue with rendering the "View on GitHub" button:

<img width="1142" src="https://user-images.githubusercontent.com/359239/51538051-9e018100-1e26-11e9-917a-2eeae8d53282.png">

I traced it to this character in the stylesheet. Removing that and running it locally puts the "View on GitHub" link back in the top-right:

<img width="1099"  src="https://user-images.githubusercontent.com/359239/51538083-b1ace780-1e26-11e9-82fb-d6cbbed3c933.png">
