### PR TITLE
warn about orphaned files during CI

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,10 +4,10 @@ AllCops:
     - 'scripts/**/*.rb'
 
 Metrics/CyclomaticComplexity:
-  Max: 7
+  Max: 9
 
 Metrics/PerceivedComplexity:
-  Max: 8
+  Max: 9
 
 Metrics/LineLength:
   Max: 186

--- a/scripts/cibuild.rb
+++ b/scripts/cibuild.rb
@@ -57,7 +57,6 @@ def check_folder(root)
   puts 'Move these inside _data/projects to ensure they are listed on the site'
 
   exit(-1)
-
 end
 
 root = File.expand_path('..', __dir__)

--- a/scripts/cibuild.rb
+++ b/scripts/cibuild.rb
@@ -31,7 +31,7 @@ def check_folder(root)
     exit(-1)
   end
 
-  valid_yaml_files = ["_config.yml", "docker-compose.yml", ".rubocop.yml"]
+  valid_yaml_files = ['_config.yml', 'docker-compose.yml', '.rubocop.yml']
 
   Find.find("#{root}/") do |path|
     next unless FileTest.file?(path)
@@ -40,7 +40,7 @@ def check_folder(root)
     basename = File.basename(path)
     next if valid_yaml_files.include?(basename)
 
-    other_files << basename  if File.extname(path) == '.yml'
+    other_files << basename if File.extname(path) == '.yml'
   end
 
   count = other_files.count
@@ -53,7 +53,7 @@ def check_folder(root)
       puts " - #{f}"
     end
 
-    puts "Move these inside _data/projects to ensure they are listed on the site"
+    puts 'Move these inside _data/projects to ensure they are listed on the site'
 
     exit(-1)
   end

--- a/scripts/cibuild.rb
+++ b/scripts/cibuild.rb
@@ -45,18 +45,19 @@ def check_folder(root)
 
   count = other_files.count
 
-  if count.positive?
-    puts "#{count} files found in root which look like content files:"
-    r = Pathname.new(root)
+  return unless count.positive?
 
-    other_files.each do |f|
-      puts " - #{f}"
-    end
+  puts "#{count} files found in root which look like content files:"
+  r = Pathname.new(root)
 
-    puts 'Move these inside _data/projects to ensure they are listed on the site'
-
-    exit(-1)
+  other_files.each do |f|
+    puts " - #{f}"
   end
+
+  puts 'Move these inside _data/projects to ensure they are listed on the site'
+
+  exit(-1)
+
 end
 
 root = File.expand_path('..', __dir__)

--- a/scripts/cibuild.rb
+++ b/scripts/cibuild.rb
@@ -19,17 +19,17 @@ def check_folder(root)
 
   count = other_files.count
 
-  return unless count.positive?
+  if count.positive?
+    puts "#{count} files found in projects directory which are not YAML files:"
+    r = Pathname.new(root)
 
-  puts "#{count} files found in projects directory which are not YAML files:"
-  r = Pathname.new(root)
+    other_files.each do |f|
+      relative_path = Pathname.new(f).relative_path_from(r).to_s
+      puts " - #{relative_path}"
+    end
 
-  other_files.each do |f|
-    relative_path = Pathname.new(f).relative_path_from(r).to_s
-    puts " - #{relative_path}"
+    exit(-1)
   end
-
-  exit(-1)
 end
 
 root = File.expand_path('..', __dir__)

--- a/scripts/cibuild.rb
+++ b/scripts/cibuild.rb
@@ -30,6 +30,33 @@ def check_folder(root)
 
     exit(-1)
   end
+
+  valid_yaml_files = ["_config.yml", "docker-compose.yml", ".rubocop.yml"]
+
+  Find.find("#{root}/") do |path|
+    next unless FileTest.file?(path)
+    next unless File.dirname(path) == root
+
+    basename = File.basename(path)
+    next if valid_yaml_files.include?(basename)
+
+    other_files << basename  if File.extname(path) == '.yml'
+  end
+
+  count = other_files.count
+
+  if count.positive?
+    puts "#{count} files found in root which look like content files:"
+    r = Pathname.new(root)
+
+    other_files.each do |f|
+      puts " - #{f}"
+    end
+
+    puts "Move these inside _data/projects to ensure they are listed on the site"
+
+    exit(-1)
+  end
 end
 
 root = File.expand_path('..', __dir__)


### PR DESCRIPTION
While reviewing #1558 I realised this file was at the root of the repository, so this PR adds in a check to CI to fail with messaging to prevent the reviewer from accidentally merging it in:

```
$ ruby scripts/cibuild.rb
1 files found in root which look like content files:
 - legesher.yml
Move these inside _data/projects to ensure they are listed on the site