### PR TITLE
review and tidy up ProjectService tests

### DIFF
--- a/tests/spec/ProjectsServiceSpec.js
+++ b/tests/spec/ProjectsServiceSpec.js
@@ -1,165 +1,149 @@
-var _ = require('underscore');
-
-var sampleProjects = require('../src/sampleProjects');
-var ProjectsService = require('../../javascripts/projectsService');
+const sampleProjects = require('../src/sampleProjects');
+const ProjectsService = require('../../javascripts/projectsService');
 
 describe('ProjectsService', function() {
-  var projectsService;
+  describe('simple project list', function() {
+    let projectsService;
 
-  beforeEach(function() {
-    projectsService = new ProjectsService(sampleProjects);
-  });
-
-  it('should be defined', function() {
-    expect(projectsService).toBeDefined();
-  });
-
-  it('should have get method defined', function() {
-    expect(projectsService.get).toBeDefined();
-  });
-
-  it('should have getTags method defined', function() {
-    expect(projectsService.getTags).toBeDefined();
-  });
-
-  it('should return projects list when get method is called', function() {
-    expect(projectsService.get()).toBeDefined();
-  });
-
-  it('should return tags map when getTags method is called', function() {
-    expect(projectsService.getTags()).toBeDefined();
-  });
-
-  describe('when instantiated with projects data', function() {
-    it('should extract and create tags map from projects data', function() {
-      var tags = _.toArray(projectsService.getTags());
-      expect(tags).toBeDefined();
+    beforeEach(function() {
+      projectsService = new ProjectsService(sampleProjects);
     });
 
-    it('should ignore case of tag while creating the tag map', function() {
-      var tags = _.toArray(projectsService.getTags());
-      expect(tags.length).toBe(15);
+    describe('get', function() {
+      it('returns expected project count', function() {
+        expect(projectsService.get()).toHaveLength(2);
+      });
+
+      describe('filtering', function() {
+        it('??? happens when number provided as a name', function() {
+          const tags = null;
+          const names = ['1'];
+          const project = projectsService.get(tags, names);
+
+          expect(project).toBeDefined();
+          expect(project[0].name).toBe('LibGit2Sharp');
+          expect(project[1]).toBe(undefined);
+        });
+
+        it('all projects returned when given falsy values', function() {
+          const projects = projectsService.get(null, true, undefined);
+
+          expect(projects).toHaveLength(2);
+
+          const projectNames = projects.map(function(p) { return p.name; });
+          expect(projectNames).toContain('Glimpse');
+          expect(projectNames).toContain('LibGit2Sharp');
+        });
+
+        it('returns single project when providing array of tags', function() {
+          const projects = projectsService.get(['web']);
+          expect(projects).toHaveLength(1);
+        });
+
+        it('array of tags searched using case-insensitve comparison', function() {
+          const projects = projectsService.get(['WEB']);
+          expect(projects).toHaveLength(1);
+        });
+
+        it('array of non-matching tags returns no projects', function() {
+          const projects = projectsService.get(['oops']);
+          expect(projects).toHaveLength(0);
+        });
+      });
     });
 
-    it('should sort the tags by the frequency of occurance and then by name', function() {
-      var tags = _.toArray(projectsService.getTags());
-      expect(tags[0].name).toBe('API');
-      expect(tags[1].name).toBe('ASP.NET');
-      expect(tags[2].name).toBe('bindings');
-    });
-  });
+    describe('getTags', function() {
+      it('returns collection of parsed tags', function() {
+        expect(projectsService.getTags()).toHaveLength(15);
+      });
 
-  describe('When filtering by name', function() {
-    it('Should return the correct project given the correct index', function() {
-      var project = projectsService.get(null, ['1'], undefined);
-      expect(project).toBeDefined();
-      expect(project[0].name).toBe('LibGit2Sharp');
-      expect(project[1]).toBe(undefined);
+      it('includes projects assigned each tag', function() {
+        var tags = projectsService.getTags();
+        expect(tags).toContainEqual({ name: 'API', frequency: 1, projects: ['LibGit2Sharp'] });
+        expect(tags).toContainEqual({ name: 'C#', frequency: 2, projects: ['Glimpse', 'LibGit2Sharp'] });
+        expect(tags).toContainEqual({ name: 'bindings', frequency: 1, projects: ['LibGit2Sharp'] });
+      });
     });
 
-    it.skip('Should return all projects if given falsy values', function() {
-      var projects = projectsService.get(null, true, undefined);
+    describe('getPopularTags', function() {
+      it('returns 10 tags by default', function() {
+        expect(projectsService.getPopularTags()).toHaveLength(10);
+      });
 
-      expect(projects).toBeDefined();
+      it('returns requested number if specified', function() {
+        const tags = projectsService.getPopularTags(1);
+        expect(tags).toContainEqual({ name: 'C#', frequency: 2, projects: ['Glimpse', 'LibGit2Sharp'] });
+      });
+
+      it('returns expected top tag', function() {
+        expect(projectsService.getPopularTags(1)).toHaveLength(1);
+      });
+
+      it('cannot return more than the total tags available', function() {
+        const tags = projectsService.getTags();
+        expect(projectsService.getPopularTags(99)).toHaveLength(tags.length);
+      });
+    });
+
+    it.skip('should return shuffled projects list', function() {
+      const firstProject = sampleProjects[0];
+
+      var projects = projectsService.get();
 
       // TODO: this test is dependent on sort order and may fail because the test
       //       list of projects only contains two projects
-      expect(projects[1].name).toBe('Glimpse');
-      expect(projects.length).toEqual(2);
-    });
-  });
-
-  it.skip('should return shuffled projects list  ', function() {
-    const firstProject = sampleProjects[0];
-
-    var projects = projectsService.get();
-
-    // TODO: this test is dependent on sort order and may fail because the test
-    //       list of projects only contains two projects
-    expect(projects[0].name).not.toEqual(firstProject.name);
-  });
-
-  describe('when get method is called with no parameters', function() {
-    it('should return all the projects', function() {
-      var projects = projectsService.get();
-      expect(projects.length).toBe(2);
-    });
-  });
-
-  describe('when get method is called with an empty tags array', function() {
-    it('should return all the projects', function() {
-      var projects = projectsService.get();
-      expect(projects.length).toBe(2);
-    });
-  });
-
-  describe('when get method is called with matching tags array', function() {
-    it('should return all projects associated with those tags', function() {
-      var projects = projectsService.get(['web']);
-      expect(projects.length).toBe(1);
+      expect(projects[0].name).not.toEqual(firstProject.name);
     });
 
-    it('should apply case insensitve search for projects associated with those tags', function() {
-      var projects = projectsService.get(['WEB']);
-      expect(projects.length).toBe(1);
-    });
-  });
+    describe('when get method is called with tags parameter as a string', function() {
+      it('should return all projects associated with those tags', function() {
+        var projects = projectsService.get('web');
+        expect(projects.length).toBe(1);
+      });
 
-  describe('when get method is called tags array and none of the tags match', function() {
-    it('should return 0 projects', function() {
-      var projects = projectsService.get(['Oops']);
-      expect(projects.length).toBe(0);
-    });
-  });
-
-  describe('when get method is called with tags parameter as a string', function() {
-    it('should return all projects associated with those tags', function() {
-      var projects = projectsService.get('web');
-      expect(projects.length).toBe(1);
+      it('should match the tags after trimming leading and trailing spaces', function() {
+        var projects = projectsService.get(' web ');
+        expect(projects.length).toBe(1);
+      });
     });
 
-    it('should match the tags after trimming leading and trailing spaces', function() {
-      var projects = projectsService.get(' web ');
-      expect(projects.length).toBe(1);
-    });
-  });
-
-  describe('when get method is called with tags array containing both matching and non matching tags', function() {
-    it('should return projects for the matching tags and ignore non matching tag', function() {
-      var projects = projectsService.get(['c#', 'Oops']);
-      expect(projects.length).toBe(2);
-    });
-  });
-
-  describe('Expect multiple filters to work tremendously good', function() {
-    it('If it does not take any filters then it should return projects', function() {
-      var projects = projectsService.get(undefined, undefined, undefined);
-      expect(projects.length).toBe(2);
+    describe('when get method is called with tags array containing both matching and non matching tags', function() {
+      it('should return projects for the matching tags and ignore non matching tag', function() {
+        var projects = projectsService.get(['c#', 'Oops']);
+        expect(projects.length).toBe(2);
+      });
     });
 
-    it('Should take a name filter and tag filter with no issues', function() {
-      var projects = projectsService.get(['c#'], ['0'], undefined);
-      expect(projects.length).toBe(1);
-    });
+    describe('Expect multiple filters to work tremendously good', function() {
+      it('If it does not take any filters then it should return projects', function() {
+        var projects = projectsService.get(undefined, undefined, undefined);
+        expect(projects.length).toBe(2);
+      });
 
-    it('Should take a name filter and wrong tag filter and expect nothing', function() {
-      var projects = projectsService.get(['web'], ['1'], undefined);
-      expect(projects.length).toBe(0);
-    });
+      it('Should take a name filter and tag filter with no issues', function() {
+        var projects = projectsService.get(['c#'], ['0'], undefined);
+        expect(projects.length).toBe(1);
+      });
 
-    it('Should take a name filter and label filter with no issues', function() {
-      var projects = projectsService.get(undefined, ['1'], ['1']);
-      expect(projects.length).toBe(1);
-    });
+      it('Should take a name filter and wrong tag filter and expect nothing', function() {
+        var projects = projectsService.get(['web'], ['1'], undefined);
+        expect(projects.length).toBe(0);
+      });
 
-    it('Should take a tag filter and label filter with no issues', function() {
-      var projects = projectsService.get(['c#'], undefined, ['1']);
-      expect(projects.length).toBe(1);
-    });
+      it('Should take a name filter and label filter with no issues', function() {
+        var projects = projectsService.get(undefined, ['1'], ['1']);
+        expect(projects.length).toBe(1);
+      });
 
-    it('Should take all three filters and return a project', function() {
-      var projects = projectsService.get(['c#'], ['1'], ['1']);
-      expect(projects.length).toBe(1);
+      it('Should take a tag filter and label filter with no issues', function() {
+        var projects = projectsService.get(['c#'], undefined, ['1']);
+        expect(projects.length).toBe(1);
+      });
+
+      it('Should take all three filters and return a project', function() {
+        var projects = projectsService.get(['c#'], ['1'], ['1']);
+        expect(projects.length).toBe(1);
+      });
     });
   });
 });

--- a/tests/spec/ProjectsServiceSpec.js
+++ b/tests/spec/ProjectsServiceSpec.js
@@ -88,7 +88,7 @@ describe('ProjectsService', function() {
     it.skip('should return shuffled projects list', function() {
       const firstProject = sampleProjects[0];
 
-      var projects = projectsService.get();
+      const projects = projectsService.get();
 
       // TODO: this test is dependent on sort order and may fail because the test
       //       list of projects only contains two projects
@@ -97,51 +97,51 @@ describe('ProjectsService', function() {
 
     describe('when get method is called with tags parameter as a string', function() {
       it('should return all projects associated with those tags', function() {
-        var projects = projectsService.get('web');
+        const projects = projectsService.get('web');
         expect(projects.length).toBe(1);
       });
 
       it('should match the tags after trimming leading and trailing spaces', function() {
-        var projects = projectsService.get(' web ');
+        const projects = projectsService.get(' web ');
         expect(projects.length).toBe(1);
       });
     });
 
     describe('when get method is called with tags array containing both matching and non matching tags', function() {
       it('should return projects for the matching tags and ignore non matching tag', function() {
-        var projects = projectsService.get(['c#', 'Oops']);
+        const projects = projectsService.get(['c#', 'Oops']);
         expect(projects.length).toBe(2);
       });
     });
 
     describe('Expect multiple filters to work tremendously good', function() {
       it('If it does not take any filters then it should return projects', function() {
-        var projects = projectsService.get(undefined, undefined, undefined);
+        const projects = projectsService.get(undefined, undefined, undefined);
         expect(projects.length).toBe(2);
       });
 
       it('Should take a name filter and tag filter with no issues', function() {
-        var projects = projectsService.get(['c#'], ['0'], undefined);
+        const projects = projectsService.get(['c#'], ['0'], undefined);
         expect(projects.length).toBe(1);
       });
 
       it('Should take a name filter and wrong tag filter and expect nothing', function() {
-        var projects = projectsService.get(['web'], ['1'], undefined);
+        const projects = projectsService.get(['web'], ['1'], undefined);
         expect(projects.length).toBe(0);
       });
 
       it('Should take a name filter and label filter with no issues', function() {
-        var projects = projectsService.get(undefined, ['1'], ['1']);
+        const projects = projectsService.get(undefined, ['1'], ['1']);
         expect(projects.length).toBe(1);
       });
 
       it('Should take a tag filter and label filter with no issues', function() {
-        var projects = projectsService.get(['c#'], undefined, ['1']);
+        const projects = projectsService.get(['c#'], undefined, ['1']);
         expect(projects.length).toBe(1);
       });
 
       it('Should take all three filters and return a project', function() {
-        var projects = projectsService.get(['c#'], ['1'], ['1']);
+        const projects = projectsService.get(['c#'], ['1'], ['1']);
         expect(projects.length).toBe(1);
       });
     });

--- a/tests/spec/ProjectsServiceSpec.js
+++ b/tests/spec/ProjectsServiceSpec.js
@@ -30,7 +30,9 @@ describe('ProjectsService', function() {
 
           expect(projects).toHaveLength(2);
 
-          const projectNames = projects.map(function(p) { return p.name; });
+          const projectNames = projects.map(function(p) {
+            return p.name;
+          });
           expect(projectNames).toContain('Glimpse');
           expect(projectNames).toContain('LibGit2Sharp');
         });
@@ -58,10 +60,22 @@ describe('ProjectsService', function() {
       });
 
       it('includes projects assigned each tag', function() {
-        var tags = projectsService.getTags();
-        expect(tags).toContainEqual({ name: 'API', frequency: 1, projects: ['LibGit2Sharp'] });
-        expect(tags).toContainEqual({ name: 'C#', frequency: 2, projects: ['Glimpse', 'LibGit2Sharp'] });
-        expect(tags).toContainEqual({ name: 'bindings', frequency: 1, projects: ['LibGit2Sharp'] });
+        const tags = projectsService.getTags();
+        expect(tags).toContainEqual({
+          name: 'API',
+          frequency: 1,
+          projects: ['LibGit2Sharp'],
+        });
+        expect(tags).toContainEqual({
+          name: 'C#',
+          frequency: 2,
+          projects: ['Glimpse', 'LibGit2Sharp'],
+        });
+        expect(tags).toContainEqual({
+          name: 'bindings',
+          frequency: 1,
+          projects: ['LibGit2Sharp'],
+        });
       });
     });
 
@@ -72,7 +86,11 @@ describe('ProjectsService', function() {
 
       it('returns requested number if specified', function() {
         const tags = projectsService.getPopularTags(1);
-        expect(tags).toContainEqual({ name: 'C#', frequency: 2, projects: ['Glimpse', 'LibGit2Sharp'] });
+        expect(tags).toContainEqual({
+          name: 'C#',
+          frequency: 2,
+          projects: ['Glimpse', 'LibGit2Sharp'],
+        });
       });
 
       it('returns expected top tag', function() {


### PR DESCRIPTION
I'd like to boost our test coverage a bit before I dive into the outstanding PRs that attempt to fix things. First thing I looked into was our current `ProjectServices` tests to see what could be dropped or improved.

This is where we're at currently:

```
=============================== Coverage summary ===============================
Statements   : 61.07% ( 182/298 )
Branches     : 62.2% ( 102/164 )
Functions    : 60.76% ( 48/79 )
Lines        : 61.77% ( 181/293 )
================================================================================
Test Suites: 2 passed, 2 total
Tests:       1 skipped, 36 passed, 37 total
Snapshots:   0 total
Time:        1.841s
Ran all test suites.
```

<img width="548" src="https://user-images.githubusercontent.com/359239/65470675-90334e00-de42-11e9-8dfe-d85fb25af692.png">
