### PR TITLE
add names to config jobs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,12 +4,14 @@ on: [push,pull_request]
 
 jobs:
   docker:
+    name: "Test Docker build"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - name: Build Docker container
       run: docker build .
   javascript:
+    name: "Test JavaScript"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
@@ -27,6 +29,7 @@ jobs:
         CI: true
 
   site:
+    name: "Test Jekyll Site"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "eslint-check": "eslint --print-config javascripts/main.js | eslint-config-prettier-check",
     "lint": "eslint javascripts/*.js tests/**/*.js",
     "lint-fix": "eslint --fix javascripts/*.js tests/**/*.js",
-    "prettier": "prettier --check javascripts/*.js tests/**/*.js docs/**/*.md .github/**/*.md",
+    "prettier": "prettier --check javascripts/*.js tests/**/*.js docs/**/*.md .github/**/*.md README.md",
     "prettier-fix": "prettier --write javascripts/*.js tests/**/*.js docs/**/*.md .github/**/*.md",
     "test": "jest --config ./jest.config.js --verbose --coverage"
   },


### PR DESCRIPTION
When I get a notification that a build fails I get GUIDs for the job names:

<img width="529" src="https://user-images.githubusercontent.com/359239/67147035-5863ce80-f267-11e9-9faf-618a943eae45.png">

I think this is the way to make the list show a more friendly name.