### PR TITLE
a bit more polish for the README page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,8 @@
-up-for-grabs.net
+[up-for-grabs.net](https://up-for-grabs.net/)
 ![Continuous Integration  status](https://github.com/up-for-grabs/up-for-grabs.net/workflows/Continuous%20Integration/badge.svg)
 [![Netlify Status](https://api.netlify.com/api/v1/badges/0ee7bf9f-1aed-465b-8e9e-01de009a8a7e/deploy-status)](https://app.netlify.com/sites/up-for-grabs-test-bench/deploys)
 [![All Contributors](https://img.shields.io/badge/all_contributors-11-orange.svg?style=flat-square)](#contributors)
 ================
-
-Do you run or participate in an open-source project? Submit a Pull Request to add it to the list!
-
-Visit the website: [up-for-grabs.net](https://up-for-grabs.net/)
 
 ## List your project
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Visit the website: [up-for-grabs.net](https://up-for-grabs.net/)
 
 ## List your project
 
-If you know of a project that should be listed on Up for Grabs,
+If you know of or own a project that should be listed on Up for Grabs,
 [follow the instructions to open a pull request](docs/list-a-project.md).
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 [up-for-grabs.net](https://up-for-grabs.net/)
-![Continuous Integration  status](https://github.com/up-for-grabs/up-for-grabs.net/workflows/Continuous%20Integration/badge.svg)
+![Continuous Integration status](https://github.com/up-for-grabs/up-for-grabs.net/workflows/Continuous%20Integration/badge.svg)
 [![Netlify Status](https://api.netlify.com/api/v1/badges/0ee7bf9f-1aed-465b-8e9e-01de009a8a7e/deploy-status)](https://app.netlify.com/sites/up-for-grabs-test-bench/deploys)
 [![All Contributors](https://img.shields.io/badge/all_contributors-11-orange.svg?style=flat-square)](#contributors)
 ================
+
+<a href="https://up-for-grabs.net/"><img width="814" src="https://user-images.githubusercontent.com/359239/67390578-50f83a00-f573-11e9-835d-02eb9e019afb.png"></a>
+
+This repository contains the content for the Up-For-Grabs website.
 
 ## List your project
 

--- a/docs/list-a-project.md
+++ b/docs/list-a-project.md
@@ -12,7 +12,7 @@ We are interested in active open source projects that meet this criteria:
 - maintainers are happy and willing to review and work with new contributors to
   help them learn more about open source
 
-If you project does not satisfy all of this criteria, it may be declined at the
+If your project does not satisfy all of this criteria, it may be declined at the
 review process. We'll provide suggestions to help address these things so that
 it may be listed in the future.
 


### PR DESCRIPTION
This PR addresses some feedback from #1588 and also refreshes the header itself.

Each of the commits should be self-explanatory.

[Rendered preview for README.md](https://github.com/shiftkey/up-for-grabs.net/blob/docs-tidy-up/README.md)