### PR TITLE
 Added bundler to the gem install script in Dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ENV JSON_GEM_VERSION 1.8.6
 RUN apk --update add --virtual build_deps \
     build-base ruby-dev libc-dev linux-headers \
   && gem install --verbose --no-document \
+    bundler \
     json:${JSON_GEM_VERSION} \
     github-pages:${GITHUB_GEM_VERSION} \
     jekyll-github-metadata \


### PR DESCRIPTION
I know Jekyll has bundler as a dependency already. But I've had issues on several Windows installs where the Jekyll package script won't build bundler correctly. I think it has something to do with native libraries being used. However, it builds just fine on its own. So I put it in the gem installer command before it calls Jekyll package to mitigate this.