### PR TITLE
schema validation of project files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,12 @@ AllCops:
     - '.github/actions/**/*.rb'
     - 'scripts/**/*.rb'
 
+Metrics/CyclomaticComplexity:
+  Max: 7
+
+Metrics/PerceivedComplexity:
+  Max: 8
+
 Metrics/LineLength:
   Max: 186
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,6 @@ source 'https://rubygems.org'
 
 gem 'github-pages', group: :jekyll_plugins
 
+gem 'json_schemer'
+
 gem 'rubocop', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,8 @@ GEM
     concurrent-ruby (1.1.5)
     dnsruby (1.61.3)
       addressable (~> 2.5)
+    ecma-re-validator (0.2.0)
+      regexp_parser (~> 1.2)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
@@ -86,6 +88,7 @@ GEM
       octokit (~> 4.0)
       public_suffix (~> 3.0)
       typhoeus (~> 1.3)
+    hana (1.3.5)
     html-pipeline (2.12.0)
       activesupport (>= 2)
       nokogiri (>= 1.4)
@@ -198,6 +201,11 @@ GEM
       gemoji (~> 3.0)
       html-pipeline (~> 2.2)
       jekyll (~> 3.0)
+    json_schemer (0.2.7)
+      ecma-re-validator (~> 0.2)
+      hana (~> 1.3)
+      regexp_parser (~> 1.5)
+      uri_template (~> 0.7)
     kramdown (1.17.0)
     liquid (4.0.0)
     listen (3.1.5)
@@ -230,6 +238,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    regexp_parser (1.6.0)
     rouge (3.11.0)
     rubocop (0.75.0)
       jaro_winkler (~> 1.5.1)
@@ -260,6 +269,7 @@ GEM
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.0)
+    uri_template (0.7.0)
 
 PLATFORMS
   ruby
@@ -268,6 +278,7 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
+  json_schemer
   rubocop
 
 BUNDLED WITH

--- a/_data/projects/EigengrausGenerator.yml
+++ b/_data/projects/EigengrausGenerator.yml
@@ -6,7 +6,7 @@ tags:
 - javascript
 - twine
 - sugarcube
-- d&d
+- dungeons-and-dragons
 - procedural-generation
 - random-generation
 - generation

--- a/_data/projects/GrandNode.yml
+++ b/_data/projects/GrandNode.yml
@@ -7,7 +7,7 @@ desc: >-
   or services online.
 site: https://grandnode.com/
 tags:
-- dotnet
+- ".net"
 - c#
 - ecommerce
 - mongodb

--- a/_data/projects/dotnet-architecture.yml
+++ b/_data/projects/dotnet-architecture.yml
@@ -4,7 +4,6 @@ desc: Code example that follows the Microsoft Architecture guidance.
 site: https://github.com/dotnet-architecture/eShopOnWeb
 tags:
 - web
-- dotnet
 - razor-pages
 - ".net"
 - docker

--- a/_data/projects/entity-framework-6.yml
+++ b/_data/projects/entity-framework-6.yml
@@ -9,9 +9,9 @@ tags:
 - ef
 - database
 - data
-- o/rm
+- object-relational-mapper
 - ado.net
-- entityframework
+- entity-framework
 upforgrabs:
   name: good first issue
   link: https://github.com/aspnet/EntityFramework6/labels/good%20first%20issue

--- a/_data/projects/entity-framework-core.yml
+++ b/_data/projects/entity-framework-core.yml
@@ -9,9 +9,9 @@ tags:
 - ef
 - database
 - data
-- o/rm
+- object-relational-mapper
 - ado.net
-- entityframework
+- entity-framework
 upforgrabs:
   name: good first issue
   link: https://github.com/aspnet/EntityFrameworkCore/labels/good%20first%20issue

--- a/_data/projects/in-toto.yml
+++ b/_data/projects/in-toto.yml
@@ -6,7 +6,8 @@ tags:
 - python
 - security
 - software-supply-chain
-- ci/cd
+- continuous-integration
+- continuous-delivery
 upforgrabs:
   name: Up for grabs
   link: https://github.com/in-toto/in-toto/labels/Up%20for%20grabs

--- a/_data/projects/opencensus-csharp.yml
+++ b/_data/projects/opencensus-csharp.yml
@@ -11,7 +11,6 @@ tags:
 - trace
 - c#
 - ".net"
