### PR TITLE
introduce some new and updated docs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Up for Grabs
 
-This guide will help you get setup so you can make changes to the project, view
+This guide will help you get set up so you can make changes to the project, view
 them locally and verify that the site will deploy correctly when opening a pull
 request.
 
@@ -55,7 +55,7 @@ view using a local development server:
 bundle exec jekyll serve
 ```
 
-Te site should be accessible in your browser at `localhost:4000`.
+The site should be accessible in your browser at `localhost:4000`.
 
 ### Testing with Docker
 
@@ -116,7 +116,7 @@ $ npm run lint
 $ npm run prettier
 ```
 
-Both of these tools have "auto-fix" options, which nay fix the problems reported
+Both of these tools have "auto-fix" options, which may fix the problems reported
 without needing manual work:
 
 ```

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,7 +1,8 @@
 # Contributing to Up for Grabs
 
-This guide will help you get setup and outline ways you can get involved with
-the project.
+This guide will help you get setup so you can make changes to the project, view
+them locally and verify that the site will deploy correctly when opening a pull
+request.
 
 ## Project Setup
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -34,9 +34,9 @@ v10.16.3
 There are two recommended ways to test the site locally, based on what OS you
 are currently using:
 
- - for macOS or Linux contributors - either approach is fine
- - for Windows contributors - Docker is recommended because Ruby on Windows has
-   some issues that need experience to properly workaround
+- for macOS or Linux contributors - either approach is fine
+- for Windows contributors - Docker is recommended because Ruby on Windows has
+  some issues that need experience to properly workaround
 
 ### Testing without Docker
 
@@ -62,9 +62,9 @@ Te site should be accessible in your browser at `localhost:4000`.
 contributors who don't want to install the tooling locally. Check the setup
 instructions for your OS for more information:
 
- - [Docker for Windows](https://docs.docker.com/docker-for-windows/install/)
- - [Docker for macOS](https://docs.docker.com/docker-for-mac/install/)
- - [Other platforms, including Linux distros](https://docs.docker.com/v17.12/install/)
+- [Docker for Windows](https://docs.docker.com/docker-for-windows/install/)
+- [Docker for macOS](https://docs.docker.com/docker-for-mac/install/)
+- [Other platforms, including Linux distros](https://docs.docker.com/v17.12/install/)
 
 Once you have that installed, use the `docker-compose` command to build and
 view the site:

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,123 @@
+# Contributing to Up for Grabs
+
+This guide will help you get setup and outline ways you can get involved with
+the project.
+
+## Project Setup
+
+This repository contains the GitHub Pages content and some additional Ruby and
+NodeJS tooling to help verify changes as part of publishing the site.
+
+To get a local clone of the repository:
+
+```
+git clone https://github.com/up-for-grabs/up-for-grabs.net.git
+```
+
+If you have a fork of the repository on GitHub, replace the first `up-for-grabs`
+with your GitHub account.
+
+We require Ruby 2.6, Bundler 2 and Node 10+ to test the site. You can check
+these are present by running these commands in a terminal:
+
+```
+$ ruby -v
+ruby 2.6.4p104 (2019-08-28 revision 67798) [x86_64-darwin18]
+$ bundle -v
+Bundler version 2.0.2
+$ node -v
+v10.16.3
+```
+
+## Testing the site
+
+There are two recommended ways to test the site locally, based on what OS you
+are currently using:
+
+ - for macOS or Linux contributors - either approach is fine
+ - for Windows contributors - Docker is recommended because Ruby on Windows has
+   some issues that need experience to properly workaround
+
+### Testing without Docker
+
+Within your local clone of the up-for-grabs repository, run these commands to
+install the dependencies needed:
+
+```
+bundle install
+```
+
+Once you've done that, this command will build the site and make it available to
+view using a local development server:
+
+```
+bundle exec jekyll serve
+```
+
+Te site should be accessible in your browser at `localhost:4000`.
+
+### Testing with Docker
+
+[Docker](https://docker.com) can also be used to build and test the site, for
+contributors who don't want to install the tooling locally. Check the setup
+instructions for your OS for more information:
+
+ - [Docker for Windows](https://docs.docker.com/docker-for-windows/install/)
+ - [Docker for macOS](https://docs.docker.com/docker-for-mac/install/)
+ - [Other platforms, including Linux distros](https://docs.docker.com/v17.12/install/)
+
+Once you have that installed, use the `docker-compose` command to build and
+view the site:
+
+```
+docker-compose up
+```
+
+If that completes without error, open your browser to `localhost:4000` to view
+the site.
+
+## Automated testing
+
+We have a suite of additional tooling that can be run to verify the contents of
+the repository. These are run as part of any pull request or build on GitHub,
+so it is recommended to run these locally before pushing changes.
+
+### Validate Project Listings
+
+This script scans all the projects under `_data/projects` to verify they can be
+parsed correctly, and have the expected fields.
+
+```
+$ ruby scripts/cibuild.rb
+```
+
+If you run this and it reports an error, check the file and fix the error before
+continuing.
+
+### Validate JavaScript Content
+
+We use `jest` to test the JavaScript modules in the project:
+
+```
+$ npm test
+```
+
+If this command reports errors, it is likely that the site functionality has
+been impacted by a change. Please investigate and address the issue before
+proceeding.
+
+We also use `eslint` and `prettier` in this project to lint and apply consistent
+formatting to the JavaScript modules in the project:
+
+```
+$ npm run lint
+$ npm run prettier
+```
+
+Both of these tools have "auto-fix" options, which nay fix the problems reported
+without needing manual work:
+
+```
+$ npm run lint-fix
+$ npm run prettier-fix
+```

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -37,7 +37,7 @@ are currently using:
 
 - for macOS or Linux contributors - either approach is fine
 - for Windows contributors - Docker is recommended because Ruby on Windows has
-  some issues that need experience to properly workaround
+  some issues that need familiarity with the toolchain to properly workaround
 
 ### Testing without Docker
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -81,12 +81,13 @@ the site.
 
 We have a suite of additional tooling that can be run to verify the contents of
 the repository. These are run as part of any pull request or build on GitHub,
-so it is recommended to run these locally before pushing changes.
+and it is recommended to run these locally before pushing changes to save time
+with reviews.
 
 ### Validate Project Listings
 
-This script scans all the projects under `_data/projects` to verify they can be
-parsed correctly, and have the expected fields.
+This script scans all the data files under `_data/projects` to verify they can be
+parsed correctly, and have the expected schema defined.
 
 ```
 $ ruby scripts/cibuild.rb

