### PR TITLE
Updated upforgrabs issues link

### DIFF
--- a/_data/projects/CypherPokerJS.yml
+++ b/_data/projects/CypherPokerJS.yml
@@ -24,4 +24,4 @@ tags:
 - contract
 upforgrabs:
   name: help wanted
-  link: https://github.com/monicanagent/cypherpoker.js/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22
+  link: https://github.com/monicanagent/cypherpoker.js/labels/help%20wanted


### PR DESCRIPTION
Previous URL was an issue search URL (no issue count being included in Up For Grabs homepage). Please merge this change and accept my apologies for the oversight!