### PR TITLE
cleanup redirected projects

### DIFF
--- a/_data/projects/MERN-Boilerplate.yml
+++ b/_data/projects/MERN-Boilerplate.yml
@@ -1,7 +1,7 @@
 ---
 name: MERN-Boilerplate
 desc: This is boilerplate for MERN stack with integrations like Redux and SSR
-site: https://github.com/anikethsaha/MERN-Boilerplate
+site: https://github.com/anikethsaha/MERN
 tags:
 - node.js
 - javascript
@@ -14,7 +14,7 @@ tags:
 - server-side-rendering
 upforgrabs:
   name: help wanted
-  link: https://github.com/anikethsaha/MERN-Boilerplate/labels/help%20wanted
+  link: https://github.com/anikethsaha/MERN/labels/help%20wanted
 stats:
   issue-count: 4
   last-updated: '2019-10-16T16:04:02Z'

--- a/_data/projects/kentico-kenticokontentjs.yml
+++ b/_data/projects/kentico-kenticokontentjs.yml
@@ -1,7 +1,7 @@
 ---
 name: kentico-content-js
 desc: Repository hosting various Kentico Kontent Javascript packages
-site: https://github.com/Kentico/kentico-kontent-js
+site: https://github.com/Kentico/kontent-delivery-sdk-js
 tags:
 - javascript
 - typescript
@@ -19,7 +19,7 @@ tags:
 - caas
 upforgrabs:
   name: up-for-grabs
-  link: https://github.com/Kentico/kentico-kontent-js/labels/up-for-grabs
+  link: https://github.com/Kentico/kontent-delivery-sdk-js/labels/up-for-grabs
 stats:
   issue-count: 3
   last-updated: '2019-10-17T08:09:15Z'

--- a/_data/projects/vidarjs.yml
+++ b/_data/projects/vidarjs.yml
@@ -1,7 +1,7 @@
 ---
-name: vidar.js
+name: vidar
 desc: A flexible video-editing library for the browser
-site: https://github.com/clabe45/vidar.js
+site: https://github.com/clabe45/vidar
 tags:
 - javascript
 - vanilla-javascript
@@ -10,7 +10,7 @@ tags:
 - automation
 upforgrabs:
   name: help wanted
-  link: https://github.com/clabe45/vidar.js/labels/help%20wanted
+  link: https://github.com/clabe45/vidar/labels/help%20wanted
 stats:
   issue-count: 4
   last-updated: '2019-10-18T10:19:40Z'


### PR DESCRIPTION
These projects have been moved to new locations, which was picked up in the last `Cleanup stale projects` run:

```
Encountered error while trying to validate '_data/projects/MERN-Boilerplate.yml' - Repository anikethsaha/MERN-Boilerplate now lives at anikethsaha/MERN and should be updated
Encountered error while trying to validate '_data/projects/vidarjs.yml' - Repository clabe45/vidar.js now lives at clabe45/vidar and should be updated
Encountered error while trying to validate '_data/projects/kentico-kenticokontentjs.yml' - Repository Kentico/kentico-kontent-js now lives at Kentico/kontent-delivery-sdk-js and should be updated
```