### PR TITLE
render some projects when browser does not support JS

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,8 +19,8 @@ github: [metadata]
 
 # DO NOT DELETE THIS
 # This is used to build up the array of projects rendered inside a <noscript>
-# tag to support browsers which disable JS. For more context check out 
-# https://github.com/up-for-grabs/up-for-grabs.net/pull/XYZ which explains what
+# tag to support browsers which disable JS. For more context check out
+# https://github.com/up-for-grabs/up-for-grabs.net/pull/1412 which explains what
 # this gives us.
 emptyArray: []
 

--- a/_config.yml
+++ b/_config.yml
@@ -17,3 +17,10 @@ exclude:
 
 github: [metadata]
 
+# DO NOT DELETE THIS
+# This is used to build up the array of projects rendered inside a <noscript>
+# tag to support browsers which disable JS. For more context check out 
+# https://github.com/up-for-grabs/up-for-grabs.net/pull/XYZ which explains what
+# this gives us.
+emptyArray: []
+

--- a/_includes/noscript.html
+++ b/_includes/noscript.html
@@ -57,10 +57,9 @@
             {% endif %}
             {% if project.tags %}
             <p class="tags">
-                {% for tag in project.tags %}
-                    <a href="#/filters?tags={{ tag | cgi_escape }}>" tabindex="-1">{{ tag }}</a>
-                    {% if forloop.index < project.tags.size %}, {% endif %}
-                {% endfor %}
+            {% for tag in project.tags %}
+              <a href="#/filters?tags={{ tag | cgi_escape }}>" tabindex="-1">{{ tag }}</a>{% if forloop.index < project.tags.size %}, {% endif %}
+            {% endfor %}
             </p>
             {% endif %}
         </td>

--- a/_includes/noscript.html
+++ b/_includes/noscript.html
@@ -58,7 +58,7 @@
             {% if project.tags %}
             <p class="tags">
             {% for tag in project.tags %}
-              <a href="#/filters?tags={{ tag | cgi_escape }}>" tabindex="-1">{{ tag }}</a>{% if forloop.index < project.tags.size %}, {% endif %}
+              {{ tag }}{% if forloop.index < project.tags.size %}, {% endif %}
             {% endfor %}
             </p>
             {% endif %}

--- a/_includes/noscript.html
+++ b/_includes/noscript.html
@@ -59,9 +59,7 @@
             <p class="tags">
                 {% for tag in project.tags %}
                     <a href="#/filters?tags={{ tag | cgi_escape }}>" tabindex="-1">{{ tag }}</a>
-                    {% if forloop.index < project.tags.size %}
-                      ,
-                    {% endif %}
+                    {% if forloop.index < project.tags.size %}, {% endif %}
                 {% endfor %}
             </p>
             {% endif %}

--- a/_includes/noscript.html
+++ b/_includes/noscript.html
@@ -1,0 +1,73 @@
+<noscript>
+  <div class="warning">
+    You have disabled JavaScript on this site. As we rely on JavaScript for
+    important functionality on the site, we will fallback to instead render
+    a selection of available projects for you to explore.
+  </div>
+
+  {% comment %}
+    This stage enumerates the list of projects, which are grouped by the hash
+    (file name) and the value (parsed contents of file) and builds up an array
+    of projects that we can use in the next stage.
+  {% endcomment %}
+
+  {% assign values = site.emptyArray %}
+  {% for project_hash in site.data.projects %}
+    {% assign project = project_hash[1] %}
+    {% assign values = values | push: project %}
+  {% endfor %}
+
+  {% comment %}
+    This stage does some filtering on the array of projects so that we can
+    select a random sample of projects. This will change on each build, so we
+    don't need to worry about the same projects appearing each time.
+
+    TODO: can we filter out projects that have zero open issues?
+  {% endcomment %}
+  {% assign sampled_projects = values | where_exp: "stats", "stats != nil" | sample: 50 %}
+
+  <table class="projects">
+    {% for project in sampled_projects %}
+      {% if project.stats != nil %}
+      <tbody class="counted">
+      {% else %}
+      <tbody>
+      {% endif %}
+      <tr>
+        <td colspan="2" class="title">
+            <span class="proj"><a href="{{ project.site }}" target="_blank">{{ project.name }}</a></span>
+        </td>
+      </tr>
+      <tr>
+        <td class="details">
+          <p class="label">
+            <a href="{{ project.upforgrabs.link }}" title="View open issues for {{ project.name }}" target="_blank" tabindex="-1">
+            {{ project.upforgrabs.name }}
+            {% if project.stats != nil %}
+              <span class="count" title="Last updated {{ project.stats['last-updated'] | date_to_long_string: "ordinal" }}">{{ project.stats['issue-count'] }}</span>
+            {% else %}
+              <span class="count" title="Unknown count of open tasks">??</span>
+            {% endif %}
+            </a>
+          </p>
+        </td>
+        <td class="details">
+            {% if project.desc %}
+            <span class="desc">{{ project.desc }}</span>
+            {% endif %}
+            {% if project.tags %}
+            <p class="tags">
+                {% for tag in project.tags %}
+                    <a href="#/filters?tags={{ tag | cgi_escape }}>" tabindex="-1">{{ tag }}</a>
+                    {% if forloop.index < project.tags.size %}
+                      ,
+                    {% endif %}
+                {% endfor %}
+            </p>
+            {% endif %}
+        </td>
+      </tr>
+      </tbody>
+    {% endfor %}
+  </table>
+</noscript>

