### PR TITLE
cleanup tests and drop old rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,6 @@
     "no-var": "off",
     "prefer-template": "off",
     "func-names": "off",
-    "prefer-arrow-callback": "off",
     "one-var": "off",
     "operator-linebreak": "off",
     "eqeqeq": "off",

--- a/javascripts/fetchIssueCount.js
+++ b/javascripts/fetchIssueCount.js
@@ -1,6 +1,6 @@
 /* eslint global-require: "off" */
 /* eslint block-scoped-var: "off" */
-/* eslint prefer-arrow-callback: [ "error" ] */
+
 /* eslint arrow-parens: [ "error", "as-needed" ] */
 /* eslint function-paren-newline: [ "off" ] */
 /* eslint implicit-arrow-linebreak: [ "off" ] */

--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -1,5 +1,5 @@
 // @ts-nocheck
-/* eslint prefer-arrow-callback: [ "error" ] */
+
 /* eslint arrow-parens: [ "error", "as-needed" ] */
 
 define([

--- a/javascripts/projectLoader.js
+++ b/javascripts/projectLoader.js
@@ -1,4 +1,3 @@
-/* eslint prefer-arrow-callback: [ "error" ] */
 /* eslint arrow-parens: [ "error", "as-needed" ] */
 /* eslint global-require: "off" */
 /* eslint block-scoped-var: "off" */

--- a/javascripts/projectsService.js
+++ b/javascripts/projectsService.js
@@ -1,6 +1,6 @@
 /* eslint global-require: "off" */
 /* eslint block-scoped-var: "off" */
-/* eslint prefer-arrow-callback: [ "error" ] */
+
 /* eslint arrow-parens: [ "error", "as-needed" ] */
 /* eslint function-paren-newline: [ "off" ] */
 /* eslint implicit-arrow-linebreak: [ "off" ] */

--- a/tests/spec/FetchIssueCountSpec.js
+++ b/tests/spec/FetchIssueCountSpec.js
@@ -25,19 +25,19 @@ function stubFetchResult(items, etag) {
   });
 }
 
