### PR TITLE
refactoring to tidy up Ruby scripts

### DIFF
--- a/.github/workflows/update-stats.yml
+++ b/.github/workflows/update-stats.yml
@@ -11,3 +11,4 @@ jobs:
     - uses: ./.github/actions/update-stats
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        APPLY_CHANGES: 1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,14 +9,8 @@ Metrics/LineLength:
 Metrics/AbcSize:
   Max: 66
 
-Metrics/CyclomaticComplexity:
-  Max: 15
-
 Metrics/MethodLength:
   Max: 59
-
-Metrics/PerceivedComplexity:
-  Max: 15
 
 Style/GlobalVars:
   Exclude:

--- a/scripts/cibuild.rb
+++ b/scripts/cibuild.rb
@@ -2,194 +2,62 @@
 
 require 'safe_yaml'
 require 'uri'
+require 'pathname'
+require 'find'
+require_relative 'project_validator.rb'
 
-def strip_or_self!(str)
-  str.strip! || str if str
-end
+def check_folder(root)
+  other_files = []
 
-def sanitize_yaml_string!(str, name)
-  sanatized = strip_or_self!(str)
-  sanatized = sanatized.sub(name + ': ', '')
-                       .sub(name + ' : ', '')
+  Find.find("#{root}/_data/projects") do |path|
+    next unless FileTest.file?(path)
 