--- a/_includes/noscript.html
+++ b/_includes/noscript.html
@@ -11,20 +11,20 @@
     of projects that we can use in the next stage.
   {% endcomment %}
 
-  {% assign values = site.emptyArray %}
+  {% assign projects_with_stats = site.emptyArray %}
   {% for project_hash in site.data.projects %}
     {% assign project = project_hash[1] %}
-    {% assign values = values | push: project %}
+    {% if project.stats != nil %}
+    {% assign projects_with_stats = projects_with_stats | push: project %}
+    {% endif %}
   {% endfor %}
 
   {% comment %}
     This stage does some filtering on the array of projects so that we can
     select a random sample of projects. This will change on each build, so we
     don't need to worry about the same projects appearing each time.
-
-    TODO: can we filter out projects that have zero open issues?
   {% endcomment %}
-  {% assign sampled_projects = values | where_exp: "stats", "stats != nil" | sample: 50 %}
+  {% assign sampled_projects = projects_with_stats | where_exp: "item", "item.stats['issue-count'] > 0" | sample: 50 %}
 
   <table class="projects">
     {% for project in sampled_projects %}

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@ layout: default
 <div class="block">
   <h1><span class="header-inside">Projects</span></h1>
   <div id="projects-panel">
+    {% include noscript.html %}
   </div>
 </div>
 <div class="block">


### PR DESCRIPTION
Resolves #511
Supersedes #1079

This PR improves the experience when a user visits the site without JS. This is what you currently see today:

<img width="766" src="https://user-images.githubusercontent.com/359239/66082398-75e32980-e540-11e9-9138-5d07ec4b0682.png">

I wanted to pick up #1079 and take it to it's logical conclusion but I had some issues with the approach chosen:

 - rendering every project in the list wasn't optimal now that we're at almost at 800 projects
 - the order of projects is not randomized in that way
 - we lacked any sorts of stats for the projects listed (now available due to #1346)

So what does this PR give us now when JS is disabled? 

 - render a randomized list of 50 projects 
   - this is set at build time, so it'll regenerate each time the site publishes to GitHub Pages
 - embedded stats alongside each project 
   - we couldn't do this before because we hit the GitHub API directly)
 - added a warning message to explain the behaviour
   - this is unstyled for now and would be great for someone else to polish

Here's a quick screenshot:

<img width="766" src="https://user-images.githubusercontent.com/359239/66082675-fe61ca00-e540-11e9-8b3b-30fc4c5986bc.png">

This feels like a better incremental change than what was initially proposed in #1079, and we can refine this over time based on how we feel about it.

 - [x] update comment to link to this PR
 - [x] measure overhead of including this static list of projects
 - [x] confirm or give up on excluding projects with zero open issues
 - [x] test deploy site with JS disabled
 - [x] test deploy site with JS enabled
 - [x] get tag links working or disable them for now