--- a/README.md
+++ b/README.md
@@ -56,31 +56,10 @@ file is worth reading, as it contains:
  - guidance for testing locally
  - commands to run to verify changes
 
-## How This All Works
-We use a few great features of Jekyll and GitHub Pages to host this entire site for free.
+## How does the site work?
 
-* We are using a file called `scripts.html` which is an include file. When we publish the site, Jekyll uses this to concatenate and generate the scripts that will actually be downloaded when a user visits the site.
-* Within the `scripts.html` template, we're referencing `site.data.projects`, which gives us access to the entire directory of `.yml` files as a set of variables. We combine this with the `jsonify` liquid transformer to turn them into a JSON object. This means that the raw data is generated once, so it downloads very quickly as static data.
-* When the web page is opened, our startup JS processes each project in the array of projects and pushes it into the array that the rest of the site uses.
-* We use [travis-ci](https://travis-ci.org/up-for-grabs/up-for-grabs.net) to run a custom ruby script, `cibuild`, that checks all the `.yml` files to make sure they can be appropriately parsed. This makes sure we don't merge any incorrectly formed project files.
-
-What this means is that, when a pull request is merged, GitHub Pages automatically builds the site via Jekyll and publishes it to our GitHub -- no database or hosting needed. (Thanks, GitHub!)
-
-## Automation and Curation
-
-Because of the immense number of projects currently tracked in Up-for-Grabs,
-we've spent time adding tasks to run periodically so we can focus on curation
-and site improvements.
-
-Recent examples :
-
- - Cleanup stale projects - each week a task runs to review the list of projects
-   and remove any that have been marked as archived or are no longer accessible
-   via the GitHub API.
- - Update project stats - every day a task runs to check each project and commit
-   statistics to the data files. This allows us to cache statistics each time
-   the site is published and makes it easier for visitors to see which projects
-   have available issues.
+If you want to learn more about the various parts of the Up-for-Grabs project,
+the [How it works](docs/how-it-works.md) document is a good overview.
 
 ## Contributors ✨
 

--- a/README.md
+++ b/README.md
@@ -47,39 +47,14 @@ npm install -g generator-up-for-grabs
 yo up-for-grabs
 ```
 
-## Testing the Site Locally
+## Contributing
 
-If you haven't already, clone the repository to your machine:
+If you would like to get involved with the project, the [CONTRIBUTING.md](.github/CONTRIBUTING.md)
+file is worth reading, as it contains:
 
-```
-git clone https://github.com/up-for-grabs/up-for-grabs.net.git
-```
-
-If you have a fork of the repository, change `up-for-grabs` into your GitHub account named above.
-
-We recommend installing Ruby 2.6.x and Bundler 2.0.x to test the site - you can confirm these are present by running these commands:
-
-```
-$ ruby -v
-ruby 2.6.4p104 (2019-08-28 revision 67798) [x86_64-darwin18]
-$ bundle -v
-Bundler version 2.0.2
-```
-
-If you're happy with that, run these commands in the directory where you cloned the up-for-grabs repository:
-
-```
-bundle install
-bundle exec jekyll serve
-```
-
-Alternatively, the application can be run in a [Docker](https://docker.com) container:
-
-```
-docker-compose up
-```
-
-Then open your browser to `localhost:4000` to view the site.
+ - instructions about getting your environment setup
+ - guidance for testing locally
+ - commands to run to verify changes
 
 ## How This All Works
 We use a few great features of Jekyll and GitHub Pages to host this entire site for free.

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ yo up-for-grabs
 
 ## Contributing
 
-If you would like to get involved with the project, the [CONTRIBUTING.md](.github/CONTRIBUTING.md)
-file is worth reading, as it contains:
+If you would like to get involved with the project, please read the
+[CONTRIBUTING.md](.github/CONTRIBUTING.md) file as it contains:
 
  - instructions about getting your environment setup
  - guidance for testing locally

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -8,16 +8,16 @@ the key parts of the Up-for-Grabs site and project.
 The main site is a Jekyll repository hosted on GitHub Pages, but it leverages
 some neat features of Jekyll along the way.
 
-* We use [Data files](https://jekyllrb.com/docs/datafiles/) to represent the
+- We use [Data files](https://jekyllrb.com/docs/datafiles/) to represent the
   projects listed on the site - one file per project
-* We convert this file to JSON inside [`javascripts/projects.json`](../javascripts/projects.json)
+- We convert this file to JSON inside [`javascripts/projects.json`](../javascripts/projects.json)
   when the site is built and published
-* The [`projectLoader`](../javascripts/projectLoader.js) module runs when the
+- The [`projectLoader`](../javascripts/projectLoader.js) module runs when the
   page is loaded, retrieving these projects and making them available for the
   site
-* The [`projectsService`](../javascripts/projectsService.js) module handles
+- The [`projectsService`](../javascripts/projectsService.js) module handles
   the rest of the work to sort and search the projects
-* The [`main`](../javascripts/main.js) module handles the rest of the work to
+- The [`main`](../javascripts/main.js) module handles the rest of the work to
   render the list of projects and provide the UI for filtering based on label
   or tags
 
@@ -27,16 +27,16 @@ We've settled on some infrastructure choices that mean we don't need to worry
 about managing our own servers, and can save time on the manual work that comes
 with a project of this size:
 
-* GitHub Actions run on each build and pull request to validate the project is
+- GitHub Actions run on each build and pull request to validate the project is
   in a state where it can be deployed
-* Netlify hooks run on each pull request to test the deploy and provide a
+- Netlify hooks run on each pull request to test the deploy and provide a
   preview so that reviewers do not need to pull down and verify the changes
   locally
-* When a commit is pushed to the `gh-pages` branch, a deploy is started to
+- When a commit is pushed to the `gh-pages` branch, a deploy is started to
   publishes the latest code to GitHub Pages, which hosts our site
-* A GitHub Action runs weekly to scan the project list and cleanup any that have
+- A GitHub Action runs weekly to scan the project list and cleanup any that have
   stale projects, by checking they are still accessible via the GitHub API. This
   saves us time having to manually review projects for inactivity.
-* A GitHub action runs daily to check each project and commit statistics to the
+- A GitHub action runs daily to check each project and commit statistics to the
   data files. This allows us to cache statistics each time the site is published
   and makes it easier for visitors to see which projects have available issues.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -34,10 +34,10 @@ with a project of this size:
   deploy and provide a preview so that reviewers do not need to pull down and
   verify the changes locally
 - When a commit is pushed to the `gh-pages` branch, a deploy is started to
-  publishes the latest code to [GitHub Pages](https://pages.github.com/), which
+  publish the latest code to [GitHub Pages](https://pages.github.com/), which
   hosts the site
 - A GitHub action runs weekly to scan the project list and cleanup any that have
-  stale projects, by checking they are still accessible via the GitHub API. This
+  stale projects, by checking if they are still accessible via the GitHub API. This
   saves us time having to manually review projects for inactivity.
 - A GitHub action runs daily to check each project and commit statistics to the
   data files. This allows us to cache statistics each time the site is published

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,0 +1,42 @@
+# How It Works
+
+Rather than explaining the entirety of the stack, this document will explain
+the key parts of the Up-for-Grabs site and project.
+
+## Displaying projects
+
+The main site is a Jekyll repository hosted on GitHub Pages, but it leverages
+some neat features of Jekyll along the way.
+
+* We use [Data files](https://jekyllrb.com/docs/datafiles/) to represent the
+  projects listed on the site - one file per project
+* We convert this file to JSON inside [`javascripts/projects.json`](../javascripts/projects.json)
+  when the site is built and published
+* The [`projectLoader`](../javascripts/projectLoader.js) module runs when the
+  page is loaded, retrieving these projects and making them available for the
+  site
+* The [`projectsService`](../javascripts/projectsService.js) module handles
+  the rest of the work to sort and search the projects
+* The [`main`](../javascripts/main.js) module handles the rest of the work to
+  render the list of projects and provide the UI for filtering based on label
+  or tags
+
+## Project Infrastructure
+
+We've settled on some infrastructure choices that mean we don't need to worry
+about managing our own servers, and can save time on the manual work that comes
+with a project of this size:
+
+* GitHub Actions run on each build and pull request to validate the project is
+  in a state where it can be deployed
+* Netlify hooks run on each pull request to test the deploy and provide a
+  preview so that reviewers do not need to pull down and verify the changes
+  locally
+* When a commit is pushed to the `gh-pages` branch, a deploy is started to
+  publishes the latest code to GitHub Pages, which hosts our site
+* A GitHub Action runs weekly to scan the project list and cleanup any that have
+  stale projects, by checking they are still accessible via the GitHub API. This
+  saves us time having to manually review projects for inactivity.
+* A GitHub action runs daily to check each project and commit statistics to the
+  data files. This allows us to cache statistics each time the site is published
+  and makes it easier for visitors to see which projects have available issues.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -9,9 +9,10 @@ The main site is a Jekyll repository hosted on GitHub Pages, but it leverages
 some neat features of Jekyll along the way.
 
 - We use [Data files](https://jekyllrb.com/docs/datafiles/) to represent the
-  projects listed on the site - one file per project
+  projects listed on the site - one file per project, found under
+  `_data/projects`
 - We convert this file to JSON inside [`javascripts/projects.json`](../javascripts/projects.json)
-  when the site is built and published
+  when the site is built using `jekyll`
 - The [`projectLoader`](../javascripts/projectLoader.js) module runs when the
   page is loaded, retrieving these projects and making them available for the
   site
@@ -27,14 +28,15 @@ We've settled on some infrastructure choices that mean we don't need to worry
 about managing our own servers, and can save time on the manual work that comes
 with a project of this size:
 
-- GitHub Actions run on each build and pull request to validate the project is
-  in a state where it can be deployed
-- Netlify hooks run on each pull request to test the deploy and provide a
-  preview so that reviewers do not need to pull down and verify the changes
-  locally
+- [GitHub Actions](https://github.com/features/actions) run on each build and
+  pull request to validate the project is in a state where it can be deployed
+- [Netlify](https://www.netlify.com/) hooks run on each pull request to test the
+  deploy and provide a preview so that reviewers do not need to pull down and
+  verify the changes locally
 - When a commit is pushed to the `gh-pages` branch, a deploy is started to
-  publishes the latest code to GitHub Pages, which hosts our site
-- A GitHub Action runs weekly to scan the project list and cleanup any that have
+  publishes the latest code to [GitHub Pages](https://pages.github.com/), which
+  hosts the site
+- A GitHub action runs weekly to scan the project list and cleanup any that have
   stale projects, by checking they are still accessible via the GitHub API. This
   saves us time having to manually review projects for inactivity.
 - A GitHub action runs daily to check each project and commit statistics to the

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "eslint-check": "eslint --print-config javascripts/main.js | eslint-config-prettier-check",
     "lint": "eslint javascripts/*.js tests/**/*.js",
     "lint-fix": "eslint --fix javascripts/*.js tests/**/*.js",
-    "prettier": "prettier --check javascripts/*.js tests/**/*.js docs/**/*.md",
-    "prettier-fix": "prettier --write javascripts/*.js tests/**/*.js docs/**/*.md",
+    "prettier": "prettier --check javascripts/*.js tests/**/*.js docs/**/*.md .github/**/*.md",
+    "prettier-fix": "prettier --write javascripts/*.js tests/**/*.js docs/**/*.md .github/**/*.md",
     "test": "jest --config ./jest.config.js --verbose --coverage"
   },
   "dependencies": {


### PR DESCRIPTION
Related to #1368

This PR simplifies the README by moving two important sections out to their own documentation, and refreshing them to reflect what is current for the project.

Rendered previews:

 - [README.md](https://github.com/shiftkey/up-for-grabs.net/blob/writing-some-docs/README.md)
 - [.github/CONTRIBUTING.md](https://github.com/shiftkey/up-for-grabs.net/blob/writing-some-docs/.github/CONTRIBUTING.md)
 - [docs/how-it-works.md](https://github.com/shiftkey/up-for-grabs.net/blob/writing-some-docs/docs/how-it-works.md)

TODO:

 - [x] extracted and refreshed
 - [x] reviewing and edits
 - [x] address any feedback