### PR TITLE
import functionality from local gem for CI build

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -90,7 +90,7 @@ This script scans all the data files under `_data/projects` to verify they can b
 parsed correctly, and have the expected schema defined.
 
 ```
-$ ruby scripts/validate_data_files.rb
+$ bundle exec ruby scripts/validate_data_files.rb
 ```
 
 If you run this and it reports an error, check the file and fix the error before

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -44,5 +44,5 @@ jobs:
         bundle install --jobs 4 --retry 3
         bundle exec rubocop
         bundle exec jekyll build
-        ruby scripts/validate_data_files.rb
+        bundle exec ruby scripts/validate_data_files.rb
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,6 @@ gem 'github-pages', group: :jekyll_plugins
 
 gem 'json_schemer'
 
+gem 'up_for_grabs_tooling', :github => 'up-for-grabs/tooling', :branch => 'master'
+
 gem 'rubocop', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,14 @@
+GIT
+  remote: https://github.com/up-for-grabs/tooling.git
+  revision: 4dd5fb1ee7cc8f7f455cc5ae3930ca82a34b648d
+  branch: master
+  specs:
+    up_for_grabs_tooling (0.0.1)
+      graphql-client (~> 0.16)
+      json_schemer (~> 0.2)
+      octokit (~> 4.14)
+      safe_yaml (~> 1.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -88,6 +99,10 @@ GEM
       octokit (~> 4.0)
       public_suffix (~> 3.0)
       typhoeus (~> 1.3)
+    graphql (1.9.14)
+    graphql-client (0.16.0)
+      activesupport (>= 3.0)
+      graphql (~> 1.8)
     hana (1.3.5)
     html-pipeline (2.12.0)
       activesupport (>= 2)
@@ -280,6 +295,7 @@ DEPENDENCIES
   github-pages
   json_schemer
   rubocop
+  up_for_grabs_tooling!
 
 BUNDLED WITH
    2.0.1

--- a/scripts/data_files_validator.rb
+++ b/scripts/data_files_validator.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-require_relative 'project.rb'
+require 'up_for_grabs_tooling'
+
+require_relative 'project_validator'
 
 # Validate the data files
 class DataFilesValidator
@@ -17,7 +19,7 @@ class DataFilesValidator
     schemer = JSONSchemer.schema(schema)
 
     projects.each do |p|
-      validation_errors = p.validation_errors(schemer)
+      validation_errors = ProjectValidator.validate(p, schemer)
       if validation_errors.empty?
         projects_without_issues << [p, nil]
       else

--- a/scripts/project_validator.rb
+++ b/scripts/project_validator.rb
@@ -2,19 +2,12 @@
 
 # Represents the checks performed on a project to ensure it can be parsed
 # and used as site data in Jekyll
-class Project
-  attr_accessor :full_path, :relative_path
-
-  def initialize(relative_path, full_path)
-    @relative_path = relative_path
-    @full_path = full_path
-  end
-
-  def validation_errors(schemer)
+class ProjectValidator
+  def self.validate(project, schemer)
     errors = []
 
     begin
-      yaml = YAML.safe_load(File.read(@full_path))
+      yaml = project.read_yaml
     rescue Psych::SyntaxError => e
       errors << "Unable to parse the contents of file - Line: #{e.line}, Offset: #{e.offset}, Problem: #{e.problem}"
     rescue StandardError
@@ -38,7 +31,7 @@ class Project
 
   private
 
-  def format_error(err)
+  def self.format_error(err)
     field = err.fetch('data_pointer')
     value = err.fetch('data')
     type = err.fetch('type')
@@ -94,7 +87,7 @@ class Project
     'react' => 'reactjs'
   }.freeze
 
-  def validate_preferred_tags(tags)
+  def self.validate_preferred_tags(tags)
     errors = []
 
     tags.each do |tag|
@@ -106,7 +99,7 @@ class Project
     errors
   end
 
-  def validate_tags(yaml)
+  def self.validate_tags(yaml)
     errors = []
 
     tags = yaml['tags']

--- a/scripts/project_validator.rb
+++ b/scripts/project_validator.rb
@@ -29,8 +29,6 @@ class ProjectValidator
     errors
   end
 
-  private
-
   def self.format_error(err)
     field = err.fetch('data_pointer')
     value = err.fetch('data')
@@ -114,4 +112,6 @@ class ProjectValidator
 
     errors
   end
+
+  private_class_method :format_error, :validate_preferred_tags, :validate_tags
 end


### PR DESCRIPTION
This PR experiments with using a small piece of the `up_for_grabs_tooling` gem published to https://github.com/up-for-grabs/tooling. I want to be able to be able to share functionality across the infrastructure, and this seems to be the easiest approach.

The upside of moving things out to https://github.com/up-for-grabs/tooling means that I can add tests and better organize things there, and simply require the module here where needed.

 - [x] CI passes
 - [x] no false positives when running suite


