### PR TITLE
workdir is important for docker run

### DIFF
--- a/.github/actions/cleanup-archived-projects/Dockerfile
+++ b/.github/actions/cleanup-archived-projects/Dockerfile
@@ -12,4 +12,4 @@ RUN bundle install
 
 COPY . .
 
-ENTRYPOINT ["bundle", "exec", "ruby", "/cleanup_projects.rb"]
+ENTRYPOINT ["/run.sh"]

--- a/.github/actions/cleanup-archived-projects/Dockerfile
+++ b/.github/actions/cleanup-archived-projects/Dockerfile
@@ -8,6 +8,8 @@ LABEL "com.github.actions.color"="orange"
 
 COPY Gemfile ./
 
+RUN bundle version
+
 RUN bundle install
 
 COPY . .

--- a/.github/actions/cleanup-archived-projects/run.sh
+++ b/.github/actions/cleanup-archived-projects/run.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+cd /
+bundle version
+bundle exec ruby /cleanup_projects.rb

--- a/.github/actions/update-stats/Dockerfile
+++ b/.github/actions/update-stats/Dockerfile
@@ -8,6 +8,8 @@ LABEL "com.github.actions.color"="blue"
 
 COPY Gemfile ./
 
+RUN bundle version
+
 RUN bundle install
 
 COPY . .

--- a/.github/actions/update-stats/Dockerfile
+++ b/.github/actions/update-stats/Dockerfile
@@ -12,4 +12,4 @@ RUN bundle install
 
 COPY . .
 
-ENTRYPOINT ["bundle", "exec", "ruby", "/update_stats.rb"]
+ENTRYPOINT ["/run.sh"]

--- a/.github/actions/update-stats/run.sh
+++ b/.github/actions/update-stats/run.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+cd /
+bundle version
+bundle exec ruby /update_stats.rb

--- a/.github/workflows/cleanup-stale-projects.yml
+++ b/.github/workflows/cleanup-stale-projects.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Cleanup archived projects
-      uses: ./.github/actions/cleanup-archived-projects
+      uses: .github/actions/cleanup-archived-projects
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         APPLY_CHANGES: 1

--- a/.github/workflows/update-project-stats.yml
+++ b/.github/workflows/update-project-stats.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: ./.github/actions/update-stats
+    - uses: .github/actions/update-stats
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         APPLY_CHANGES: 1


### PR DESCRIPTION
I overlooked this when testing locally, but actions on Docker set the workdir to be the root of the repository, which means this is trying to use the `Gemfile` at the root of the repository:

```
/usr/local/lib/ruby/2.6.0/rubygems.rb:283:in `find_spec_for_exe': Could not find 'bundler' (2.0.1) required by your /github/workspace/Gemfile.lock. (Gem::GemNotFoundException)
To update to the latest version installed on your system, run `bundle update --bundler`.
To install the missing version, run `gem install bundler:2.0.1`
	from /usr/local/lib/ruby/2.6.0/rubygems.rb:302:in `activate_bin_path'
	from /usr/local/bin/bundle:23:in `<main>'
```

We want to use the one copied to `/` when running `bundle exec`, so this script ensures we `cd` to the right location first.