### PR TITLE
PR to change Docker-Kubernetes name at Up-for-Grabs website

### DIFF
--- a/_data/projects/Docker-Kubernetes.yml
+++ b/_data/projects/Docker-Kubernetes.yml
@@ -1,0 +1,15 @@
+name: Maven-Using-CMD
+desc: >-
+  Creating a Hello World code project in Java using the Apache Maven build tool and automating it using
+  Jenkins.
+site: https://github.com/NishkarshRaj/Docker-Kubernetes
+tags:
+- docker
+- kubernetes
+- container
+- orchestration
+- virtualization
+- devops
+upforgrabs:
+  name: Up-for-Grabs
+  link: https://github.com/NishkarshRaj/Docker-Kubernetes/labels/Up-for-Grabs


### PR DESCRIPTION
My project is already hosted on website but it was having the wrong name (in the PR #1427).
I updated it in this PR.
@shiftkey @ritwik12 please review.