### PR TITLE
update a renamed GitHub repository

### DIFF
--- a/_data/projects/kentico-kontentdeliverysdkjava.yml
+++ b/_data/projects/kentico-kontentdeliverysdkjava.yml
@@ -1,7 +1,7 @@
 ---
 name: delivery-sdk-java
-desc: Kentico Cloud Delivery Java SDK.
-site: https://github.com/Kentico/delivery-sdk-java
+desc: Kentico Kontent Delivery Java SDK.
+site: https://github.com/Kentico/kontent-delivery-sdk-java
 tags:
 - java
 - kentico
@@ -12,7 +12,7 @@ tags:
 - caas
 upforgrabs:
   name: up-for-grabs
-  link: https://github.com/Kentico/delivery-sdk-java/labels/up-for-grabs
+  link: https://github.com/Kentico/kontent-delivery-sdk-java/labels/up-for-grabs
 stats:
   issue-count: 5
   last-updated: '2019-10-04T21:22:42Z'


### PR DESCRIPTION
The most recent run of [`Cleanup archived projects`](https://github.com/up-for-grabs/up-for-grabs.net/commit/ffecafb265765f6f652874237300904dd7e65da9/checks?check_suite_id=253603532) found this repository has been renamed:

```
Encountered error while trying to validate '_data/projects/kentico-deliverysdkjava.yml' - Repository Kentico/delivery-sdk-java now lives at Kentico/kontent-delivery-sdk-java and should be updated
```

This PR tidies it up and adjusts the name