### PR TITLE
caching stats in project output on build

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -30,8 +30,8 @@
     </ul>
   </div>
   <table class="projects">
-   <% _.each(projects, function(project){ %>
-    <tbody>
+   <% _.each(projects, function(project) { %>
+    <tbody class="<% if ( project.stats ) { %>counted<% } %>">
     <tr>
        <td colspan="2" class="title">
            <span class="proj"><a href="<%-project.site %>" target="_blank"><%-project.name %></a></span>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -39,7 +39,17 @@
     </tr>
     <tr>
        <td class="details">
-        <p class="label"><a href="<%- project.upforgrabs.link %>" title="View open issues for <%-project.name %>" target="_blank" tabindex="-1"><%-project.upforgrabs.name %></a></p>
+        <p class="label">
+          <a href="<%- project.upforgrabs.link %>" title="View open issues for <%-project.name %>" target="_blank" tabindex="-1">
+            <%-project.upforgrabs.name %>
+
+            <% if (project.stats) { %>
+              <span class="count"><%-project.stats['issue-count']%></span>
+            <% } else { %>
+              <span class="count">??</span>
+            <% } %>
+          </a>
+        </p>
        </td>
        <td class="details">
            <% if (project.desc) { %>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -42,11 +42,8 @@
         <p class="label">
           <a href="<%- project.upforgrabs.link %>" title="View open issues for <%-project.name %>" target="_blank" tabindex="-1">
             <%-project.upforgrabs.name %>
-
             <% if (project.stats) { %>
               <span class="count"><%-project.stats['issue-count']%></span>
-            <% } else { %>
-              <span class="count">??</span>
             <% } %>
           </a>
         </p>
@@ -92,4 +89,3 @@
   pageTracker._trackPageview();
   } catch(err) {}
 </script>
-

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -42,8 +42,12 @@
         <p class="label">
           <a href="<%- project.upforgrabs.link %>" title="View open issues for <%-project.name %>" target="_blank" tabindex="-1">
             <%-project.upforgrabs.name %>
-            <% if (project.stats) { %>
-              <span class="count"><%-project.stats['issue-count']%></span>
+            <% if (project.stats) {
+              const now = new Date();
+              let lastUpdated = new Date(project.stats['last-updated']);
+              let since = relativeTime(now, lastUpdated);
+              %>
+              <span class="count" title="Last updated <%- since %>"><%-project.stats['issue-count']%></span>
             <% } %>
           </a>
         </p>

--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -20,10 +20,41 @@ define([
       : location.href + 'filters';
   };
 
+  // inspired by https://stackoverflow.com/a/6109105/1363815 until I have a better
+  // idea of what we want to do here
+  function relativeTime(current, previous) {
+    var msPerMinute = 60 * 1000;
+    var msPerHour = msPerMinute * 60;
+    var msPerDay = msPerHour * 24;
+    var msPerMonth = msPerDay * 30;
+    var msPerYear = msPerDay * 365;
+
+    var elapsed = current - previous;
+
+    if (elapsed < msPerMinute) {
+      return Math.round(elapsed / 1000) + ' seconds ago';
+    }
+    if (elapsed < msPerHour) {
+      return Math.round(elapsed / msPerMinute) + ' minutes ago';
+    }
+    if (elapsed < msPerDay) {
+      return Math.round(elapsed / msPerHour) + ' hours ago';
+    }
+    if (elapsed < msPerMonth) {
+      return 'about ' + Math.round(elapsed / msPerDay) + ' days ago';
+    }
+    if (elapsed < msPerYear) {
+      return 'about ' + Math.round(elapsed / msPerMonth) + ' months ago';
+    }
+
+    return 'about ' + Math.round(elapsed / msPerYear) + ' years ago';
+  }
+
   var renderProjects = function(tags, names, labels) {
     projectsPanel.html(
       compiledtemplateFn({
         projects: projectsSvc.get(tags, names, labels),
+        relativeTime: relativeTime,
         tags: projectsSvc.getTags(),
         popularTags: projectsSvc.getPopularTags(6),
         selectedTags: tags,

--- a/javascripts/projectsService.js
+++ b/javascripts/projectsService.js
@@ -218,8 +218,12 @@ define(['underscore'], function(_) {
       }
     }
 
-    var projects = _.map(ordering, function(i) {
+    var all_projects = _.map(ordering, function(i) {
       return _projectsData.projects[i];
+    });
+
+    var projects = _.filter(all_projects, function(project) {
+      return project.stats ? project.stats['issue-count'] > 0 : true;
     });
 
     _.each(_projectsData.tags, function(tag) {


### PR DESCRIPTION
Resolves #1329
Resolves #261 
Closes #1369

 - run the update stats action against all the projects
 - tweak the template for each project to look for this stats object and add the number

You can see this live at the Netlify deploy URL: https://deploy-preview-1346--up-for-grabs-test-bench.netlify.com/

Before I can go live with this, I need to do a bunch of things:
 
 - [x] extract first commit into own PR
 - [x] wire up new action to open a PR which will update these stats
 - [x] find a way to add a tooltip with the last updated field (using a quick "relative time" function)
 - [x] hide projects from results which have 0 cached issues (different case to "unknown")
 - [x] test updating stats again today 
 - [x] move action to run at a different hour each day so it won't clash with project cleanup work