### PR TITLE
Update ghost2 project link

### DIFF
--- a/_data/projects/ghost2.yml
+++ b/_data/projects/ghost2.yml
@@ -1,7 +1,7 @@
 ---
 name: ghost2
 desc: A modular, multi-featured Discord bot.
-site: https://github.com/cbryant02/ghost2
+site: https://github.com/ghost2-discord/ghost2
 tags:
 - java
 - oss
@@ -10,7 +10,7 @@ tags:
 - gradle
 upforgrabs:
   name: good first issue
-  link: https://github.com/cbryant02/ghost2/labels/good%20first%20issue
+  link: https://github.com/ghost2-discord/ghost2/labels/good%20first%20issue
 stats:
   issue-count: 0
   last-updated: '2019-10-17T21:11:43Z'


### PR DESCRIPTION
The repo has been permanently moved to a GitHub organization, and is no longer under my account. I've updated the links accordingly.