### PR TITLE
scaffolding for a 'unified' actions environment

### DIFF
--- a/.github/actions/all/sitevalidator.Dockerfile
+++ b/.github/actions/all/sitevalidator.Dockerfile
@@ -1,0 +1,7 @@
+FROM ruby:2.6-stretch
+
+RUN pwd
+
+RUN ruby -v
+
+RUN ruby validate_site.rb

--- a/.github/workflows/validate-site-new.yml
+++ b/.github/workflows/validate-site-new.yml
@@ -1,0 +1,16 @@
+name: Validate Site New
+
+on: [pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: ./.github/actions/all/sitevalidator.Dockerfile
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        APPLY_CHANGES: 1
+


### PR DESCRIPTION
This is a little experiment to poke at the Actions environment to see if I can provide it a named `Dockerfile` in a directory (up until this point I've only provided the directory name, so this might not work).

Why does this matter? When `docker build` runs it uses the directory containing the Dockerfile as the context, and scripts outside the directory are inaccessible (so I can't copy in files I might need). This is great for simple things, but I'm building up some common Ruby functionality that I'd like to share between actions, without going through the ceremony of publishing to rubygems.
