### PR TITLE
remove inline JSON and globals for projects

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -69,17 +69,6 @@
    <% }) %>
    </table>
 </script>
-<script src="//cdnjs.cloudflare.com/ajax/libs/showdown/1.3.0/showdown.min.js"></script>
-<script type="text/javascript">
-  var files = {{ site.data.projects | jsonify }};
-  var projects = new Array();
-  var converter = new showdown.Converter();
-  for (var fileName in files) {
-    var project = files[fileName];
-    project.desc = converter.makeHtml(project.desc);
-    projects.push(project);
-  }
-</script>
 <script src="{{ site.github.url }}javascripts/lib/require.js" data-main="javascripts/app"></script>
 <!-- Google Analytics -->
 <script>

--- a/javascripts/app.js
+++ b/javascripts/app.js
@@ -9,6 +9,7 @@ requirejs.config({
     jquery: '//cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.min',
     sammy: '//cdnjs.cloudflare.com/ajax/libs/sammy.js/0.7.6/sammy.min',
     chosen: '//cdnjs.cloudflare.com/ajax/libs/chosen/1.8.7/chosen.jquery.min',
+    showdown: '//cdnjs.cloudflare.com/ajax/libs/showdown/1.3.0/showdown.min',
     'promise-polyfill':
       '//cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min',
     'whatwg-fetch': '//cdn.jsdelivr.net/npm/whatwg-fetch@3.0.0/dist/fetch.umd',

--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -2,6 +2,7 @@
 
 define([
   'jquery',
+  'projectLoader',
   'projectsService',
   'fetchIssueCount',
   'underscore',
@@ -9,7 +10,7 @@ define([
   // chosen is listed here as a dependency because it's used from a jQuery
   // selector, and needs to be ready before this code runs
   'chosen',
-], ($, ProjectsService, fetchIssueCount, _, sammy) => {
+], ($, loadProjects, ProjectsService, fetchIssueCount, _, sammy) => {
   var compiledtemplateFn = null,
     projectsPanel = null;
 

--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -290,13 +290,7 @@ define([
       window.location.href = '#/tags/' + tagsString;
     });
 
-    function promiseWrappedProjects() {
-      return new Promise(function(resolve) {
-        resolve(projects);
-      });
-    }
-
-    promiseWrappedProjects().then(function(p) {
+    loadProjects().then(function(p) {
       var projectsSvc = new ProjectsService(p);
 
       var app = sammy(function() {

--- a/javascripts/projectLoader.js
+++ b/javascripts/projectLoader.js
@@ -1,0 +1,41 @@
+/* eslint global-require: "off" */
+/* eslint block-scoped-var: "off" */
+
+// @ts-nocheck
+
+// required for loading into a NodeJS context
+if (typeof define !== 'function') {
+  var define = require('amdefine')(module);
+}
+
+define(['showdown', 'whatwg-fetch', 'promise-polyfill'], function(showdown) {
+  const { fetch } = window;
+
+  function loadProjects() {
+    return fetch('/javascripts/projects.json')
+      .then(function(response) {
+        return response.json();
+      })
+      .then(function(files) {
+        const projects = [];
+        const converter = new showdown.Converter();
+        const keys = Object.keys(files);
+
+        for (let i = 0; i < keys.length; i++) {
+          const key = keys[i];
+          var project = files[key];
+          project.desc = converter.makeHtml(project.desc);
+          projects.push(project);
+        }
+
+        return projects;
+      })
+      .catch(function(error) {
+        // eslint-disable-next-line no-console
+        console.error('Unable to load project files', error);
+        return [];
+      });
+  }
+
+  return loadProjects;
+});

--- a/javascripts/projects.json
+++ b/javascripts/projects.json
@@ -1,0 +1,5 @@
+---
+---
+{{ site.data.projects | jsonify }}
+
+


### PR DESCRIPTION
Following on from #1434, this PR removes the inline projects list and introduces a standalone module to asynchronously load and setup the list of projects.

 - [x] investigate how this changes download sizes
 - [x] investigate how this changes performance of site
