### PR TITLE
[WIP] fix links interactions

### DIFF
--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -144,6 +144,11 @@
       renderProjects(tags, names, labels)
     });
 
+    this.get('#/tags/:tag', function() {
+      var tag = prepareForHTML(this.params['tag']);
+      renderProjects(tag)
+    })
+
     this.get("#/", function (context) {
       renderProjects();
     });

--- a/javascripts/projectsService.js
+++ b/javascripts/projectsService.js
@@ -205,7 +205,7 @@
         filtered_projects = applyLabelsFilter(filtered_projects, this.getLabels(), labels);
       }
       if (tags && tags.length) {
-        filtered_projects = applyTagsFilter(filtered_projects, this.getTags(), tags);
+        filtered_projects = applyTagsFilter(filtered_projects, tagsMap, tags);
       }
       return filtered_projects
     };


### PR DESCRIPTION
Fixes #1149 
Fixes #1150 

 - [x] correctly handles popular tags (which updates and sets the `tags` querystring parameter

<img width="899" src="https://user-images.githubusercontent.com/359239/51551181-50940c80-1e44-11e9-9e10-31de059fdf2d.png">

 - [x] correctly handles selecting a tag in the details of a project (navigates to new `#/tags/:tag` route)

<img width="914" src="https://user-images.githubusercontent.com/359239/51551331-a668b480-1e44-11e9-8781-fbad4a225faa.png">

 - [ ] selecting a filter from the drop-down updates the URL correctly (currently uses the index of the tag, not the tag name)
 - [ ] tags in URL should appear in filter list
 - [ ] avoid need for `#/tags/:tag` route and make `details` tag links update the URL correctly (via a click event handler?)