### PR TITLE
standardize JS on single-quotes for strings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,7 @@
   "rules": {
     "space-before-function-paren": "off",
     "comma-dangle": ["error", "only-multiline"],
-    "quotes": ["error", "double"],
+    "quotes": ["error", "single"],
     "no-undef": "off",
     "vars-on-top": "off",
     "no-var": "off",

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -2,5 +2,5 @@
   "trailingComma": "es5",
   "tabWidth": 2,
   "semi": true,
-  "singleQuote": false
+  "singleQuote": true
 }

--- a/docs/client-side-scripting.md
+++ b/docs/client-side-scripting.md
@@ -45,26 +45,26 @@ main script.
 ```js
 requirejs.config({
   // the default directory to use to find and load resources
-  baseUrl: "javascripts",
+  baseUrl: 'javascripts',
   paths: {
     // external scripts hosted on CDN
     underscore:
-      "//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.9.1/underscore-min",
-    jquery: "//cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.min",
-    sammy: "//cdnjs.cloudflare.com/ajax/libs/sammy.js/0.7.6/sammy.min",
-    chosen: "//cdnjs.cloudflare.com/ajax/libs/chosen/1.8.7/chosen.jquery.min",
+      '//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.9.1/underscore-min',
+    jquery: '//cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.min',
+    sammy: '//cdnjs.cloudflare.com/ajax/libs/sammy.js/0.7.6/sammy.min',
+    chosen: '//cdnjs.cloudflare.com/ajax/libs/chosen/1.8.7/chosen.jquery.min',
   },
   shim: {
     // chosen is not UMD-compatible, so we need to use this hook to ensure
     // jquery is loaded as a prerequisite
     chosen: {
-      deps: ["jquery"],
+      deps: ['jquery'],
     },
   },
 });
 
 // after configuring require, load the main script
-requirejs(["main"]);
+requirejs(['main']);
 ```
 
 If you wish to consume a third-party dependency in the Up-For-Grabs client-side
@@ -77,13 +77,13 @@ of the application.
 
 ```js
 define([
-  "jquery",
-  "projectsService",
-  "underscore",
-  "sammy",
+  'jquery',
+  'projectsService',
+  'underscore',
+  'sammy',
   // chosen is listed here as a dependency because it's used from a jQuery
   // selector, and needs to be ready before this code runs
-  "chosen",
+  'chosen',
 ], ($, ProjectsService, _, sammy) => {
   // application code goes here
 });
@@ -121,7 +121,7 @@ Ensure your module defines this _before_ it uses a `define`:
 
 ```js
 // required for loading into a NodeJS context
