### PR TITLE
Work around for popular tags bug

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -16,18 +16,19 @@
     </select>
   </div>
   <div class="filters-panel cf">
-    <h5>Filter by tags: </h5>
+    <h5>Filter by popular tags: </h5>
     <select class="tags-filter" multiple data-placeholder="Select a tag..." >
     <% _.each(tags, function(entry, key){ %>
       <option value="<%-key%>"><%- entry.name%>  (<%-entry.frequency%>)</option>
     <% }) %>
     </select>
+    <!-- removed the <a> tags for the popularTags -->
     <h5>Popular tags: </h5>
     <ul class="popular-tags">
     <% _.each(popularTags, function(entry, key){ %>
-      <li><a><%-entry.name%></a> (<%-entry.frequency%>)</li>
+      <li><%-entry.name%> (<%-entry.frequency%>)
     <% }) %>
-    </ul>
+    </ul> 
   </div>
   <table class="projects">
    <% _.each(projects, function(project){ %>
@@ -57,6 +58,7 @@
     </tbody>
    <% }) %>
    </table>
+  <br/>
 </script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/showdown/1.3.0/showdown.min.js"></script>
 <script type="text/javascript">

--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -32,6 +32,7 @@
       no_results_text: "No project found by that name.",
       width: "95%"
     }).val(names).trigger('chosen:updated').change(function (e) {
+      console.log(this.val)
       location.href = updateQueryStringParameter(getFilterUrl(), 'names', encodeURIComponent(($(this).val() || "")))
     });
 
@@ -42,17 +43,23 @@
       location.href = updateQueryStringParameter(getFilterUrl(), 'labels', encodeURIComponent(($(this).val() || "")));
     });
 
-    projectsPanel.find("ul.popular-tags").children().each(function(i, elem){
-        $(elem).on("click", function(){
-            selTags = ($('.tags-filter').val() || [])
-            selectedTag = preparePopTagName($(this).text() || "");
-            if (selectedTag){
-                selTags.push(selectedTag)
-                location.href = updateQueryStringParameter(
-                    getFilterUrl(), 'tags', encodeURIComponent((selTags))); 
-            }
-        });
-    });
+    // POPTAG commented out just incase we want to revert back.
+    // projectsPanel.find("ul.popular-tags").children().each(function(i, elem){
+    //     $(elem).on("click", function(){
+    //         selTags = ($('.tags-filter').val() || [])
+    //         console.log("seltag", selTags)
+    //         selectedTag = preparePopTagName($(this).text() || "");
+    //         console.log("selected", selectedTag)
+    //         if (selectedTag){
+    //             selTags.push(selectedTag)
+    //             location.href = updateQueryStringParameter(
+    //                 getFilterUrl(), 'tags', encodeURIComponent((selTags || ""))); 
+    //         }else {
+    //           location.href = updateQueryStringParameter(
+    //             getFilterUrl(), 'tags', encodeURIComponent((selTags || "")))
+    //         }
+    //     });
+    // });
 
   };
 

--- a/javascripts/projectsService.js
+++ b/javascripts/projectsService.js
@@ -205,13 +205,9 @@
         filtered_projects = applyLabelsFilter(filtered_projects, this.getLabels(), labels);
       }
       if (tags && tags.length) {
-        filtered_projects = applyTagsFilter(filtered_projects, tagsMap, tags);
+        filtered_projects = applyTagsFilter(filtered_projects, this.getTags(), tags);
       }
       return filtered_projects
-    };
-
-    this.getTags = function () {
-      return _.sortBy(tagsMap, function(entry, key){return entry.name.toLowerCase();});
     };
 
     this.getNames = function () {
@@ -222,6 +218,10 @@
       return _.sortBy(labelsMap, function(entry, key){return entry.name.toLowerCase();});
     };
 
+    this.getTags = function () {
+      return _.sortBy(tagsMap, function (entry, key) { return entry.frequency }).reverse();
+    };
+    
     this.getPopularTags = function (popularTagCount) {
       return _.take(_.values(tagsMap), popularTagCount || 10);
     }


### PR DESCRIPTION
So I was getting real frustrated with not being able to fix the popular tags bug haha, I reverted this test branch back to a working version where popular tags used to work. This version the tags filter did not work, when I fixed it the popular tags stopped working. the change is this... 

`if (tags && tags.length) {
        filtered_projects = applyTagsFilter(filtered_projects, tagsMap, tags);
      }`

to
`if (tags && tags.length) {
        filtered_projects = applyTagsFilter(filtered_projects, this.getTags(), tags);
      }`

Changing this little code breaks the popular tags filter. So I was really choosing between tags or popular tags. it bothered me so much cuz it did not make sense that I merged the two. now the tags are filtered by popularity instead of a-z. 

Submitting a pull request to see what y'all think. also closes https://github.com/up-for-grabs/up-for-grabs.net/issues/1150