### PR TITLE
Add Microsoft Azure SDK for Java as project

### DIFF
--- a/_data/projects/azure-sdk-for-java.yml
+++ b/_data/projects/azure-sdk-for-java.yml
@@ -1,0 +1,12 @@
+name: Microsoft Azure SDK for Java
+desc: Microsoft Azure SDK for Java developers to interface with Azure cloud services.
+site: https://github.com/Azure/azure-sdk-for-java
+tags:
+- java
+- microsoft
+- azure
+- cloud
+- sdk
+upforgrabs:
+  name: Up for grabs
+  link: https://github.com/Azure/azure-sdk-for-java/labels/Up%20for%20grabs


### PR DESCRIPTION
This PR is to register [Microsoft Azure SDK for Java](https://github.com/Azure/azure-sdk-for-java) to up-for-grabs.net.