### PR TITLE
[WIP] update and merge stats change in background, without opening a PR

### DIFF
--- a/.github/actions/merge-successful-branch/Dockerfile
+++ b/.github/actions/merge-successful-branch/Dockerfile
@@ -1,0 +1,17 @@
+FROM ruby:2.6-stretch
+
+# Labels for GitHub to read the action
+LABEL "com.github.actions.name"="Merge successful branch"
+LABEL "com.github.actions.description"="When a commit status returns success, merge the related branch if it belongs to one of our scheduled actions."
+LABEL "com.github.actions.icon"="git-merge"
+LABEL "com.github.actions.color"="purple"
+
+COPY Gemfile ./
+
+RUN bundle version
+
+RUN bundle install
+
+COPY . .
+
+ENTRYPOINT ["/run.sh"]

--- a/.github/actions/merge-successful-branch/Gemfile
+++ b/.github/actions/merge-successful-branch/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'octokit'
+gem 'safe_yaml'
+
+gem 'up_for_grabs_tooling', :git => 'https://github.com/up-for-grabs/tooling.git', :branch => 'master'

--- a/.github/actions/merge-successful-branch/merge_successful_branch.rb
+++ b/.github/actions/merge-successful-branch/merge_successful_branch.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'safe_yaml'
+require 'uri'
+require 'octokit'
+require 'pathname'
+
+require 'up_for_grabs_tooling'
+
+repo = ENV['GITHUB_REPOSITORY']
+event_file_path = ENV['GITHUB_EVENT_PATH']
+
+start = Time.now
+
+puts "Inspecting projects files for '#{repo}'"
+
+file = File.open(event_file_path)
+text = file.read
+
+json = text.to_json
+
+puts "Event payload: #{json}"
+
+finish = Time.now
+delta = finish - start
+
+puts "Operation took #{delta}s"
+puts
+
+exit 0

--- a/.github/actions/merge-successful-branch/merge_successful_branch.rb
+++ b/.github/actions/merge-successful-branch/merge_successful_branch.rb
@@ -19,7 +19,18 @@ text = file.read
 
 json = text.to_json
 
-puts "Event payload: #{json}"
+puts "Event payload: '#{json}'"
+
+if json['state'] == 'success'
+
+  branches = json['branches']
+
+  branches_matching_pattern = branches.select { |b| b.name ~= /(updated-stats|deprecated-projects)-[0-9]{8}/i }
+
+  branches_matching_pattern.each do |branch|
+  end
+
+end
 
 finish = Time.now
 delta = finish - start

--- a/.github/actions/merge-successful-branch/run.sh
+++ b/.github/actions/merge-successful-branch/run.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+cd /
+bundle version
+bundle exec ruby /merge_successful_branch.rb

--- a/.github/actions/update-stats/update_stats.rb
+++ b/.github/actions/update-stats/update_stats.rb
@@ -165,10 +165,10 @@ Dir.chdir($root_directory) do
         puts " - #{key}:"
         errors.each { |error| puts "    - #{error}" }
       end
-      puts "Not pushing to default branch. Need to investigate what went wrong."
+      puts 'Not pushing to default branch. Need to investigate what went wrong.'
     else
       system("git commit -am 'regenerated project stats'")
-      system("git push origin gh-pages")
+      system('git push origin gh-pages')
     end
   end
 end

--- a/.github/actions/update-stats/update_stats.rb
+++ b/.github/actions/update-stats/update_stats.rb
@@ -145,6 +145,8 @@ end
 
 clean = true
 
+branch_name = Time.now.strftime('updated-stats-%Y%m%d')
+
 Dir.chdir($root_directory) do
   system('git config --global user.name "github-actions"')
   system('git config --global user.email "github-actions@users.noreply.github.com"')
@@ -167,8 +169,9 @@ Dir.chdir($root_directory) do
       end
       puts 'Not pushing to default branch. Need to investigate what went wrong.'
     else
+      system("git checkout -b #{branch_name}")
       system("git commit -am 'regenerated project stats'")
-      system('git push origin gh-pages')
+      system("git push origin #{branch_name}")
     end
   end
 end

--- a/.github/actions/update-stats/update_stats.rb
+++ b/.github/actions/update-stats/update_stats.rb
@@ -136,9 +136,7 @@ if found_pr
   exit 0
 end
 
-projects = Project.find_in_directory($root_directory)
-
-projects.each { |p| verify_project(p) }
+Project.find_in_directory($root_directory).each { |p| verify_project(p) }
 
 unless $apply_changes
   puts 'APPLY_CHANGES environment variable unset, exiting instead of making a new PR'

--- a/.github/actions/update-stats/update_stats.rb
+++ b/.github/actions/update-stats/update_stats.rb
@@ -145,8 +145,6 @@ end
 
 clean = true
 
-branch_name = Time.now.strftime('updated-stats-%Y%m%d')
-
 Dir.chdir($root_directory) do
   system('git config --global user.name "github-actions"')
   system('git config --global user.email "github-actions@users.noreply.github.com"')

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
     - gh-pages
+    - 'updated-stats-[0-9]+'
 
 jobs:
   docker:

--- a/.github/workflows/merge-successful-branch.yml
+++ b/.github/workflows/merge-successful-branch.yml
@@ -1,0 +1,13 @@
+name: Merge Successful Branch
+
+on: status
+
+jobs:
+  mergeC:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Merge successful branch
+      uses: ./.github/actions/merge-successful-branch
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
It's been over a month since we first enabled stats in the project, and I think I'm ready to leave this running in the background rather than have it open a PR after each run.

- [x] test changes locally before doing any further work
- [x] commit and push to branch matching pattern
- [x] stop creating PR after work is done
- [x] update CI action to run on branches matching this pattern
- [x] create action to run on [`status`](https://help.github.com/en/github/automating-your-workflow-with-github-actions/events-that-trigger-workflows#status-event-status) event
  - [ ] exit if not a `success` event -> something went wrong
  - [ ] find PR associated with branch -> exit if not found
  - [ ] if PR is mergeable, use the [merge API](https://developer.github.com/v3/repos/merging/) to land the commits -> exit if not valid
- [ ] ???
