### PR TITLE
make eslint and prettier play nicer

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,7 @@
 {
-  "extends": "airbnb-base",
+  "extends": [ "airbnb-base", "prettier" ],
   "rules": {
     "space-before-function-paren": "off",
-    "comma-dangle": ["error", "only-multiline"],
-    "quotes": ["error", "single"],
     "no-undef": "off",
     "vars-on-top": "off",
     "no-var": "off",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1410,6 +1410,15 @@
         "object.entries": "^1.1.0"
       }
     },
+    "eslint-config-prettier": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.4.0.tgz",
+      "integrity": "sha512-YrKucoFdc7SEko5Sxe4r6ixqXPDP1tunGw91POeZTTRKItf/AMFYt/YLEQtZMkR2LVpAVhcAcZgcWpm1oGPW7w==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^6.0.0"
+      }
+    },
     "eslint-import-resolver-node": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
@@ -2578,6 +2587,12 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
       "dev": true
     },
     "get-stream": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "license": "MIT",
   "scripts": {
     "check": "tsc",
+    "eslint-check": "eslint --print-config javascripts/main.js | eslint-config-prettier-check",
     "lint": "eslint javascripts/*.js tests/**/*.js",
     "lint-fix": "eslint --fix javascripts/*.js tests/**/*.js",
     "prettier": "prettier --check javascripts/*.js tests/**/*.js docs/**/*.md",
@@ -22,6 +23,7 @@
     "eslint": "^6.5.1",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-plugin-import": "^2.18.2",
+    "eslint-config-prettier": "6.4.0",
     "jest": "^24.9.0",
     "jest-fetch-mock": "^2.1.2",
     "jest-localstorage-mock": "^2.4.0",


### PR DESCRIPTION
As part of figuring out how to smooth the integration between prettier and eslint, while upgrading the JS to more modern features, the first thing I should have handy is [`eslint-config-prettier`](https://github.com/prettier/eslint-config-prettier).

The caveats and gotchas for this are outlined [here](https://github.com/prettier/eslint-config-prettier#special-rules), but with the next few PRs that build on top of this I want to:

 - pay down the custom rules in each file, so that things are consistent across all JS files
 - pay down the custom rules defined in our root `.eslintrc.json`

I'll try and carve off work for others to help out with, but the first few PRs like #1523 and #1520 have shown me that it's not as smooth as I'd hoped it to be.