### PR TITLE
Fix link to gitlab issues

### DIFF
--- a/_data/projects/gitlab.yml
+++ b/_data/projects/gitlab.yml
@@ -11,4 +11,4 @@ tags:
 - web
 upforgrabs:
   name: Accepting merge requests
-  link: https://gitlab.com/groups/gitlab-org/-/issues?state=opened&assignee_id=0&label_name[]=Accepting%20merge%20requests
+  link: https://gitlab.com/groups/gitlab-org/-/issues?state=opened&label_name[]=Accepting%20merge%20requests


### PR DESCRIPTION
The [current link](https://gitlab.com/groups/gitlab-org/-/issues?state=opened&assignee_id=0&label_name[]=Accepting%20merge%20requests) leads to the issues page with no issues displayed. After removing `assignee_id=0` all open issues with the label are shown.