### PR TITLE
address bug introduced by refactoring

### DIFF
--- a/.github/actions/update-stats/update_stats.rb
+++ b/.github/actions/update-stats/update_stats.rb
@@ -9,7 +9,7 @@ require 'graphql/client/http'
 
 require 'up_for_grabs_tooling'
 
-def update(project, apply_changes)
+def update(project, apply_changes = false)
   return unless project.github_project?
 
   result = GitHubRepositoryLabelActiveCheck.run(project)

--- a/.github/actions/update-stats/update_stats.rb
+++ b/.github/actions/update-stats/update_stats.rb
@@ -80,7 +80,7 @@ end
 
 projects = Project.find_in_directory(root_directory)
 
-projects.each { |p| update(p) }
+projects.each { |p| update(p, apply_changes) }
 
 unless apply_changes
   puts 'APPLY_CHANGES environment variable unset, exiting instead of making a new PR'


### PR DESCRIPTION
This was an unexpected side-effect of #1684 - I eliminated the global `$apply_changes` but forgot to pass it in here. This PR provides two changes:

 - the fix for the issue reported in [the action run](https://github.com/up-for-grabs/up-for-grabs.net/commit/94100d962d9e76a6251553ded7ee4c9b5ff959e3/checks?check_suite_id=307003771)
 - make this second parameter optional, and default it to `false` if not provided