-- dotnet
 - cloud
 - stats
 - monitoring

--- a/_data/projects/populateG.yml
+++ b/_data/projects/populateG.yml
@@ -7,7 +7,8 @@ tags:
 - go
 - rest-api
 - web-application
-- html/css
+- html
+- css
 - google-api
 - templating
 upforgrabs:

--- a/_data/projects/random-password-generator.yml
+++ b/_data/projects/random-password-generator.yml
@@ -6,7 +6,8 @@ desc: >-
 site: https://github.com/suryasr007/random-password-generator
 tags:
 - frontend
-- html/css
+- html
+- css
 - javascript
 - jquery
 upforgrabs:

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,91 @@
+{
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://example.com/root.json",
+  "type": "object",
+  "title": "Schema for the Up-For-Grabs project file",
+  "required": ["name", "desc", "site", "tags", "upforgrabs"],
+  "properties": {
+    "name": {
+      "$id": "#/properties/name",
+      "type": "string",
+      "title": "The name of the project",
+      "examples": ["My Cool Project"],
+      "pattern": "^(.*)$"
+    },
+    "desc": {
+      "$id": "#/properties/desc",
+      "type": "string",
+      "title": "A description to summarize the project",
+      "examples": [
+        "This is a neat project that does a really cool thing."
+      ]
+    },
+    "site": {
+      "$id": "#/properties/site",
+      "type": "string",
+      "title": "The URL to the main project site",
+      "examples": ["https://github.com/solr-express/solr-express"],
+      "format": "uri"
+    },
+    "tags": {
+      "$id": "#/properties/tags",
+      "type": "array",
+      "title": "The Tags Schema",
+      "items": {
+        "$id": "#/properties/tags/items",
+        "type": "string",
+        "title": "The Items Schema",
+        "examples": ["solr", "c#", ".net-framework", ".net-core"],
+        "pattern": "^([a-z0-9+#.-]*)$"
+      }
+    },
+    "upforgrabs": {
+      "$id": "#/properties/upforgrabs",
+      "type": "object",
+      "title": "The Upforgrabs Schema",
+      "required": ["name", "link"],
+      "properties": {
+        "name": {
+          "$id": "#/properties/upforgrabs/properties/name",
+          "type": "string",
+          "title": "The Name Schema",
+          "examples": ["up for grabs"],
+          "pattern": "^(.*)$"
+        },
+        "link": {
+          "$id": "#/properties/upforgrabs/properties/link",
+          "type": "string",
+          "title": "The Link Schema",
+          "examples": [
+            "https://github.com/solr-express/solr-express/labels/up%20for%20grabs"
+          ],
+          "format": "uri"
+        }
+      }
+    },
+    "stats": {
+      "$id": "#/properties/stats",
+      "type": "object",
+      "title": "Statistics for the current project",
+      "default": null,
+      "required": ["issue-count", "last-updated"],
+      "properties": {
+        "issue-count": {
+          "$id": "#/properties/stats/properties/issue-count",
+          "type": "integer",
+          "title": "The Issue-count Schema",
+          "default": 0,
+          "minimum": 0
+        },
+        "last-updated": {
+          "$id": "#/properties/stats/properties/last-updated",
+          "type": "string",
+          "title": "The Last-updated Schema",
+          "default": "",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/schema.json
+++ b/schema.json
@@ -31,11 +31,11 @@
     "tags": {
       "$id": "#/properties/tags",
       "type": "array",
-      "title": "The Tags Schema",
+      "title": "A list of tags to help identify the project",
       "items": {
         "$id": "#/properties/tags/items",
         "type": "string",
-        "title": "The Items Schema",
+        "title": "A tag entry",
         "examples": ["solr", "c#", ".net-framework", ".net-core"],
         "pattern": "^([a-z0-9+#.-]*)$"
       }
@@ -43,20 +43,20 @@
     "upforgrabs": {
       "$id": "#/properties/upforgrabs",
       "type": "object",
-      "title": "The Upforgrabs Schema",
+      "title": "The schema for the original UpForGrabs project information",
       "required": ["name", "link"],
       "properties": {
         "name": {
           "$id": "#/properties/upforgrabs/properties/name",
           "type": "string",
-          "title": "The Name Schema",
+          "title": "The name of the label used by the project",
           "examples": ["up for grabs"],
           "pattern": "^(.*)$"
         },
         "link": {
           "$id": "#/properties/upforgrabs/properties/link",
           "type": "string",
-          "title": "The Link Schema",
+          "title": "A URL to the list of issues that are ideal for new contributors",
           "examples": [
             "https://github.com/solr-express/solr-express/labels/up%20for%20grabs"
           ],

--- a/scripts/cibuild.rb
+++ b/scripts/cibuild.rb
@@ -4,6 +4,8 @@ require 'safe_yaml'
 require 'uri'
 require 'pathname'
 require 'find'
+require 'json_schemer'
+
 require_relative 'project_validator.rb'
 
 def check_folder(root)
@@ -42,8 +44,11 @@ end
 projects_with_errors = []
 projects_without_issues = []
 
+schema = Pathname.new("#{root}/schema.json")
+schemer = JSONSchemer.schema(schema)
+
 projects.each do |p|
-  validation_errors = p.validation_errors
+  validation_errors = p.validation_errors(schemer)
   if validation_errors.empty?
     projects_without_issues << [p, nil]
   else

--- a/scripts/project_validator.rb
+++ b/scripts/project_validator.rb
@@ -47,7 +47,7 @@ class Project
     valid = schemer.valid?(yaml)
     unless valid
       raw_errors = schemer.validate(yaml).to_a
-      formatted_messages = raw_errors.map { |err| format_error (err) }
+      formatted_messages = raw_errors.map { |err| format_error err }
       errors.concat(formatted_messages)
     end
 
@@ -65,7 +65,7 @@ class Project
 
     if field.start_with?('/tags/')
       "Tag '#{value}' contains invalid characters. Allowed characters: a-z, 0-9, +, #, . or -"
-    elsif field.start_with?('/site') || field.start_with?("/upforgrabs/link")
+    elsif field.start_with?('/site') || field.start_with?('/upforgrabs/link')
       "Field '#{field}' expects a URL but instead found '#{value}'. Please check and update this value."
     elsif field.start_with?('/stats/last-updated')
       "Field '#{field}' expects date-time string but instead found '#{value}'. Please check and update this value."
@@ -73,7 +73,7 @@ class Project
       "Field '#{field}' expects a non-negative integer but instead found '#{value}'. Please check and update this value."
     elsif type == 'required'
       details = err.fetch('details')
-      keys = details["missing_keys"]
+      keys = details['missing_keys']
       "Required fields are missing from file: #{keys.join(', ')}. Please check the example on the README and add these values."
     else
       "Field '#{field}' with value '#{value}' failed to satisfy the rule '#{type}'. Check the value and try again."

--- a/scripts/project_validator.rb
+++ b/scripts/project_validator.rb
@@ -37,7 +37,7 @@ class Project
     ''
   end
 
-  def validation_errors
+  def validation_errors(schemer)
     errors = []
 
     begin
@@ -50,6 +50,18 @@ class Project
 
     # don't continue if there was a problem parsing
     return errors if errors.any?
+
+    valid = schemer.valid?(yaml)
+    unless valid
+      raw_errors = schemer.validate(yaml).to_a
+      formatted_messages = raw_errors.map do |e|
+        field = e.fetch('data_pointer')
+        value = e.fetch('data')
+        type = e.fetch('type')
+        "Field '#{field}' with value '#{value}' failed to satisfy the rule '#{type}'. Check the value and try again."
+      end
+      errors.concat(formatted_messages)
+    end
 
     errors.concat(validate_summary(yaml))
     errors.concat(validate_tags(yaml))

--- a/scripts/project_validator.rb
+++ b/scripts/project_validator.rb
@@ -47,23 +47,7 @@ class Project
     valid = schemer.valid?(yaml)
     unless valid
       raw_errors = schemer.validate(yaml).to_a
-      formatted_messages = raw_errors.map do |err|
-        field = err.fetch('data_pointer')
-        value = err.fetch('data')
-        type = err.fetch('type')
-
-        if field.start_with?('/tags/')
-          "Tag '#{value}' contains invalid characters. Allowed characters: a-z, 0-9, +, #, . or -"
-        elsif field.start_with?('/site') || field.start_with?("/upforgrabs/link")
-          "Field '#{field}' expects a URL but instead found '#{value}'. Please check and update this value."
-        elsif field.start_with?('/stats/last-updated')
-          "Field '#{field}' expects date-time string but instead found '#{value}'. Please check and update this value."
-        elsif field.start_with?('/stats/issue-count')
-          "Field '#{field}' expects a non-negative integer but instead found '#{value}'. Please check and update this value."
-        else
-          "Field '#{field}' with value '#{value}' failed to satisfy the rule '#{type}'. Check the value and try again."
-        end
-      end
+      formatted_messages = raw_errors.map { |err| format_error (err) }
       errors.concat(formatted_messages)
     end
 
@@ -73,6 +57,24 @@ class Project
   end
 
   private
+
+  def format_error(err)
+    field = err.fetch('data_pointer')
+    value = err.fetch('data')
+    type = err.fetch('type')
+
+    if field.start_with?('/tags/')
+      "Tag '#{value}' contains invalid characters. Allowed characters: a-z, 0-9, +, #, . or -"
+    elsif field.start_with?('/site') || field.start_with?("/upforgrabs/link")
+      "Field '#{field}' expects a URL but instead found '#{value}'. Please check and update this value."
+    elsif field.start_with?('/stats/last-updated')
+      "Field '#{field}' expects date-time string but instead found '#{value}'. Please check and update this value."
+    elsif field.start_with?('/stats/issue-count')
+      "Field '#{field}' expects a non-negative integer but instead found '#{value}'. Please check and update this value."
+    else
+      "Field '#{field}' with value '#{value}' failed to satisfy the rule '#{type}'. Check the value and try again."
+    end
+  end
 
   # preference is a map of [bad tag]: [preferred tag]
   PREFERENCES = {

--- a/scripts/project_validator.rb
+++ b/scripts/project_validator.rb
@@ -10,13 +10,6 @@ class Project
     @full_path = full_path
   end
 
-  def self.valid_url?(url)
-    uri = URI.parse(url)
-    uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
-  rescue URI::InvalidURIError
-    false
-  end
-
   def validate_tag_list(taglist)
     result = ''
 

--- a/scripts/project_validator.rb
+++ b/scripts/project_validator.rb
@@ -71,6 +71,10 @@ class Project
       "Field '#{field}' expects date-time string but instead found '#{value}'. Please check and update this value."
     elsif field.start_with?('/stats/issue-count')
       "Field '#{field}' expects a non-negative integer but instead found '#{value}'. Please check and update this value."
+    elsif type == 'required'
+      details = err.fetch('details')
+      keys = details["missing_keys"]
+      "Required fields are missing from file: #{keys.join(', ')}. Please check the example on the README and add these values."
     else
       "Field '#{field}' with value '#{value}' failed to satisfy the rule '#{type}'. Check the value and try again."
     end

--- a/scripts/project_validator.rb
+++ b/scripts/project_validator.rb
@@ -77,6 +77,7 @@ class Project
     'commandline' => 'command-line',
     'csharp' => 'c#',
     'docs' => 'documentation',
+    'dotnet' => '.net',
     'dotnet-core' => '.net core',
     'encrypt' => 'encryption',
     'fsharp' => 'f#',

--- a/scripts/project_validator.rb
+++ b/scripts/project_validator.rb
@@ -100,9 +100,7 @@ class Project
     tags.each do |tag|
       preferred_tag = PREFERENCES[tag]
 
-      if preferred_tag
-        errors << "Rename tag '#{tag}' to be'#{preferred_tag}'"
-      end
+      errors << "Rename tag '#{tag}' to be'#{preferred_tag}'" if preferred_tag
     end
 
     errors

--- a/scripts/project_validator.rb
+++ b/scripts/project_validator.rb
@@ -47,10 +47,10 @@ class Project
     valid = schemer.valid?(yaml)
     unless valid
       raw_errors = schemer.validate(yaml).to_a
-      formatted_messages = raw_errors.map do |e|
-        field = e.fetch('data_pointer')
-        value = e.fetch('data')
-        type = e.fetch('type')
+      formatted_messages = raw_errors.map do |err|
+        field = err.fetch('data_pointer')
+        value = err.fetch('data')
+        type = err.fetch('type')
         "Field '#{field}' with value '#{value}' failed to satisfy the rule '#{type}'. Check the value and try again."
       end
       errors.concat(formatted_messages)

--- a/scripts/project_validator.rb
+++ b/scripts/project_validator.rb
@@ -51,7 +51,18 @@ class Project
         field = err.fetch('data_pointer')
         value = err.fetch('data')
         type = err.fetch('type')
-        "Field '#{field}' with value '#{value}' failed to satisfy the rule '#{type}'. Check the value and try again."
+
+        if field.start_with?('/tags/')
+          "Tag '#{value}' contains invalid characters. Allowed characters: a-z, 0-9, +, #, . or -"
+        elsif field.start_with?('/site') || field.start_with?("/upforgrabs/link")
+          "Field '#{field}' expects a URL but instead found '#{value}'. Please check and update this value."
+        elsif field.start_with?('/stats/last-updated')
+          "Field '#{field}' expects date-time string but instead found '#{value}'. Please check and update this value."
+        elsif field.start_with?('/stats/issue-count')
+          "Field '#{field}' expects a non-negative integer but instead found '#{value}'. Please check and update this value."
+        else
+          "Field '#{field}' with value '#{value}' failed to satisfy the rule '#{type}'. Check the value and try again."
+        end
       end
       errors.concat(formatted_messages)
     end

--- a/scripts/project_validator.rb
+++ b/scripts/project_validator.rb
@@ -63,9 +63,7 @@ class Project
       errors.concat(formatted_messages)
     end
 
-    errors.concat(validate_summary(yaml))
     errors.concat(validate_tags(yaml))
-    errors.concat(validate_upforgrabs(yaml))
 
     errors
   end
@@ -105,20 +103,6 @@ class Project
     'react' => 'reactjs'
   }.freeze
 
-  def validate_summary(yaml)
-    errors = []
-
-    errors << "Required 'name' attribute is not defined" if yaml['name'].nil?
-
-    errors << "Required 'site' attribute is not defined" if yaml['site'].nil?
-
-    errors << "Required 'site' attribute to be a valid url" unless Project.valid_url?(yaml['site'])
-
-    errors << "Required 'desc' attribute is not defined" if yaml['desc'].nil?
-
-    errors
-  end
-
   def validate_tags(yaml)
     errors = []
 
@@ -133,24 +117,6 @@ class Project
     dups = tags.group_by { |t| t }.keep_if { |_, t| t.length > 1 }
 
     errors << "Duplicate tags found: #{dups.keys.join ', '}" if dups.any?
-
-    errors
-  end
-
-  def validate_upforgrabs(yaml)
-    errors = []
-
-    # validating the current schema
-    errors << "Required 'upforgrabs' attribute is not defined" if yaml['upforgrabs'].nil?
-
-    # bail out early if not found
-    return errors if yaml['upforgrabs'].nil?
-
-    errors << "Required 'upforgrabs.name' attribute is not defined" if yaml['upforgrabs']['name'].nil?
-
-    errors << "Required 'upforgrabs.link' attribute is not defined" if yaml['upforgrabs']['link'].nil?
-
-    errors << "Required 'upforgrabs.link' attribute to be a valid url" unless Project.valid_url?(yaml['upforgrabs']['link'])
 
     errors
   end


### PR DESCRIPTION
I've been pondering how I can make changes to the project format without losing my sanity about all the projects that are currently listed, and I started exploring how to validate things using a predefined schema. YAML schema validation itself seems rather sparse, but [JSON Schema](http://json-schema.org/) turned out to be reusable for YAML files after I parse them into a Ruby object so I started down this rabbit hole.

Because the validation in `project_validator.rb` is rather straight-forward, I was able to throw away a lot of the existing custom validation, and I caught some new labels that can be renamed to something else.

This will also free me up to make additive changes to the schema for new optional fields to tackle ideas proposed in #578 #607 #617 #462 

TODO:

 - [x] finish schema definition
 - [x] cleanup tags for impacted projects
 - [x] test how things fail when you omit strings
 - [x] test how things fail when you mess up URLs
 - [x] test how things fail when you submit an invalid tag
 - [x] improve formatting based on `type` raised and feedback above