### PR TITLE
fix logo anchor redirecting to / instead of /#/

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,7 @@
 <header>
     <a id="forkme_banner" href="https://github.com/up-for-grabs/up-for-grabs.net">View on GitHub</a>
     <div class="container">
-        <a id="go-back-home" href="/"><img src="{{ site.github.url }}/images/logo.png" alt="Up For Grabs"></a>
+        <a id="go-back-home" href="/#/"><img src="{{ site.github.url }}/images/logo.png" alt="Up For Grabs"></a>
         <h1 class="ribbon">
             <strong class="ribbon-content">Explore open source projects and <a href="https://nikcodes.com/2013/05/10/new-contributor-jump-in">jump in!</a></strong>
         </h1>


### PR DESCRIPTION
Clicking on the logo anchor and then on any in-site link (can't find better term for this) sends you to the github pages 404 page.

How to reproduce this:
- Go to https://up-for-grabs.net/#/
- Click on the logo on the top left
- Click on any in-site link (for example the `javascript` tag)
- You now land on 404 page, for example https://up-for-grabs.net/filters?tags=javascript

<details>
<summary>Small example as gif</summary>

![V4kLHX4qNO](https://user-images.githubusercontent.com/24881032/66344934-3efd8100-e94f-11e9-9b61-1f83f82ce48f.gif)

</details>

With this PR that behavior no longer occurs and clicking on tags etc. still works.