### PR TITLE
fewer globals in app setup

### DIFF
--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -10,8 +10,7 @@ define([
   // selector, and needs to be ready before this code runs
   'chosen',
 ], ($, ProjectsService, fetchIssueCount, _, sammy) => {
-  var projectsSvc = new ProjectsService(projects),
-    compiledtemplateFn = null,
+  var compiledtemplateFn = null,
     projectsPanel = null;
 
   var getFilterUrl = function() {
@@ -289,6 +288,8 @@ define([
       var tagsString = tags.join(',');
       window.location.href = '#/tags/' + tagsString;
     });
+
+    var projectsSvc = new ProjectsService(projects);
 
     var app = sammy(function() {
       /*

--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -50,17 +50,19 @@ define([
     return 'about ' + Math.round(elapsed / msPerYear) + ' years ago';
   }
 
-  var renderProjects = function(tags, names, labels) {
+  var renderProjects = function(projectService, tags, names, labels) {
+    const allTags = projectService.getTags();
+
     projectsPanel.html(
       compiledtemplateFn({
-        projects: projectsSvc.get(tags, names, labels),
+        projects: projectService.get(tags, names, labels),
         relativeTime: relativeTime,
-        tags: projectsSvc.getTags(),
-        popularTags: projectsSvc.getPopularTags(6),
+        tags: allTags,
+        popularTags: projectService.getPopularTags(6),
         selectedTags: tags,
-        names: projectsSvc.getNames(),
+        names: projectService.getNames(),
         selectedNames: names,
-        labels: projectsSvc.getLabels(),
+        labels: projectService.getLabels(),
         selectedLabels: labels,
       })
     );
@@ -122,8 +124,7 @@ define([
           selTags = $('.tags-filter').val() || [];
           selectedTag = preparePopTagName($(this).text() || '');
           if (selectedTag) {
-            tagID = projectsSvc
-              .getTags()
+            tagID = allTags
               .map(function(tag) {
                 return tag.name.toLowerCase();
               })
@@ -223,11 +224,11 @@ define([
       var labels = prepareForHTML(getParameterByName('labels'));
       var names = prepareForHTML(getParameterByName('names'));
       var tags = prepareForHTML(getParameterByName('tags'));
-      renderProjects(tags, names, labels);
+      renderProjects(projectsSvc, tags, names, labels);
     });
 
     this.get('#/', function() {
-      renderProjects();
+      renderProjects(projectsSvc);
     });
   });
 

--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -214,24 +214,6 @@ define([
     return text ? text.toLowerCase().split(',') : text;
   };
 
-  var app = sammy(function() {
-    /*
-     * This is the route used to filter by tags/names/labels
-     * It ensures to read values from the URI query param and perform actions
-     * based on that. NOTE: It has major side effects on the browser.
-     */
-    this.get('#/filters', function() {
-      var labels = prepareForHTML(getParameterByName('labels'));
-      var names = prepareForHTML(getParameterByName('names'));
-      var tags = prepareForHTML(getParameterByName('tags'));
-      renderProjects(projectsSvc, tags, names, labels);
-    });
-
-    this.get('#/', function() {
-      renderProjects(projectsSvc);
-    });
-  });
-
   var issueCount = function(project) {
     var a = $(project).find('.label a'),
       gh = a
@@ -306,6 +288,24 @@ define([
         });
       var tagsString = tags.join(',');
       window.location.href = '#/tags/' + tagsString;
+    });
+
+    var app = sammy(function() {
+      /*
+      * This is the route used to filter by tags/names/labels
+      * It ensures to read values from the URI query param and perform actions
+      * based on that. NOTE: It has major side effects on the browser.
+      */
+      this.get('#/filters', function() {
+        var labels = prepareForHTML(getParameterByName('labels'));
+        var names = prepareForHTML(getParameterByName('names'));
+        var tags = prepareForHTML(getParameterByName('tags'));
+        renderProjects(projectsSvc, tags, names, labels);
+      });
+
+      this.get('#/', function() {
+        renderProjects(projectsSvc);
+      });
     });
 
     app.raise_errors = true;

--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -289,27 +289,35 @@ define([
       window.location.href = '#/tags/' + tagsString;
     });
 
-    var projectsSvc = new ProjectsService(projects);
+    function promiseWrappedProjects() {
+      return new Promise(function(resolve) {
+        resolve(projects);
+      });
+    }
 
-    var app = sammy(function() {
-      /*
-      * This is the route used to filter by tags/names/labels
-      * It ensures to read values from the URI query param and perform actions
-      * based on that. NOTE: It has major side effects on the browser.
-      */
-      this.get('#/filters', function() {
-        var labels = prepareForHTML(getParameterByName('labels'));
-        var names = prepareForHTML(getParameterByName('names'));
-        var tags = prepareForHTML(getParameterByName('tags'));
-        renderProjects(projectsSvc, tags, names, labels);
+    promiseWrappedProjects().then(function(p) {
+      var projectsSvc = new ProjectsService(p);
+
+      var app = sammy(function() {
+        /*
+         * This is the route used to filter by tags/names/labels
+         * It ensures to read values from the URI query param and perform actions
+         * based on that. NOTE: It has major side effects on the browser.
+         */
+        this.get('#/filters', function() {
+          var labels = prepareForHTML(getParameterByName('labels'));
+          var names = prepareForHTML(getParameterByName('names'));
+          var tags = prepareForHTML(getParameterByName('tags'));
+          renderProjects(projectsSvc, tags, names, labels);
+        });
+
+        this.get('#/', function() {
+          renderProjects(projectsSvc);
+        });
       });
 
-      this.get('#/', function() {
-        renderProjects(projectsSvc);
-      });
+      app.raise_errors = true;
+      app.run('#/');
     });
-
-    app.raise_errors = true;
-    app.run('#/');
   });
 });


### PR DESCRIPTION
This PR started as an experiment to see if we can move this chunk of code from `scripts.html` into the rest of the client-side JS:

https://github.com/up-for-grabs/up-for-grabs.net/blob/b020dc273d494b7d21c71eb57edb951874205d36/_includes/scripts.html#L72-L82

This code:

 - inlines all the site data on build as a JSON payload
 - downloads a third-party script (blocking)
 - reads all the projects and converts any markdown into HTML
 - sets `projects` as a global object

This is immediately used inside `main.js` as state for the `ProjectsService`:

https://github.com/up-for-grabs/up-for-grabs.net/blob/b020dc273d494b7d21c71eb57edb951874205d36/javascripts/main.js#L13-L15

And `projectsSvc` is used in many places inside the script.

So before I look at moving that first snippet into the rest of the app, I wanted to tidy up how the app is composed using the `projects` global:

 - wrap it in a promise to emulate asynchronously loading the projects
 - explicitly pass in `projectService` wherever needed, avoiding the global
 - reorder scripts so that the app setup still works as expected


TODO:

 - [x] CI passes
 - [x] test deploy site and confirm no regressions