### PR TITLE
tweaking stale config to ensure things are closed

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,8 +1,8 @@
 only: pulls
 
 pulls:
-  daysUntilStale: 14
-  daysUntilClose: 0
+  daysUntilStale: 13
+  daysUntilClose: 1
   onlyLabels:
     - 'needs work'
   exemptLabels:
@@ -10,8 +10,9 @@ pulls:
   staleLabel: stale
   exemptAssignees: true
   markComment: >
-    This pull request will be closed because it has not had recent activity after
-    being reviewed. If you are still interested in adding your project to the site,
-    please submit a new pull request and address the above feedback. Thank you
-    for your contribution!
+    This pull request will be closed tomorrow because it has not had recent
+    activity after being reviewed. If you are still interested in adding your
+    project to the site, please submit a new pull request and address the above
+    feedback. Thank you for your contribution!
   closeComment: false
+  unmarkComment: false


### PR DESCRIPTION
After seeing https://github.com/up-for-grabs/up-for-grabs.net/pull/1424#issuecomment-543702099 get labelled as expected but not closed, I went and skimmed the source of the app to understand what happened.

Turns out `daysUntilClose` cannot be zero because it looks like the code will skip over any closing (yay JS truthiness):

https://github.com/probot/stale/blob/e3c53ebf879cccaf856fba1602fdd67f878c3ee3/lib/stale.js#L51-L63

```js
    const daysUntilClose = this.getConfigValue(type, 'daysUntilClose')


    if (daysUntilClose) {
      this.logger.trace({ owner, repo }, 'Configured to close stale issues')
      const closableItems = (await this.getClosable(type)).data.items


      await Promise.all(closableItems.filter(issue => !issue.locked).map(issue => {
        this.close(type, issue)
      }))
    } else {
      this.logger.trace({ owner, repo }, 'Configured to leave stale issues open')
    }
  }
```

This change should enforce closing stale PRs as expected, and tweak the message to indicate it won't be closed immediately.