-if (typeof define !== "function") {
-  var define = require("amdefine")(module);
+if (typeof define !== 'function') {
+  var define = require('amdefine')(module);
 }
 ```

--- a/javascripts/app.js
+++ b/javascripts/app.js
@@ -1,23 +1,23 @@
 // @ts-nocheck
 
 requirejs.config({
-  baseUrl: "javascripts",
+  baseUrl: 'javascripts',
   paths: {
     // external scripts hosted on CDN
     underscore:
-      "//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.9.1/underscore-min",
-    jquery: "//cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.min",
-    sammy: "//cdnjs.cloudflare.com/ajax/libs/sammy.js/0.7.6/sammy.min",
-    chosen: "//cdnjs.cloudflare.com/ajax/libs/chosen/1.8.7/chosen.jquery.min",
+      '//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.9.1/underscore-min',
+    jquery: '//cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.min',
+    sammy: '//cdnjs.cloudflare.com/ajax/libs/sammy.js/0.7.6/sammy.min',
+    chosen: '//cdnjs.cloudflare.com/ajax/libs/chosen/1.8.7/chosen.jquery.min',
   },
   shim: {
     // chosen is not UMD-compatible, so we need to use this hook to ensure
     // jquery is loaded as a prerequisite
     chosen: {
-      deps: ["jquery"],
+      deps: ['jquery'],
     },
   },
 });
 
 // after configuring require, load the main script
-requirejs(["main"]);
+requirejs(['main']);

--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -1,22 +1,22 @@
 // @ts-nocheck
 
 define([
-  "jquery",
-  "projectsService",
-  "underscore",
-  "sammy",
+  'jquery',
+  'projectsService',
+  'underscore',
+  'sammy',
   // chosen is listed here as a dependency because it's used from a jQuery
   // selector, and needs to be ready before this code runs
-  "chosen",
+  'chosen',
 ], ($, ProjectsService, _, sammy) => {
   var projectsSvc = new ProjectsService(projects),
     compiledtemplateFn = null,
     projectsPanel = null;
 
   var getFilterUrl = function() {
-    return location.href.indexOf("/#/filters") > -1
+    return location.href.indexOf('/#/filters') > -1
       ? location.href
-      : location.href + "filters";
+      : location.href + 'filters';
   };
 
   var renderProjects = function(tags, names, labels) {
@@ -34,66 +34,66 @@ define([
     );
 
     projectsPanel
-      .find("select.tags-filter")
+      .find('select.tags-filter')
       .chosen({
-        no_results_text: "No tags found by that name.",
-        width: "95%",
+        no_results_text: 'No tags found by that name.',
+        width: '95%',
       })
       .val(tags)
-      .trigger("chosen:updated")
+      .trigger('chosen:updated')
       .change(function() {
         location.href = updateQueryStringParameter(
           getFilterUrl(),
-          "tags",
-          encodeURIComponent($(this).val() || "")
+          'tags',
+          encodeURIComponent($(this).val() || '')
         );
       });
 
     projectsPanel
-      .find("select.names-filter")
+      .find('select.names-filter')
       .chosen({
         search_contains: true,
-        no_results_text: "No project found by that name.",
-        width: "95%",
+        no_results_text: 'No project found by that name.',
+        width: '95%',
       })
       .val(names)
-      .trigger("chosen:updated")
+      .trigger('chosen:updated')
       .change(function() {
         location.href = updateQueryStringParameter(
           getFilterUrl(),
-          "names",
-          encodeURIComponent($(this).val() || "")
+          'names',
+          encodeURIComponent($(this).val() || '')
         );
       });
 
     projectsPanel
-      .find("select.labels-filter")
+      .find('select.labels-filter')
       .chosen({
-        no_results_text: "No project found by that label.",
-        width: "95%",
+        no_results_text: 'No project found by that label.',
+        width: '95%',
       })
       .val(labels)
-      .trigger("chosen:updated")
+      .trigger('chosen:updated')
       .change(function() {
         location.href = updateQueryStringParameter(
           getFilterUrl(),
-          "labels",
-          encodeURIComponent($(this).val() || "")
+          'labels',
+          encodeURIComponent($(this).val() || '')
         );
       });
 
     projectsPanel
-      .find("ul.popular-tags")
+      .find('ul.popular-tags')
       .children()
       .each(function(i, elem) {
-        $(elem).on("click", function() {
-          selTags = $(".tags-filter").val() || [];
-          selectedTag = preparePopTagName($(this).text() || "");
+        $(elem).on('click', function() {
+          selTags = $('.tags-filter').val() || [];
+          selectedTag = preparePopTagName($(this).text() || '');
           if (selectedTag) {
             selTags.push(selectedTag);
             location.href = updateQueryStringParameter(
               getFilterUrl(),
-              "tags",
+              'tags',
               encodeURIComponent(selTags)
             );
           }
@@ -107,8 +107,8 @@ define([
     @return string - The value of the Name
   */
   var preparePopTagName = function(name) {
-    if (name === "") return "";
-    return name.toLowerCase().split(" ")[0];
+    if (name === '') return '';
+    return name.toLowerCase().split(' ')[0];
   };
 
   /**
@@ -116,13 +116,13 @@ define([
    * @return string - The value of the URL when adding/removing values to it.
    */
   var updateQueryStringParameter = function(uri, key, value) {
-    var re = new RegExp("([?&])" + key + "=.*?(&|$)", "i");
-    var separator = uri.indexOf("?") !== -1 ? "&" : "?";
+    var re = new RegExp('([?&])' + key + '=.*?(&|$)', 'i');
+    var separator = uri.indexOf('?') !== -1 ? '&' : '?';
     if (uri.match(re)) {
-      return uri.replace(re, "$1" + key + "=" + value + "$2");
+      return uri.replace(re, '$1' + key + '=' + value + '$2');
     }
 
-    return uri + separator + key + "=" + value;
+    return uri + separator + key + '=' + value;
   };
 
   /**
@@ -134,12 +134,12 @@ define([
    */
   var getParameterByName = function(name, url) {
     if (!url) url = window.location.href;
-    name = name.replace(/[\[\]]/g, "\\$&");
-    var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+    name = name.replace(/[\[\]]/g, '\\$&');
+    var regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)'),
       results = regex.exec(url);
     if (!results) return null;
-    if (!results[2]) return "";
-    return decodeURIComponent(results[2].replace(/\+/g, " "));
+    if (!results[2]) return '';
+    return decodeURIComponent(results[2].replace(/\+/g, ' '));
   };
 
   /**
@@ -150,15 +150,15 @@ define([
   $(window).scroll(function() {
     var height = $(window).scrollTop();
     if (height > 100) {
-      $("#back2Top").fadeIn();
+      $('#back2Top').fadeIn();
     } else {
-      $("#back2Top").fadeOut();
+      $('#back2Top').fadeOut();
     }
   });
   $(document).ready(function() {
-    $("#back2Top").click(function(event) {
+    $('#back2Top').click(function(event) {
       event.preventDefault();
-      $("html, body").animate({ scrollTop: 0 }, "slow");
+      $('html, body').animate({ scrollTop: 0 }, 'slow');
       return false;
     });
   });
@@ -170,7 +170,7 @@ define([
    * @return Array - Returns an array of splitted values if given a text. Otherwise undefined
    */
   var prepareForHTML = function(text) {
-    return text ? text.toLowerCase().split(",") : text;
+    return text ? text.toLowerCase().split(',') : text;
   };
 
   var app = sammy(function() {
@@ -179,14 +179,14 @@ define([
      * It ensures to read values from the URI query param and perform actions
      * based on that. NOTE: It has major side effects on the browser.
      */
-    this.get("#/filters", function() {
-      var labels = prepareForHTML(getParameterByName("labels"));
-      var names = prepareForHTML(getParameterByName("names"));
-      var tags = prepareForHTML(getParameterByName("tags"));
+    this.get('#/filters', function() {
+      var labels = prepareForHTML(getParameterByName('labels'));
+      var names = prepareForHTML(getParameterByName('names'));
+      var tags = prepareForHTML(getParameterByName('tags'));
       renderProjects(tags, names, labels);
     });
 
-    this.get("#/", function() {
+    this.get('#/', function() {
       renderProjects();
     });
   });
@@ -194,7 +194,7 @@ define([
   var storage = (function(global) {
     function set(name, value) {
       try {
-        if (typeof global.localStorage !== "undefined") {
+        if (typeof global.localStorage !== 'undefined') {
           global.localStorage.setItem(name, JSON.stringify(value));
         }
       } catch (exception) {
@@ -208,7 +208,7 @@ define([
     }
 
     function get(name) {
-      if (typeof global.localStorage !== "undefined") {
+      if (typeof global.localStorage !== 'undefined') {
         return JSON.parse(global.localStorage.getItem(name));
       }
       return undefined;
@@ -221,13 +221,13 @@ define([
   })(window);
 
   var issueCount = function(project) {
-    var a = $(project).find(".label a"),
+    var a = $(project).find('.label a'),
       gh = a
-        .attr("href")
+        .attr('href')
         .match(/github.com(\/[^\/]+\/[^\/]+\/)(?:issues\/)?labels\/([^\/]+)$/),
       url =
-        gh && "https://api.github.com/repos" + gh[1] + "issues?labels=" + gh[2],
-      count = a.find(".count");
+        gh && 'https://api.github.com/repos' + gh[1] + 'issues?labels=' + gh[2],
+      count = a.find('.count');
 
     if (count.length) {
       return;
@@ -258,9 +258,9 @@ define([
     $.ajax(url)
       .done(function(data) {
         var resultCount =
-          data && typeof data.length === "number"
+          data && typeof data.length === 'number'
             ? data.length.toString()
-            : "?";
+            : '?';
         count.html(resultCount);
         storage.set(gh[1], {
           count: resultCount,
@@ -269,20 +269,20 @@ define([
       })
       .fail(function(jqXHR, textStatus, errorThrown) {
         var rateLimited =
-            jqXHR.getResponseHeader("X-RateLimit-Remaining") === "0",
+            jqXHR.getResponseHeader('X-RateLimit-Remaining') === '0',
           rateLimitReset =
             rateLimited &&
-            new Date(1000 * +jqXHR.getResponseHeader("X-RateLimit-Reset")),
+            new Date(1000 * +jqXHR.getResponseHeader('X-RateLimit-Reset')),
           message = rateLimitReset
-            ? "GitHub rate limit met. Reset at " +
+            ? 'GitHub rate limit met. Reset at ' +
               rateLimitReset.toLocaleTimeString() +
-              "."
-            : "Could not get issue count from GitHub: " +
+              '.'
+            : 'Could not get issue count from GitHub: ' +
               ((jqXHR.responseJSON && jqXHR.responseJSON.message) ||
                 errorThrown) +
-              ".";
-        count.html("?!");
-        count.attr("title", message);
+              '.';
+        count.html('?!');
+        count.attr('title', message);
       });
   };
 
@@ -299,33 +299,33 @@ define([
         );
       };
 
-    $window.on("scroll chosen:updated", function() {
-      $(".projects tbody:not(.counted)").each(function() {
+    $window.on('scroll chosen:updated', function() {
+      $('.projects tbody:not(.counted)').each(function() {
         var project = $(this);
         if (onScreen(project)) {
           issueCount(project);
-          project.addClass("counted");
+          project.addClass('counted');
         }
       });
     });
 
-    compiledtemplateFn = _.template($("#projects-panel-template").html());
-    projectsPanel = $("#projects-panel");
+    compiledtemplateFn = _.template($('#projects-panel-template').html());
+    projectsPanel = $('#projects-panel');
 
-    projectsPanel.on("click", "a.remove-tag", function(e) {
+    projectsPanel.on('click', 'a.remove-tag', function(e) {
       e.preventDefault();
       var tags = [];
       projectsPanel
-        .find("a.remove-tag")
+        .find('a.remove-tag')
         .not(this)
         .each(function() {
-          tags.push($(this).data("tag"));
+          tags.push($(this).data('tag'));
         });
-      var tagsString = tags.join(",");
-      window.location.href = "#/tags/" + tagsString;
+      var tagsString = tags.join(',');
+      window.location.href = '#/tags/' + tagsString;
     });
 
     app.raise_errors = true;
-    app.run("#/");
+    app.run('#/');
   });
 });

--- a/javascripts/projectsService.js
+++ b/javascripts/projectsService.js
@@ -4,21 +4,21 @@
 // @ts-nocheck
 
 // required for loading into a NodeJS context
-if (typeof define !== "function") {
-  var define = require("amdefine")(module);
+if (typeof define !== 'function') {
+  var define = require('amdefine')(module);
 }
 
-define(["underscore"], function(_) {
+define(['underscore'], function(_) {
   var applyTagsFilter = function(projects, tagsArray, tags) {
-    if (typeof tags === "string") {
-      tags = tags.split(",");
+    if (typeof tags === 'string') {
+      tags = tags.split(',');
     }
 
     tags = _.map(tags, function(entry) {
-      return entry && entry.replace(/^\s+|\s+$/g, "");
+      return entry && entry.replace(/^\s+|\s+$/g, '');
     });
 
-    if (!tags || !tags.length || tags[0] == "") {
+    if (!tags || !tags.length || tags[0] == '') {
       return projects;
     }
 
@@ -58,15 +58,15 @@ define(["underscore"], function(_) {
    * @param Array names : This is an array with the given name filters.
    */
   var applyNamesFilter = function(projects, projectNamesSorted, names) {
-    if (typeof names === "string") {
-      names = names.split(",");
+    if (typeof names === 'string') {
+      names = names.split(',');
     }
 
     names = _.map(names, function(entry) {
-      return entry && entry.replace(/^\s+|\s+$/g, "");
+      return entry && entry.replace(/^\s+|\s+$/g, '');
     });
 
-    if (!names || !names.length || names[0] == "") {
+    if (!names || !names.length || names[0] == '') {
       return projects;
     }
 
@@ -96,16 +96,16 @@ define(["underscore"], function(_) {
   var applyLabelsFilter = function(projects, projectLabelsSorted, labels) {
     label_indices = labels;
 
-    if (typeof labels === "string") {
-      label_indices = labels.split(",");
+    if (typeof labels === 'string') {
+      label_indices = labels.split(',');
     }
 
     labels_indices = _.map(labels, function(entry) {
-      return entry && entry.replace(/^\s+|\s+$/g, "");
+      return entry && entry.replace(/^\s+|\s+$/g, '');
     });
 
     // fallback if labels doesnt exist
-    if (!label_indices || !label_indices.length || labels[0] == "") {
+    if (!label_indices || !label_indices.length || labels[0] == '') {
       return projects;
     }
 
@@ -200,7 +200,7 @@ define(["underscore"], function(_) {
       sessionStorage.setItem;
     var ordering = null;
     if (canStoreOrdering) {
-      ordering = sessionStorage.getItem("projectOrder");
+      ordering = sessionStorage.getItem('projectOrder');
       if (ordering) {
         ordering = JSON.parse(ordering);
 
@@ -214,7 +214,7 @@ define(["underscore"], function(_) {
     if (!ordering) {
       ordering = _.shuffle(_.range(_projectsData.projects.length));
       if (canStoreOrdering) {
-        sessionStorage.setItem("projectOrder", JSON.stringify(ordering));
+        sessionStorage.setItem('projectOrder', JSON.stringify(ordering));
       }
     }
 

--- a/tests/spec/ProjectsServiceSpec.js
+++ b/tests/spec/ProjectsServiceSpec.js
@@ -1,75 +1,75 @@
-var _ = require("underscore");
+var _ = require('underscore');
 
-var sampleProjects = require("../src/sampleProjects");
-var ProjectsService = require("../../javascripts/projectsService");
+var sampleProjects = require('../src/sampleProjects');
+var ProjectsService = require('../../javascripts/projectsService');
 
-describe("ProjectsService", function() {
+describe('ProjectsService', function() {
   var projectsService;
 
   beforeEach(function() {
     projectsService = new ProjectsService(sampleProjects);
   });
 
-  it("should be defined", function() {
+  it('should be defined', function() {
     expect(projectsService).toBeDefined();
   });
 
-  it("should have get method defined", function() {
+  it('should have get method defined', function() {
     expect(projectsService.get).toBeDefined();
   });
 
-  it("should have getTags method defined", function() {
+  it('should have getTags method defined', function() {
     expect(projectsService.getTags).toBeDefined();
   });
 
-  it("should return projects list when get method is called", function() {
+  it('should return projects list when get method is called', function() {
     expect(projectsService.get()).toBeDefined();
   });
 
-  it("should return tags map when getTags method is called", function() {
+  it('should return tags map when getTags method is called', function() {
     expect(projectsService.getTags()).toBeDefined();
   });
 
-  describe("when instantiated with projects data", function() {
-    it("should extract and create tags map from projects data", function() {
+  describe('when instantiated with projects data', function() {
+    it('should extract and create tags map from projects data', function() {
       var tags = _.toArray(projectsService.getTags());
       expect(tags).toBeDefined();
     });
 
-    it("should ignore case of tag while creating the tag map", function() {
+    it('should ignore case of tag while creating the tag map', function() {
       var tags = _.toArray(projectsService.getTags());
       expect(tags.length).toBe(15);
     });
 
-    it("should sort the tags by the frequency of occurance and then by name", function() {
+    it('should sort the tags by the frequency of occurance and then by name', function() {
       var tags = _.toArray(projectsService.getTags());
-      expect(tags[0].name).toBe("API");
-      expect(tags[1].name).toBe("ASP.NET");
-      expect(tags[2].name).toBe("bindings");
+      expect(tags[0].name).toBe('API');
+      expect(tags[1].name).toBe('ASP.NET');
+      expect(tags[2].name).toBe('bindings');
     });
   });
 
-  describe("When filtering by name", function() {
-    it("Should return the correct project given the correct index", function() {
-      var project = projectsService.get(null, ["1"], undefined);
+  describe('When filtering by name', function() {
+    it('Should return the correct project given the correct index', function() {
+      var project = projectsService.get(null, ['1'], undefined);
       expect(project).toBeDefined();
-      expect(project[0].name).toBe("LibGit2Sharp");
+      expect(project[0].name).toBe('LibGit2Sharp');
       expect(project[1]).toBe(undefined);
     });
 
-    it.skip("Should return all projects if given falsy values", function() {
+    it.skip('Should return all projects if given falsy values', function() {
       var projects = projectsService.get(null, true, undefined);
 
       expect(projects).toBeDefined();
 
       // TODO: this test is dependent on sort order and may fail because the test
       //       list of projects only contains two projects
-      expect(projects[1].name).toBe("Glimpse");
+      expect(projects[1].name).toBe('Glimpse');
       expect(projects.length).toEqual(2);
     });
   });
 
-  it.skip("should return shuffled projects list  ", function() {
+  it.skip('should return shuffled projects list  ', function() {
     const firstProject = sampleProjects[0];
 
     var projects = projectsService.get();
@@ -79,86 +79,86 @@ describe("ProjectsService", function() {
     expect(projects[0].name).not.toEqual(firstProject.name);
   });
 
-  describe("when get method is called with no parameters", function() {
-    it("should return all the projects", function() {
+  describe('when get method is called with no parameters', function() {
+    it('should return all the projects', function() {
       var projects = projectsService.get();
       expect(projects.length).toBe(2);
     });
   });
 
-  describe("when get method is called with an empty tags array", function() {
-    it("should return all the projects", function() {
+  describe('when get method is called with an empty tags array', function() {
+    it('should return all the projects', function() {
       var projects = projectsService.get();
       expect(projects.length).toBe(2);
     });
   });
 
-  describe("when get method is called with matching tags array", function() {
-    it("should return all projects associated with those tags", function() {
-      var projects = projectsService.get(["web"]);
+  describe('when get method is called with matching tags array', function() {
+    it('should return all projects associated with those tags', function() {
+      var projects = projectsService.get(['web']);
       expect(projects.length).toBe(1);
     });
 
-    it("should apply case insensitve search for projects associated with those tags", function() {
-      var projects = projectsService.get(["WEB"]);
+    it('should apply case insensitve search for projects associated with those tags', function() {
+      var projects = projectsService.get(['WEB']);
       expect(projects.length).toBe(1);
     });
   });
 
-  describe("when get method is called tags array and none of the tags match", function() {
-    it("should return 0 projects", function() {
-      var projects = projectsService.get(["D'oh"]);
+  describe('when get method is called tags array and none of the tags match', function() {
+    it('should return 0 projects', function() {
+      var projects = projectsService.get(['Oops']);
       expect(projects.length).toBe(0);
     });
   });
 
-  describe("when get method is called with tags parameter as a string", function() {
-    it("should return all projects associated with those tags", function() {
-      var projects = projectsService.get("web");
+  describe('when get method is called with tags parameter as a string', function() {
+    it('should return all projects associated with those tags', function() {
+      var projects = projectsService.get('web');
       expect(projects.length).toBe(1);
     });
 
-    it("should match the tags after trimming leading and trailing spaces", function() {
-      var projects = projectsService.get(" web ");
+    it('should match the tags after trimming leading and trailing spaces', function() {
+      var projects = projectsService.get(' web ');
       expect(projects.length).toBe(1);
     });
   });
 
-  describe("when get method is called with tags array containing both matching and non matching tags", function() {
-    it("should return projects for the matching tags and ignore non matching tag", function() {
-      var projects = projectsService.get(["c#", "D'oh"]);
+  describe('when get method is called with tags array containing both matching and non matching tags', function() {
+    it('should return projects for the matching tags and ignore non matching tag', function() {
+      var projects = projectsService.get(['c#', 'Oops']);
       expect(projects.length).toBe(2);
     });
   });
 
-  describe("Expect multiple filters to work tremendously good", function() {
-    it("If it doesn't take any filters then it should return projects", function() {
+  describe('Expect multiple filters to work tremendously good', function() {
+    it('If it does not take any filters then it should return projects', function() {
       var projects = projectsService.get(undefined, undefined, undefined);
       expect(projects.length).toBe(2);
     });
 
-    it("Should take a name filter and tag filter with no issues", function() {
-      var projects = projectsService.get(["c#"], ["0"], undefined);
+    it('Should take a name filter and tag filter with no issues', function() {
+      var projects = projectsService.get(['c#'], ['0'], undefined);
       expect(projects.length).toBe(1);
     });
 
-    it("Should take a name filter and wrong tag filter and expect nothing", function() {
-      var projects = projectsService.get(["web"], ["1"], undefined);
+    it('Should take a name filter and wrong tag filter and expect nothing', function() {
+      var projects = projectsService.get(['web'], ['1'], undefined);
       expect(projects.length).toBe(0);
     });
 
-    it("Should take a name filter and label filter with no issues", function() {
-      var projects = projectsService.get(undefined, ["1"], ["1"]);
+    it('Should take a name filter and label filter with no issues', function() {
+      var projects = projectsService.get(undefined, ['1'], ['1']);
       expect(projects.length).toBe(1);
     });
 
-    it("Should take a tag filter and label filter with no issues", function() {
-      var projects = projectsService.get(["c#"], undefined, ["1"]);
+    it('Should take a tag filter and label filter with no issues', function() {
+      var projects = projectsService.get(['c#'], undefined, ['1']);
       expect(projects.length).toBe(1);
     });
 
-    it("Should take all three filters and return a project", function() {
-      var projects = projectsService.get(["c#"], ["1"], ["1"]);
+    it('Should take all three filters and return a project', function() {
+      var projects = projectsService.get(['c#'], ['1'], ['1']);
       expect(projects.length).toBe(1);
     });
   });

--- a/tests/src/sampleProjects.js
+++ b/tests/src/sampleProjects.js
@@ -1,34 +1,34 @@
 module.exports = [
   {
-    name: "Glimpse",
+    name: 'Glimpse',
     desc:
-      "Glimpse is a web debugging and diagnostics tool used to gain a better understanding of whats happening inside of your ASP.NET application.",
-    site: "https://github.com/Glimpse/Glimpse",
+      'Glimpse is a web debugging and diagnostics tool used to gain a better understanding of whats happening inside of your ASP.NET application.',
+    site: 'https://github.com/Glimpse/Glimpse',
     tags: [
-      "ASP.NET",
-      "C#",
-      "Web",
-      "WebForms",
-      "diagnostics",
-      "performance",
-      "profiling",
-      "timing",
+      'ASP.NET',
+      'C#',
+      'Web',
+      'WebForms',
+      'diagnostics',
+      'performance',
+      'profiling',
+      'timing',
     ],
     upforgrabs: {
-      name: "Jump In",
-      link: "https://github.com/Glimpse/Glimpse/issues?labels=Jump+In",
+      name: 'Jump In',
+      link: 'https://github.com/Glimpse/Glimpse/issues?labels=Jump+In',
     },
   },
   {
-    name: "LibGit2Sharp",
+    name: 'LibGit2Sharp',
     desc:
-      "LibGit2Sharp brings all the might and speed of libgit2, a native Git implementation, to the managed world of .Net and Mono.",
-    site: "https://github.com/libgit2/libgit2sharp",
-    tags: ["libgit2", "git", "wrapper", "bindings", "API", "dvcs", "vcs", "C#"],
+      'LibGit2Sharp brings all the might and speed of libgit2, a native Git implementation, to the managed world of .Net and Mono.',
+    site: 'https://github.com/libgit2/libgit2sharp',
+    tags: ['libgit2', 'git', 'wrapper', 'bindings', 'API', 'dvcs', 'vcs', 'C#'],
     upforgrabs: {
-      name: "Up for grabs",
+      name: 'Up for grabs',
       link:
-        "https://github.com/libgit2/libgit2sharp/issues?labels=Up+for+grabs",
+        'https://github.com/libgit2/libgit2sharp/issues?labels=Up+for+grabs',
     },
   },
 ];


### PR DESCRIPTION
I've been looking at some of the older PRs this weekend and figuring out some wins around maintainability of the JS parts of the app (while also enhancing things), but first I want to lean more on Prettier for formatting of the code.

This PR moves us over to standardizing on using single-quote strings in JS, rather than double-quotes. I did this because there were fewer problematic strings that embed single-quotes in the code than embed double-quotes. Prettier and ESLint are now setup to enforce this too.

In particular the `Link` header on a response from the GitHub API to handle pagination can embed several double-quote strings, which I needed to use to test functionality related to #604:

```
Link: <https://api.github.com/search/code?q=addClass+user%3Amozilla&page=2>; rel="next",
  <https://api.github.com/search/code?q=addClass+user%3Amozilla&page=34>; rel="last"
```

The strings that I found which needed manual updating in this PR were only string in test files, e.g. `D'oh` and `doesn't`. This is because Prettier skipped these strings rather than trying to re-encode them correctly, which is the desired behaviour.