### PR TITLE
adding conrad

### DIFF
--- a/_data/projects/conrad.yml
+++ b/_data/projects/conrad.yml
@@ -1,0 +1,12 @@
+---
+name: Conrad
+desc: Conrad (Conference Radar) helps you track conferences and meetups on your terminal.
+site: https://github.com/vinayak-mehta/conrad
+tags:
+- python
+upforgrabs:
+  name: good first issue
+  link: https://github.com/vinayak-mehta/conrad/labels/good%20first%20issue
+stats:
+  issue-count: 9
+  last-updated: '2019-10-28T10:50:40Z'


### PR DESCRIPTION
Conrad is a simple CLI tool to track conferences and meetups on your terminal 

I think it would be a great addition to up-for-grabs : )