-describe('fetchIssueCount', function() {
-  beforeEach(function() {
+describe('fetchIssueCount', () => {
+  beforeEach(() => {
     fetch.resetMocks();
     localStorage.clear();
   });
 
-  it('fetches the issue label URL of a GitHub project', function() {
+  it('fetches the issue label URL of a GitHub project', () => {
     const oneItem = [{}];
     stubFetchResult(oneItem);
     expect(fetchIssueCount('owner/repo', 'label')).resolves.toEqual(1);
   });
 
-  it('uses the last Link header value and infers the issue count', function() {
+  it('uses the last Link header value and infers the issue count', () => {
     const oneItem = [{}];
     fetch.mockResponseOnce(JSON.stringify(oneItem), {
       status: 200,
@@ -59,8 +59,8 @@ describe('fetchIssueCount', function() {
     );
   });
 
-  describe('local storage', function() {
-    it('can retrieve issue count from local storage for the project', function() {
+  describe('local storage', () => {
+    it('can retrieve issue count from local storage for the project', () => {
       const project = 'owner/project';
 
       const fourItems = [{}, {}, {}, {}];
@@ -68,7 +68,7 @@ describe('fetchIssueCount', function() {
 
       const promise = fetchIssueCount(project, 'label');
 
-      const cachedCount = promise.then(function() {
+      const cachedCount = promise.then(() => {
         const cached = localStorage.getItem(project);
         const obj = JSON.parse(cached);
         return obj.count;
@@ -77,7 +77,7 @@ describe('fetchIssueCount', function() {
       expect(cachedCount).resolves.toEqual(4);
     });
 
-    it('can retrieve ETag from local storage for the project', function() {
+    it('can retrieve ETag from local storage for the project', () => {
       const expectedEtag = 'bcd049ba79152d03380c34652f2cb612';
       stubFetchResult([], expectedEtag);
 
@@ -85,7 +85,7 @@ describe('fetchIssueCount', function() {
 
       const promise = fetchIssueCount(project, 'label');
 
-      const cachedEtag = promise.then(function() {
+      const cachedEtag = promise.then(() => {
         const cached = localStorage.getItem(project);
         const obj = JSON.parse(cached);
         return obj.etag;
@@ -94,13 +94,13 @@ describe('fetchIssueCount', function() {
       expect(cachedEtag).resolves.toEqual(expectedEtag);
     });
 
-    it('can read a timestamp from local storage for the project', function() {
+    it('can read a timestamp from local storage for the project', () => {
       stubFetchResult([]);
       const project = 'owner/project';
 
       const promise = fetchIssueCount(project, 'label');
 
-      const cachedDate = promise.then(function() {
+      const cachedDate = promise.then(() => {
         const cached = localStorage.getItem(project);
         const obj = JSON.parse(cached);
         return obj.date;
@@ -112,8 +112,8 @@ describe('fetchIssueCount', function() {
     });
   });
 
-  describe('caching', function() {
-    it('does not make API call if cache is valid', function() {
+  describe('caching', () => {
+    it('does not make API call if cache is valid', () => {
       const project = 'owner/project';
 
       const sixHoursAgo = new Date() - 1000 * 60 * 60 * 6;
@@ -132,7 +132,7 @@ describe('fetchIssueCount', function() {
       expect(fetch.mock.calls).toHaveLength(0);
     });
 
-    it('makes API call with etag if cache is considered expired', function() {
+    it('makes API call with etag if cache is considered expired', () => {
       const project = 'owner/project';
       const expectedEtag = 'def049ba79152d03380c34652f2cb612';
 
@@ -160,7 +160,7 @@ describe('fetchIssueCount', function() {
       );
     });
 
-    it('handles 304 Not Modified and returns cached value', function() {
+    it('handles 304 Not Modified and returns cached value', () => {
       const project = 'owner/project';
       const expectedEtag = 'b00049ba79152d03380c34652f2cb612';
 
@@ -189,7 +189,7 @@ describe('fetchIssueCount', function() {
       expect(promise).resolves.toBe(3);
     });
 
-    it('if 304 Not Modified is returned but nothing cached, returns zero', function() {
+    it('if 304 Not Modified is returned but nothing cached, returns zero', () => {
       const project = 'owner/project';
 
       // ignore the JSON in the API response if a 304 is found
@@ -206,7 +206,7 @@ describe('fetchIssueCount', function() {
       expect(promise).resolves.toBe(0);
     });
 
-    it('updates cache if a 200 is received', function() {
+    it('updates cache if a 200 is received', () => {
       const project = 'owner/project';
       const twoDaysAgo = new Date() - 2 * (1000 * 60 * 60 * 24);
 
@@ -223,7 +223,7 @@ describe('fetchIssueCount', function() {
 
       const promise = fetchIssueCount(project, 'label');
 
-      const cachedEtag = promise.then(function() {
+      const cachedEtag = promise.then(() => {
         const cached = localStorage.getItem(project);
         const obj = JSON.parse(cached);
         return obj.etag;
@@ -234,8 +234,8 @@ describe('fetchIssueCount', function() {
     });
   });
 
-  describe('error handling', function() {
-    it('handles rate-limiting response and returns an error', function() {
+  describe('error handling', () => {
+    it('handles rate-limiting response and returns an error', () => {
       const lastSundayInSeconds = 1561912503;
       const lastSunday = new Date(1000 * lastSundayInSeconds);
 
@@ -250,7 +250,7 @@ describe('fetchIssueCount', function() {
       );
     });
 
-    it('no further API calls made after rate-limiting', function(done) {
+    it('no further API calls made after rate-limiting', done => {
       const anHourFromNowInTicks = Date.now() + 1000 * 60 * 60;
       const anHourFromNow = new Date(anHourFromNowInTicks);
       const anHourFromNowInSeconds = Math.floor(anHourFromNow.getTime() / 1000);
@@ -269,7 +269,7 @@ describe('fetchIssueCount', function() {
         });
     });
 
-    it('rate-limit reset time is cleared eventually', function(done) {
+    it('rate-limit reset time is cleared eventually', done => {
       const RateLimitResetAtKey = 'Rate-Limit-Reset-At';
 
       const twoHoursAgoInTicks = Date.now() - 2 * 1000 * 60 * 60;
@@ -298,7 +298,7 @@ describe('fetchIssueCount', function() {
         });
     });
 
-    it('handles API error', function() {
+    it('handles API error', () => {
       const message = 'The repository could not be found on the server';
 
       fetch.mockResponseOnce(
@@ -321,7 +321,7 @@ describe('fetchIssueCount', function() {
       );
     });
 
-    it('handles generic error', function() {
+    it('handles generic error', () => {
       fetch.mockResponseOnce(JSON.stringify({}), {
         status: 404,
         headers: [['Content-Type', 'application/json']],

--- a/tests/spec/FetchIssueCountSpec.js
+++ b/tests/spec/FetchIssueCountSpec.js
@@ -1,3 +1,5 @@
+/* eslint prefer-arrow-callback: [ "error" ] */
+
 const fetchIssueCount = require('../../javascripts/fetchIssueCount');
 
 const defaultEtag = 'a00049ba79152d03380c34652f2cb612';

--- a/tests/spec/FetchIssueCountSpec.js
+++ b/tests/spec/FetchIssueCountSpec.js
@@ -1,5 +1,3 @@
-/* eslint prefer-arrow-callback: [ "error" ] */
-
 const fetchIssueCount = require('../../javascripts/fetchIssueCount');
 
 const defaultEtag = 'a00049ba79152d03380c34652f2cb612';

--- a/tests/spec/ProjectsServiceSpec.js
+++ b/tests/spec/ProjectsServiceSpec.js
@@ -1,5 +1,3 @@
-/* eslint prefer-arrow-callback: [ "error" ] */
-
 const sampleProjects = require('../src/sampleProjects');
 const ProjectsService = require('../../javascripts/projectsService');
 

--- a/tests/spec/ProjectsServiceSpec.js
+++ b/tests/spec/ProjectsServiceSpec.js
@@ -3,21 +3,21 @@
 const sampleProjects = require('../src/sampleProjects');
 const ProjectsService = require('../../javascripts/projectsService');
 
-describe('ProjectsService', function() {
-  describe('simple project list', function() {
+describe('ProjectsService', () => {
+  describe('simple project list', () => {
     let projectsService;
 
-    beforeEach(function() {
+    beforeEach(() => {
       projectsService = new ProjectsService(sampleProjects);
     });
 
-    describe('get', function() {
-      it('returns expected project count', function() {
+    describe('get', () => {
+      it('returns expected project count', () => {
         expect(projectsService.get()).toHaveLength(2);
       });
 
-      describe('filtering', function() {
-        it('??? happens when number provided as a name', function() {
+      describe('filtering', () => {
+        it('??? happens when number provided as a name', () => {
           const tags = null;
           const names = ['1'];
           const project = projectsService.get(tags, names);
@@ -27,41 +27,41 @@ describe('ProjectsService', function() {
           expect(project[1]).toBe(undefined);
         });
 
-        it('all projects returned when given falsy values', function() {
+        it('all projects returned when given falsy values', () => {
           const projects = projectsService.get(null, true, undefined);
 
           expect(projects).toHaveLength(2);
 
-          const projectNames = projects.map(function(p) {
+          const projectNames = projects.map(p => {
             return p.name;
           });
           expect(projectNames).toContain('Glimpse');
           expect(projectNames).toContain('LibGit2Sharp');
         });
 
-        it('returns single project when providing array of tags', function() {
+        it('returns single project when providing array of tags', () => {
           const projects = projectsService.get(['web']);
           expect(projects).toHaveLength(1);
         });
 
-        it('array of tags searched using case-insensitve comparison', function() {
+        it('array of tags searched using case-insensitve comparison', () => {
           const projects = projectsService.get(['WEB']);
           expect(projects).toHaveLength(1);
         });
 
-        it('array of non-matching tags returns no projects', function() {
+        it('array of non-matching tags returns no projects', () => {
           const projects = projectsService.get(['oops']);
           expect(projects).toHaveLength(0);
         });
       });
     });
 
-    describe('getTags', function() {
-      it('returns collection of parsed tags', function() {
+    describe('getTags', () => {
+      it('returns collection of parsed tags', () => {
         expect(projectsService.getTags()).toHaveLength(15);
       });
 
-      it('includes projects assigned each tag', function() {
+      it('includes projects assigned each tag', () => {
         const tags = projectsService.getTags();
         expect(tags).toContainEqual({
           name: 'API',
@@ -81,12 +81,12 @@ describe('ProjectsService', function() {
       });
     });
 
-    describe('getPopularTags', function() {
-      it('returns 10 tags by default', function() {
+    describe('getPopularTags', () => {
+      it('returns 10 tags by default', () => {
         expect(projectsService.getPopularTags()).toHaveLength(10);
       });
 
-      it('returns requested number if specified', function() {
+      it('returns requested number if specified', () => {
         const tags = projectsService.getPopularTags(1);
         expect(tags).toContainEqual({
           name: 'C#',
@@ -95,17 +95,17 @@ describe('ProjectsService', function() {
         });
       });
 
-      it('returns expected top tag', function() {
+      it('returns expected top tag', () => {
         expect(projectsService.getPopularTags(1)).toHaveLength(1);
       });
 
-      it('cannot return more than the total tags available', function() {
+      it('cannot return more than the total tags available', () => {
         const tags = projectsService.getTags();
         expect(projectsService.getPopularTags(99)).toHaveLength(tags.length);
       });
     });
 
-    it.skip('should return shuffled projects list', function() {
+    it.skip('should return shuffled projects list', () => {
       const firstProject = sampleProjects[0];
 
       const projects = projectsService.get();
@@ -115,52 +115,52 @@ describe('ProjectsService', function() {
       expect(projects[0].name).not.toEqual(firstProject.name);
     });
 
-    describe('when get method is called with tags parameter as a string', function() {
-      it('should return all projects associated with those tags', function() {
+    describe('when get method is called with tags parameter as a string', () => {
+      it('should return all projects associated with those tags', () => {
         const projects = projectsService.get('web');
         expect(projects.length).toBe(1);
       });
 
-      it('should match the tags after trimming leading and trailing spaces', function() {
+      it('should match the tags after trimming leading and trailing spaces', () => {
         const projects = projectsService.get(' web ');
         expect(projects.length).toBe(1);
       });
     });
 
-    describe('when get method is called with tags array containing both matching and non matching tags', function() {
-      it('should return projects for the matching tags and ignore non matching tag', function() {
+    describe('when get method is called with tags array containing both matching and non matching tags', () => {
+      it('should return projects for the matching tags and ignore non matching tag', () => {
         const projects = projectsService.get(['c#', 'Oops']);
         expect(projects.length).toBe(2);
       });
     });
 
-    describe('Expect multiple filters to work tremendously good', function() {
-      it('If it does not take any filters then it should return projects', function() {
+    describe('Expect multiple filters to work tremendously good', () => {
+      it('If it does not take any filters then it should return projects', () => {
         const projects = projectsService.get(undefined, undefined, undefined);
         expect(projects.length).toBe(2);
       });
 
-      it('Should take a name filter and tag filter with no issues', function() {
+      it('Should take a name filter and tag filter with no issues', () => {
         const projects = projectsService.get(['c#'], ['0'], undefined);
         expect(projects.length).toBe(1);
       });
 
-      it('Should take a name filter and wrong tag filter and expect nothing', function() {
+      it('Should take a name filter and wrong tag filter and expect nothing', () => {
         const projects = projectsService.get(['web'], ['1'], undefined);
         expect(projects.length).toBe(0);
       });
 
-      it('Should take a name filter and label filter with no issues', function() {
+      it('Should take a name filter and label filter with no issues', () => {
         const projects = projectsService.get(undefined, ['1'], ['1']);
         expect(projects.length).toBe(1);
       });
 
-      it('Should take a tag filter and label filter with no issues', function() {
+      it('Should take a tag filter and label filter with no issues', () => {
         const projects = projectsService.get(['c#'], undefined, ['1']);
         expect(projects.length).toBe(1);
       });
 
-      it('Should take all three filters and return a project', function() {
+      it('Should take all three filters and return a project', () => {
         const projects = projectsService.get(['c#'], ['1'], ['1']);
         expect(projects.length).toBe(1);
       });

--- a/tests/spec/ProjectsServiceSpec.js
+++ b/tests/spec/ProjectsServiceSpec.js
@@ -1,3 +1,5 @@
+/* eslint prefer-arrow-callback: [ "error" ] */
+
 const sampleProjects = require('../src/sampleProjects');
 const ProjectsService = require('../../javascripts/projectsService');
 


### PR DESCRIPTION
Following on from #1520 and #1519 I went and checked the last couple of files that didn't fit satisfy the pattern: `tests/spec/FetchIssueCountSpec.js` and `tests/spec/ProjectsServiceSpec.js`.

With those up to date, it became easier to enable the rule globally (we were opting out of the default behaviour) and then cleanup all the places where we were opt-ing into this rule.