### PR TITLE
Revert "no need for this relative path prefix"

### DIFF
--- a/.github/workflows/cleanup-stale-projects.yml
+++ b/.github/workflows/cleanup-stale-projects.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Cleanup archived projects
-      uses: .github/actions/cleanup-archived-projects
+      uses: ./.github/actions/cleanup-archived-projects
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         APPLY_CHANGES: 1

--- a/.github/workflows/update-project-stats.yml
+++ b/.github/workflows/update-project-stats.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: .github/actions/update-stats
+    - uses: ./.github/actions/update-stats
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         APPLY_CHANGES: 1


### PR DESCRIPTION
This reverts commit 94048cb74ae10401268db3169f5242590ebb1ad1 as part of #1635.

I thought it was fine but the Actions runner did not like it:

```
- Your workflow file was invalid: The pipeline is not valid. .github/workflows/cleanup-stale-projects.yml (Line: 11, Col: 13): Expected format {org}/{repo}[/path]@ref. Actual '.github/actions/cleanup-archived-projects',Input string was not in a correct format.
```