### PR TITLE
build docker image from source in preparation for bundler 2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,21 @@
-FROM starefossen/github-pages:onbuild
+FROM ruby:2-alpine
 
-RUN apk update && apk add libc-dev gcc g++ make
+ENV GITHUB_GEM_VERSION 200
+ENV JSON_GEM_VERSION 1.8.6
 
-RUN bundle install
+RUN apk --update add --virtual build_deps \
+    build-base ruby-dev libc-dev linux-headers \
+  && gem install --verbose --no-document \
+    json:${JSON_GEM_VERSION} \
+    github-pages:${GITHUB_GEM_VERSION} \
+    jekyll-github-metadata \
+    minitest \
+  && apk del build_deps \
+  && apk add git libc-dev gcc g++ make \
+  && mkdir -p /usr/src/app \
+  && rm -rf /usr/lib/ruby/gems/*/cache/*.gem
+
+WORKDIR /usr/src/app
+
+EXPOSE 4000 80
+CMD bundle install && bundle exec jekyll serve -d /_site --watch --force_polling -H 0.0.0.0 -P 4000


### PR DESCRIPTION
I believe the version of Ruby (which ships a default gem and bundler) is a blocker on any migration to bundler 2 for our docker setup. This updates the script to build using a more recent version of ruby (2.6.5 by my count) and to also use bundler when running the app.