### PR TITLE
Added lang="en" to <html>

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,7 +2,7 @@
 layout: none
 ---
 <!DOCTYPE html>
-<html>
+<html lang="en">
   {% include head.html %}
   <body>
   {% include header.html %}


### PR DESCRIPTION
When I was running the Google Chrome Audit on up-for-grabs.net, I saw that one of the errors given was that it did not include a lang attribute in <html>. I quickly fixed that by adding lang="en" in the main layout. 