-  has_double_quotes = sanatized.start_with?('\"') && sanatized.end_with?('\"')
-  has_single_quotes = sanatized.start_with?("'") && sanatized.end_with?("'")
-
-  if has_double_quotes || has_single_quotes
-    sanatized = sanatized.sub(/^\"/, '')
-                         .sub(/\"$/, '')
-                         .sub(/^'/, ')
-                         .sub(/\'$/, ')
+    other_files << path if File.extname(path) != '.yml'
   end
 
-  strip_or_self!(sanatized)
-end
+  count = other_files.count
 
-def check_folder
-  # i'm lazy
-  root = File.expand_path('..', __dir__)
+  return unless count.positive?
 
-  all_files = Dir["#{root}/_data/projects/*"]
-  yaml_files = Dir["#{root}/_data/projects/*.yml"]
+  puts "#{count} files found in projects directory which are not YAML files:"
+  r = Pathname.new(root)
 
-  # i'm lazy, there's gotta be an easier way to do this!
-  yaml_files.each { |f| all_files.delete f }
-  other_files = all_files.count
+  other_files.each do |f|
+    relative_path = Pathname.new(f).relative_path_from(r).to_s
+    puts " - #{relative_path}"
+  end
 
-  return unless other_files.positive?
-
-  puts "#{other_files} files in directory which are not YAML files:"
-  all_files.each { |f| puts " - #{f}" }
   exit(-1)
-end
-
-def valid_url?(url)
-  uri = URI.parse(url)
-  uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
-rescue URI::InvalidURIError
-  false
-end
-
-def verify_preferred_tag(tag)
-  # preference is a map of [bad tag]: [preferred tag]
-  preference = {
-    'algorithms' => 'algorithm',
-    'appletv' => 'apple-tv',
-    'asp-net' => 'asp.net',
-    'aspnet' => 'asp.net',
-    'aspnetmvc' => 'aspnet-mvc',
-    'aspnetcore' => 'aspnet-core',
-    'asp-net-core' => 'aspnet-core',
-    'assembler' => 'assembly',
-    'builds' => 'build',
-    'collaborate' => 'collaboration',
-    'coding' => 'code',
-    'colour' => 'color',
-    'commandline' => 'command-line',
-    'csharp' => 'c#',
-    'docs' => 'documentation',
-    'dotnet-core' => '.net core',
-    'encrypt' => 'encryption',
-    'fsharp' => 'f#',
-    'games' => 'game',
-    'gatsby' => 'gatsbyjs',
-    'golang' => 'go',
-    'js' => 'javascript',
-    'library' => 'libraries',
-    'linters' => 'linter',
-    'node' => 'node.js',
-    'nodejs' => 'node.js',
-    'nuget.exe' => 'nuget',
-    'parser' => 'parsing',
-    'react' => 'reactjs'
-  }
-  return "Use '#{preference[tag]}' instead of #{tag}\n" if preference[tag].present?
-
-  ''
-end
-
-def verify_tags(taglist)
-  result = ''
-  taglist.each do |tag|
-    result += "Tag '#{tag}' contains uppercase characters\n" if tag =~ /[A-Z]/
-    result += "Tag '#{tag}' contains spaces or '_' (should use '-' instead)\n" if tag =~ /[\s_]/
-    result += verify_preferred_tag(tag)
-  end
-  return "\nTag verification failed!\n" + result if result != ''
-
-  result
-end
-
-def verify_file(file)
-  begin
-    contents = File.read(file)
-
-    if contents.index('- .NET')
-      error = 'Please specify the .NET label in quotes'
-      return [file, error]
-    end
-
-    yaml = YAML.safe_load(contents)
-
-    if yaml['name'].nil?
-      error = "Required 'name' attribute is not defined"
-      return [file, error]
-    end
-
-    if yaml['site'].nil?
-      error = "Required 'site' attribute is not defined"
-      return [file, error]
-    end
-
-    unless valid_url?(yaml['site'])
-      error = "Required 'site' attribute to be a valid url"
-      return [file, error]
-    end
-
-    if yaml['desc'].nil?
-      error = "Required 'desc' attribute is not defined"
-      return [file, error]
-    end
-
-    tags = yaml['tags']
-    if tags.nil? || tags.empty?
-      error = 'No tags defined for file'
-      return [file, error]
-    end
-
-    tags_verification = verify_tags(tags)
-    return [f, tags_verification] unless tags_verification.empty?
-
-    dups = tags.group_by { |e| e }.keep_if { |_, e| e.length > 1 }
-
-    if dups.any?
-      error = "Duplicate tags found: #{dups.keys.join ', '}"
-      return [file, error]
-    end
-
-    if yaml['upforgrabs'].nil?
-      error = "Required 'upforgrabs' attribute is not defined"
-      return [file, error]
-    end
-
-    if yaml['upforgrabs']['name'].nil?
-      error = "Required 'upforgrabs.name' attribute is not defined"
-      return [file, error]
-    end
-
-    if yaml['upforgrabs']['link'].nil?
-      error = "Required 'upforgrabs.link' attribute is not defined"
-      return [file, error]
-    end
-
-    unless valid_url?(yaml['upforgrabs']['link'])
-      error = "Required 'upforgrabs.link' attribute to be a valid url"
-      return [file, error]
-    end
-  rescue Psych::SyntaxError => e
-    error = "Unable to parse the contents of file - Line: #{e.line}, Offset: #{e.offset}, Problem: #{e.problem}"
-    [file, error]
-  rescue StandardError
-    error = "Unknown exception for file: #{$ERROR_INFO}"
-    [file, error]
-  end
-
-  [file, nil]
 end
 
 root = File.expand_path('..', __dir__)
 
-check_folder
+check_folder(root)
 
-results = Dir["#{root}/_data/projects/*.yml"].map { |f| verify_file(f) }
+projects = Dir["#{root}/_data/projects/*.yml"].map do |f|
+  relative_path = Pathname.new(f).relative_path_from(root).to_s
+  Project.new(relative_path, f)
+end
 
-files_with_errors = results.reject { |_, error| error.nil? }
-success = results.select { |_, error| error.nil? }.count
+projects_with_errors = []
+projects_without_issues = []
 
-if files_with_errors.count.positive?
-  puts "#{success} files processed - #{files_with_errors.count} errors found:"
-  files_with_errors.each { |path, error| puts "#{path} - #{error}" }
+projects.each do |p|
+  validation_errors = p.validation_errors
+  if validation_errors.empty?
+    projects_without_issues << [p, nil]
+  else
+    projects_with_errors << [p, validation_errors]
+  end
+end
+
+if projects_with_errors.any?
+  puts "#{projects_with_errors.count} errors found processing projects:"
+  projects_with_errors.each do |project, errors|
+    puts " - #{project.relative_path}:"
+    errors.each { |error| puts "    - #{error}" }
+  end
   exit(-1)
 else
-  puts "#{success} files processed - no errors found!"
+  puts "#{projects_without_issues.count} files processed - no errors found!"
 end

--- a/scripts/project_validator.rb
+++ b/scripts/project_validator.rb
@@ -30,40 +30,7 @@ class Project
   end
 
   def verify_preferred_tag(tag)
-    # preference is a map of [bad tag]: [preferred tag]
-    preference = {
-      'algorithms' => 'algorithm',
-      'appletv' => 'apple-tv',
-      'asp-net' => 'asp.net',
-      'aspnet' => 'asp.net',
-      'aspnetmvc' => 'aspnet-mvc',
-      'aspnetcore' => 'aspnet-core',
-      'asp-net-core' => 'aspnet-core',
-      'assembler' => 'assembly',
-      'builds' => 'build',
-      'collaborate' => 'collaboration',
-      'coding' => 'code',
-      'colour' => 'color',
-      'commandline' => 'command-line',
-      'csharp' => 'c#',
-      'docs' => 'documentation',
-      'dotnet-core' => '.net core',
-      'encrypt' => 'encryption',
-      'fsharp' => 'f#',
-      'games' => 'game',
-      'gatsby' => 'gatsbyjs',
-      'golang' => 'go',
-      'js' => 'javascript',
-      'library' => 'libraries',
-      'linters' => 'linter',
-      'node' => 'node.js',
-      'nodejs' => 'node.js',
-      'nuget.exe' => 'nuget',
-      'parser' => 'parsing',
-      'react' => 'reactjs'
-    }
-
-    return "Use '#{preference[tag]}' instead of #{tag}\n" unless preference[tag].nil?
+    return "Use '#{PREFERENCES[tag]}' instead of #{tag}\n" unless PREFERENCES[tag].nil?
 
     ''
   end
@@ -90,6 +57,39 @@ class Project
   end
 
   private
+
+  # preference is a map of [bad tag]: [preferred tag]
+  PREFERENCES = {
+    'algorithms' => 'algorithm',
+    'appletv' => 'apple-tv',
+    'asp-net' => 'asp.net',
+    'aspnet' => 'asp.net',
+    'aspnetmvc' => 'aspnet-mvc',
+    'aspnetcore' => 'aspnet-core',
+    'asp-net-core' => 'aspnet-core',
+    'assembler' => 'assembly',
+    'builds' => 'build',
+    'collaborate' => 'collaboration',
+    'coding' => 'code',
+    'colour' => 'color',
+    'commandline' => 'command-line',
+    'csharp' => 'c#',
+    'docs' => 'documentation',
+    'dotnet-core' => '.net core',
+    'encrypt' => 'encryption',
+    'fsharp' => 'f#',
+    'games' => 'game',
+    'gatsby' => 'gatsbyjs',
+    'golang' => 'go',
+    'js' => 'javascript',
+    'library' => 'libraries',
+    'linters' => 'linter',
+    'node' => 'node.js',
+    'nodejs' => 'node.js',
+    'nuget.exe' => 'nuget',
+    'parser' => 'parsing',
+    'react' => 'reactjs'
+  }.freeze
 
   def validate_summary(yaml)
     errors = []

--- a/scripts/project_validator.rb
+++ b/scripts/project_validator.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+# Represents the checks performed on a project to ensure it can be parsed
+# and used as site data in Jekyll
+class Project
+  attr_accessor :full_path, :relative_path
+
+  def initialize(relative_path, full_path)
+    @relative_path = relative_path
+    @full_path = full_path
+  end
+
+  def self.valid_url?(url)
+    uri = URI.parse(url)
+    uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
+  rescue URI::InvalidURIError
+    false
+  end
+
+  def validate_tag_list(taglist)
+    result = ''
+    taglist.each do |tag|
+      result += "Tag '#{tag}' contains uppercase characters\n" if tag =~ /[A-Z]/
+      result += "Tag '#{tag}' contains spaces or '_' (should use '-' instead)\n" if tag =~ /[\s_]/
+      result += verify_preferred_tag(tag)
+    end
+    return "\nTag verification failed!\n" + result if result != ''
+
+    result
+  end
+
+  def verify_preferred_tag(tag)
+    # preference is a map of [bad tag]: [preferred tag]
+    preference = {
+      'algorithms' => 'algorithm',
+      'appletv' => 'apple-tv',
+      'asp-net' => 'asp.net',
+      'aspnet' => 'asp.net',
+      'aspnetmvc' => 'aspnet-mvc',
+      'aspnetcore' => 'aspnet-core',
+      'asp-net-core' => 'aspnet-core',
+      'assembler' => 'assembly',
+      'builds' => 'build',
+      'collaborate' => 'collaboration',
+      'coding' => 'code',
+      'colour' => 'color',
+      'commandline' => 'command-line',
+      'csharp' => 'c#',
+      'docs' => 'documentation',
+      'dotnet-core' => '.net core',
+      'encrypt' => 'encryption',
+      'fsharp' => 'f#',
+      'games' => 'game',
+      'gatsby' => 'gatsbyjs',
+      'golang' => 'go',
+      'js' => 'javascript',
+      'library' => 'libraries',
+      'linters' => 'linter',
+      'node' => 'node.js',
+      'nodejs' => 'node.js',
+      'nuget.exe' => 'nuget',
+      'parser' => 'parsing',
+      'react' => 'reactjs'
+    }
+
+    return "Use '#{preference[tag]}' instead of #{tag}\n" unless preference[tag].nil?
+
+    ''
+  end
+
+  def validation_errors
+    errors = []
+
+    begin
+      yaml = YAML.safe_load(File.read(@full_path))
+    rescue Psych::SyntaxError => e
+      errors << "Unable to parse the contents of file - Line: #{e.line}, Offset: #{e.offset}, Problem: #{e.problem}"
+    rescue StandardError
+      errors << "Unknown exception for file: #{$ERROR_INFO}"
+    end
+
+    # don't continue if there was a problem parsing
+    return errors if errors.any?
+
+    errors.concat(validate_summary(yaml))
+    errors.concat(validate_tags(yaml))
+    errors.concat(validate_upforgrabs(yaml))
+
+    errors
+  end
+
+  private
+
+  def validate_summary(yaml)
+    errors = []
+
+    errors << "Required 'name' attribute is not defined" if yaml['name'].nil?
+
+    errors << "Required 'site' attribute is not defined" if yaml['site'].nil?
+
+    errors << "Required 'site' attribute to be a valid url" unless Project.valid_url?(yaml['site'])
+
+    errors << "Required 'desc' attribute is not defined" if yaml['desc'].nil?
+
+    errors
+  end
+
+  def validate_tags(yaml)
+    errors = []
+
+    tags = yaml['tags']
+
+    errors << 'No tags defined for file' if tags.nil? || tags.empty?
+
+    tags_validation_errors = validate_tag_list(tags)
+    errors.concat(tags_validation_errors) unless tags_validation_errors.empty?
+
+    dups = tags.group_by { |t| t }.keep_if { |_, t| t.length > 1 }
+
+    errors << "Duplicate tags found: #{dups.keys.join ', '}" if dups.any?
+
+    errors
+  end
+
+  def validate_upforgrabs(yaml)
+    errors = []
+
+    # validating the current schema
+    errors << "Required 'upforgrabs' attribute is not defined" if yaml['upforgrabs'].nil?
+
+    # bail out early if not found
+    return errors if yaml['upforgrabs'].nil?
+
+    errors << "Required 'upforgrabs.name' attribute is not defined" if yaml['upforgrabs']['name'].nil?
+
+    errors << "Required 'upforgrabs.link' attribute is not defined" if yaml['upforgrabs']['link'].nil?
+
+    errors << "Required 'upforgrabs.link' attribute to be a valid url" unless Project.valid_url?(yaml['upforgrabs']['link'])
+
+    errors
+  end
+end


### PR DESCRIPTION
This PR introduces a `Project` abstraction to encapsulate everything needed to validate the file (including our new tags validation).

It currently lives alongside `scripts/cibuild.rb` but I'd like to get it to the point where I'm sharing more code between the CI scripts and the Actions work.

 - [x] Updated actions work as expected
 - [x] CI passes
