### PR TITLE
upgrade GA script to version found in docs

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -81,15 +81,14 @@
   }
 </script>
 <script src="{{ site.github.url }}javascripts/lib/require.js" data-main="javascripts/app"></script>
+<!-- Google Analytics -->
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-
-<script type="text/javascript">
-  var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
-  document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
+  ga('create', 'UA-45897756-1', 'auto');
+  ga('send', 'pageview');
 </script>
-<script type="text/javascript">
-  try {
-    var pageTracker = _gat._getTracker("UA-45897756-1");
-  pageTracker._trackPageview();
-  } catch(err) {}
-</script>
+<!-- End Google Analytics -->


### PR DESCRIPTION
Aiming to address this warning:

> A parser-blocking, cross site (i.e. different eTLD+1) script, https://ssl.google-analytics.com/ga.js, is invoked via document.write. The network request for this script MAY be blocked by the browser in this or a future page load due to poor network connectivity. If blocked in this page load, it will be confirmed in a subsequent console message. See https://www.chromestatus.com/feature/5718547946799104 for more details.

This was the latest script from https://developers.google.com/analytics/devguides/collection/analyticsjs but I'd honestly be fine to swap it out for something else or just remove it completely as I don't know if I have access to it (@dahlbyk @jrusbatch do you recall?).