### PR TITLE
add action to check project changes and provide feedback on each PR

### DIFF
--- a/.github/actions/project-analyzer/Dockerfile
+++ b/.github/actions/project-analyzer/Dockerfile
@@ -1,0 +1,17 @@
+FROM ruby:2.6-stretch
+
+# Labels for GitHub to read the action
+LABEL "com.github.actions.name"="Update project stats"
+LABEL "com.github.actions.description"="Use the GitHub API to refresh the stats for the current list of projects."
+LABEL "com.github.actions.icon"="refresh-cw"
+LABEL "com.github.actions.color"="blue"
+
+COPY Gemfile ./
+
+RUN bundle version
+
+RUN bundle install
+
+COPY . .
+
+ENTRYPOINT ["/run.sh"]

--- a/.github/actions/project-analyzer/Dockerfile
+++ b/.github/actions/project-analyzer/Dockerfile
@@ -1,10 +1,10 @@
 FROM ruby:2.6-stretch
 
 # Labels for GitHub to read the action
-LABEL "com.github.actions.name"="Update project stats"
-LABEL "com.github.actions.description"="Use the GitHub API to refresh the stats for the current list of projects."
+LABEL "com.github.actions.name"="Validate pull request"
+LABEL "com.github.actions.description"="Check the new or modified project files and provide guidance if there are issues"
 LABEL "com.github.actions.icon"="refresh-cw"
-LABEL "com.github.actions.color"="blue"
+LABEL "com.github.actions.color"="red"
 
 COPY Gemfile ./
 

--- a/.github/actions/project-analyzer/Gemfile
+++ b/.github/actions/project-analyzer/Gemfile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'octokit'
+gem 'safe_yaml'
+gem 'graphql-client'
+
+gem 'up_for_grabs_tooling', :git => 'https://github.com/up-for-grabs/tooling.git', :branch => 'master'

--- a/.github/actions/project-analyzer/project_analyzer.rb
+++ b/.github/actions/project-analyzer/project_analyzer.rb
@@ -199,7 +199,7 @@ root = ENV['GITHUB_WORKSPACE']
 
 # this file seems to not include the expected `/github` root folder name
 # test this and we may have to adjust these rules
-unless payload_relative_path = ENV['GITHUB_EVENT_PATH']
+unless (payload_relative_path = ENV['GITHUB_EVENT_PATH'])
   puts 'Expected environment variable GITHUB_EVENT_PATH was not set'
   exit 1
 end

--- a/.github/actions/project-analyzer/project_analyzer.rb
+++ b/.github/actions/project-analyzer/project_analyzer.rb
@@ -249,7 +249,7 @@ http = GraphQL::Client::HTTP.new('https://api.github.com/graphql') do
   def headers(_context)
     {
       "User-Agent": 'up-for-grabs-graphql-label-queries',
-      "Authorization": "bearer #{ENV['GITHUB_TOKEN']}"
+      "Authorization": "bearer #{ENV['SHIFTBOT_TOKEN']}"
     }
   end
 end

--- a/.github/actions/project-analyzer/project_analyzer.rb
+++ b/.github/actions/project-analyzer/project_analyzer.rb
@@ -46,7 +46,7 @@ if raw_files.empty?
   exit 0
 end
 
-files = raw_files.map { |f| f.chomp }
+files = raw_files.map(&:chomp)
 
 def repository_check(project)
   result = GitHubRepositoryActiveCheck.run(project)

--- a/.github/actions/project-analyzer/project_analyzer.rb
+++ b/.github/actions/project-analyzer/project_analyzer.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require 'safe_yaml'
+require 'uri'
+require 'octokit'
+require 'pathname'
+
+require 'json_schemer'
+require 'up_for_grabs_tooling'
+
+files = ARGV
+
+if files.empty?
+  puts 'No project files need to be validated'
+  exit 0
+end
+
+root = ENV['GITHUB_WORKSPACE']
+
+schema = Pathname.new("#{root}/schema.json")
+schemer = JSONSchemer.schema(schema)
+
+def repository_check(project)
+  result = GitHubRepositoryActiveCheck.run(project)
+
+  if result[:rate_limited]
+    puts 'This script is currently rate-limited by the GitHub API'
+    puts 'Marking as inconclusive to indicate that no further work will be done here'
+    exit 0
+  end
+
+  return "The GitHub repository '#{project.github_owner_name_pair}' has been marked as archived, which suggests it is not active." if result[:reason] == 'archived'
+
+  return "The GitHub repository '#{project.github_owner_name_pair}' cannot be found. Please confirm the location of the project." if result[:reason] == 'missing'
+
+  return "The GitHub repository '#{result[:old_location]}' is now at '#{result[:location]}'. Please update this project before this is merged." if result[:reason] == 'redirect'
+
+  return "The GitHub repository '#{project.github_owner_name_pair}' could not be confirmed. Error details: #{result[:error]}" if result[:reason] == 'error'
+
+  nil
+end
+
+def find_label(project)
+  yaml = project.read_yaml
+  yaml['upforgrabs']['name']
+end
+
+def label_check(project)
+  result = GitHubRepositoryLabelActiveCheck.run(project)
+
+  if result[:rate_limited]
+    puts 'This script is currently rate-limited by the GitHub API'
+    puts 'Marking as inconclusive to indicate that no further work will be done here'
+    exit 0
+  end
+
+  label = find_label(project)
+
+  return "I couldn't find the GitHub repository '#{project.github_owner_name_pair}' that was used in the `upforgrabs.link` value. Please confirm this is correct or hasn't been mis-typed." if result[:reason] == 'repository-missing'
+
+  if result[:reason] == 'missing'
+    return "The `upforgrabs.name` value '#{label}' isn't in use on the project in GitHub. This might just be a mistake due because of copy-pasting the reference template or be mis-typed. Please check the list of labels at https://github.com/#{project.github_owner_name_pair}/labels and update the project file to use the correct label."
+  end
+
+  yaml = project.read_yaml
+  link = yaml['upforgrabs']['link']
+  url = result[:url]
+
+  link_needs_rewriting = link != url && link.include?('/labels/')
+
+  if link_needs_rewriting
+    return "The label '#{label}' for GitHub repository '#{project.github_owner_name_pair}' does not match the specified `upforgrabs.link` vlaue. Please update it to '#{url}'."
+  end
+
+  nil
+end
+
+def validate_project(project, schemer)
+  message = ''
+
+  validation_errors = ProjectValidator.validate(project, schemer)
+
+  if validation_errors.any?
+    return { project: project, kind: 'validation', validation_errors: validation_errors }
+  end
+
+  # TODO: label suggestions should be their own thing?
+
+  return { project: project, message: message } unless project.github_project?
+
+  repository_error = repository_check(project)
+
+  return { project: project, kind: 'repository', message: repository_error } unless repository_error.nil?
+
+  label_error = label_check(project)
+
+  unless label_error.nil?
+    message += " - #{label_error}"
+    return { project: project, kind: 'label', message: label_error }
+  end
+
+  { project: project, kind: 'valid' }
+end
+
+projects = files.map do |f|
+  full_path = File.join(root, f)
+  Project.new(f, full_path)
+end
+
+# TODO: this shouldn't be run as the result of an action opening the PR
+# TODO: delete earlier comment if made by same author and contains the magic preamble
+
+markdown_body = "<!-- PULL REQUEST ANALYZER GITHUB ACTION -->
+
+:wave: I'm a robot checking the state of this pull request to ensure everything will be fine when merging.
+
+I noticed this PR added or modififed the data files under `_data/projects` so I had a look at what's changed...
+
+"
+
+messages = projects.map { |p| validate_project(p, schemer) }.map do |result|
+  path = result[:project].relative_path
+
+  if result[:kind] == 'valid'
+    "#### `#{path}` :white_check_mark: \nNo problems found, everything should be good to merge!"
+  elsif result[:kind] == 'validation'
+    message = result[:validation_errors].map { |e| "> - #{e}" }.join "\n"
+    "#### `#{path}` :x:\nI had some troubles parsing the project file, or there were fields that are missing that I need. Here's the details:\n#{message}"
+  elsif result[:kind] == 'repository'
+    "#### `#{path}` :x:\n#{result[:message]}"
+  elsif result[:kind] == 'label'
+    "#### `#{path}` :x:\n#{result[:message]}"
+  else
+    "#### `#{path}` :x:\nI got a result of type '#{result[:kind]}' that I don't know how to handle. I need to mention @shiftkey here as he might know more about what happened."
+  end
+end
+
+markdown_body += messages.join("\n\n")
+
+markdown_body += "\n\nAs you make changes to this pull request, I'll re-check things and let you know if this is ready for review."
+
+puts markdown_body
+
+

--- a/.github/actions/project-analyzer/project_analyzer.rb
+++ b/.github/actions/project-analyzer/project_analyzer.rb
@@ -126,7 +126,6 @@ def cleanup_old_comments(client, pull_request_number)
     }
   GRAPHQL
 
-  # TODO: this will need to be updated (or queried from the API) if we change to using the actions token
   login = 'shiftbot'
   type = 'User'
   preamble = '<!-- PULL REQUEST ANALYZER GITHUB ACTION -->'

--- a/.github/actions/project-analyzer/project_analyzer.rb
+++ b/.github/actions/project-analyzer/project_analyzer.rb
@@ -8,47 +8,6 @@ require 'pathname'
 require 'json_schemer'
 require 'up_for_grabs_tooling'
 
-root = ENV['GITHUB_WORKSPACE']
-repo = ENV['GITHUB_REPOSITORY']
-
-schema = Pathname.new("#{root}/schema.json")
-schemer = JSONSchemer.schema(schema)
-
-# this file seems to not include the expected `/github` root folder name
-# test this and we may have to adjust these rules
-unless ENV['GITHUB_EVENT_PATH']
-  puts 'Expected environment variable GITHUB_EVENT_PATH was not set'
-  exit 1
-end
-
-payload_relative_path = ENV['GITHUB_EVENT_PATH']
-
-unless File.exist?(payload_relative_path)
-  puts "Environment variable GITHUB_EVENT_PATH points to file that doesn't exist: #{payload_relative_path}"
-  exit 1
-end
-
-json_text = File.read(payload_relative_path)
-
-obj = JSON.parse(json_text)
-pull_request_number = obj['number']
-base_sha = obj['pull_request']['base']['sha']
-
-diff_output = ''
-
-Dir.chdir(root) do
-  diff_output = `git diff #{base_sha}..#{ENV['GITHUB_SHA']} --name-only -- _data/projects/`
-end
-
-raw_files = diff_output.split("\n")
-
-if raw_files.empty?
-  puts 'No project files need to be validated by this PR'
-  exit 0
-end
-
-files = raw_files.map(&:chomp)
-
 def repository_check(project)
   result = GitHubRepositoryActiveCheck.run(project)
 
@@ -109,14 +68,14 @@ def label_check(project)
   nil
 end
 
-def validate_project(project, schemer)
+def review_project(project, schemer)
   validation_errors = ProjectValidator.validate(project, schemer)
 
   return { project: project, kind: 'validation', validation_errors: validation_errors } if validation_errors.any?
 
   # TODO: label suggestions should be their own thing?
 
-  return { project: project, message: message } unless project.github_project?
+  return { project: project, kind: 'valid' } unless project.github_project?
 
   repository_error = repository_check(project)
 
@@ -129,14 +88,165 @@ def validate_project(project, schemer)
   { project: project, kind: 'valid' }
 end
 
+def cleanup_old_comments(client, pull_request_number)
+  Object.const_set :PullRequestComments, client.parse(<<-'GRAPHQL')
+    query ($owner: String!, $name: String!, $number: Int!) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $number) {
+          comments(first: 50) {
+            nodes {
+              id
+              body
+              author {
+                login
+                __typename
+              }
+            }
+          }
+        }
+      }
+    }
+  GRAPHQL
+
+  repo = ENV['GITHUB_REPOSITORY']
+  owner, name = repo.split('/')
+
+  variables = { owner: owner, name: name, number: pull_request_number }
+
+  response = client.query(PullRequestComments, variables: variables)
+
+  pull_request = response.data.repository.pull_request
+  comments = pull_request.comments
+
+  return unless comments.nodes.any?
+
+  Object.const_set :DeleteIssueComment, client.parse(<<-'GRAPHQL')
+    mutation ($input: DeleteIssueCommentInput!) {
+      deleteIssueComment(input: $input)
+    }
+  GRAPHQL
+
+  # TODO: this will need to be updated (or queried from the API) if we change to using the actions token
+  login = 'shiftbot'
+  type = 'User'
+  preamble = '<!-- PULL REQUEST ANALYZER GITHUB ACTION -->'
+
+  comments.nodes.each do |node|
+    author = node.author
+    match = author.login == login && author.__typename == type && node.body.include?(preamble)
+
+    next unless match
+
+    variables = { input: { id: node.id } }
+    response = client.query(DeleteIssueComment, variables: variables)
+
+    if response.errors.any?
+      message = response.errors[:data].join(', ')
+      puts "Message when deleting commit failed: #{message}"
+    end
+  end
+end
+
+def generate_comment_for_pull_request(projects, schemer)
+  markdown_body = "<!-- PULL REQUEST ANALYZER GITHUB ACTION -->
+
+  :wave: I'm a robot checking the state of this pull request to save the human reveiwers time." \
+  " I noticed this PR added or modififed the data files under `_data/projects/` so I had a look at what's changed.\n\n" \
+  "As you make changes to this pull request, I'll re-run these checks.\n\n"
+
+  messages = projects.compact.map { |p| review_project(p, schemer) }.map do |result|
+    path = result[:project].relative_path
+
+    if result[:kind] == 'valid'
+      "#### `#{path}` :white_check_mark: \nNo problems found, everything should be good to merge!"
+    elsif result[:kind] == 'validation'
+      message = result[:validation_errors].map { |e| "> - #{e}" }.join "\n"
+      "#### `#{path}` :x:\nI had some troubles parsing the project file, or there were fields that are missing that I need.\n\nHere's the details:\n#{message}"
+    elsif result[:kind] == 'repository' || result[:kind] == 'label'
+      "#### `#{path}` :x:\n#{result[:message]}"
+    else
+      "#### `#{path}` :question:\nI got a result of type '#{result[:kind]}' that I don't know how to handle. I need to mention @shiftkey here as he might be able to fix it."
+    end
+  end
+
+  markdown_body + messages.join("\n\n")
+end
+
+def add_comment_to_pull_request(client, subject_id, markdown_body)
+  Object.const_set :AddCommentToPullRequest, client.parse(<<-'GRAPHQL')
+    mutation ($input: AddCommentInput!) {
+      addComment(input: $input) {
+        commentEdge {
+          node {
+            url
+          }
+        }
+      }
+    }
+  GRAPHQL
+
+  variables = { input: { body: markdown_body, subjectId: subject_id } }
+
+  response = client.query(AddCommentToPullRequest, variables: variables)
+
+  return unless response.errors.any?
+
+  message = response.errors[:data].join(', ')
+  puts "Error encountered while trying to add comment: #{message}"
+end
+
+root = ENV['GITHUB_WORKSPACE']
+
+# this file seems to not include the expected `/github` root folder name
+# test this and we may have to adjust these rules
+unless payload_relative_path = ENV['GITHUB_EVENT_PATH']
+  puts 'Expected environment variable GITHUB_EVENT_PATH was not set'
+  exit 1
+end
+
+unless File.exist?(payload_relative_path)
+  puts "Environment variable GITHUB_EVENT_PATH points to file that doesn't exist: '#{payload_relative_path}'"
+  exit 1
+end
+
+json_text = File.read(payload_relative_path)
+
+obj = JSON.parse(json_text)
+pull_request_number = obj['number']
+subject_id = obj['pull_request']['node_id']
+base_sha = obj['pull_request']['base']['sha']
+base_ref = obj['pull_request']['base']['ref']
+default_branch = obj['pull_request']['base']['repo']['default_branch']
+
+unless base_ref == default_branch
+  puts "PR is targeting base branch '#{base_ref}' which is not the default branch. Ignoring..."
+  exit 0
+end
+
+diff_output = ''
+
+Dir.chdir(root) do
+  diff_output = `git diff #{base_sha}..#{ENV['GITHUB_SHA']} --name-only -- _data/projects/`
+end
+
+raw_files = diff_output.split("\n")
+
+files = raw_files.map(&:chomp)
+
+if files.empty?
+  puts 'No project files need to be validated by this PR'
+  exit 0
+end
+
 projects = files.map do |f|
   full_path = File.join(root, f)
+  return nil unless File.exist?(full_path)
+
   Project.new(f, full_path)
 end
 
 http = GraphQL::Client::HTTP.new('https://api.github.com/graphql') do
   def headers(_context)
-    # Optionally set any HTTP headers
     {
       "User-Agent": 'up-for-grabs-graphql-label-queries',
       "Authorization": "bearer #{ENV['GITHUB_TOKEN']}"
@@ -148,101 +258,11 @@ schema = GraphQL::Client.load_schema(http)
 
 client = GraphQL::Client.new(schema: schema, execute: http)
 
-PullRequestComments = client.parse <<-'GRAPHQL'
-  query ($owner: String!, $name: String!, $number: Int!) {
-    repository(owner: $owner, name: $name) {
-      pullRequest(number: $number) {
-        id
-        comments(first: 50) {
-          nodes {
-            id
-            body
-            author {
-              login
-              __typename
-            }
-          }
-        }
-      }
-    }
-  }
-GRAPHQL
+cleanup_old_comments(client, pull_request_number)
 
-owner, name = repo.split('/')
+schema = Pathname.new("#{root}/schema.json")
+schemer = JSONSchemer.schema(schema)
 
-variables = { owner: owner, name: name, number: pull_request_number }
+markdown_body = generate_comment_for_pull_request(projects, schemer)
 
-result = client.query(PullRequestComments, variables: variables)
-
-pull_request = result.data.repository.pull_request
-subject_id = pull_request.id
-comments = pull_request.comments
-
-if comments.nodes.any?
-  # TODO: delete earlier issue comment if made by same author (login == "github-actions" && __typename == "Bot")
-  # and starts with the magic preamble <!-- PULL REQUEST ANALYZER GITHUB ACTION -->
-end
-
-markdown_body = "<!-- PULL REQUEST ANALYZER GITHUB ACTION -->
-
-:wave: I'm a robot checking the state of this pull request to ensure everything will be fine when merging." \
-" I noticed this PR added or modififed the data files under `_data/projects/` so I had a look at what's changed.\n\n" \
-"As you make changes to this pull request, I'll re-run these checks to ensure this can be merged by the time someone reviews it.\n\n"
-
-messages = projects.map { |p| validate_project(p, schemer) }.map do |result|
-  path = result[:project].relative_path
-
-  if result[:kind] == 'valid'
-    "#### `#{path}` :white_check_mark: \nNo problems found, everything should be good to merge!"
-  elsif result[:kind] == 'validation'
-    message = result[:validation_errors].map { |e| "> - #{e}" }.join "\n"
-    "#### `#{path}` :x:\nI had some troubles parsing the project file, or there were fields that are missing that I need. Here's the details:\n#{message}"
-  elsif result[:kind] == 'repository' || result[:kind] == 'label'
-    "#### `#{path}` :x:\n#{result[:message]}"
-  else
-    "#### `#{path}` :question:\nI got a result of type '#{result[:kind]}' that I don't know how to handle. I need to mention @shiftkey here as he might be able to fix it."
-  end
-end
-
-markdown_body += messages.join("\n\n")
-
-puts markdown_body
-
-# add comment to PR
-
-AddCommentToPullRequest = client.parse <<-'GRAPHQL'
-  mutation ($input: AddCommentInput!) {
-    addComment(input: $input) {
-      commentEdge {
-        node {
-          repository {
-            nameWithOwner
-          }
-          issue {
-            number
-          }
-        }
-      }
-    }
-  }
-GRAPHQL
-
-variables = { input: { body: markdown_body, subjectId: subject_id } }
-
-response = client.query(AddCommentToPullRequest, variables: variables)
-
-if data = response.data
-  comment = response.data.comment_edge.node
-  nameWithOwner = comment.repository.name_with_owner
-  number = comment.issue.number
-  puts "a comment should have been created at https://github.com/#{nameWithOwner}/pull/#{number}"
-elsif response.errors.any?
-  puts "got errors from API:"
-  response.errors.each do |error|
-    puts " - #{error}"
-  end
-
-  message = response.errors[:data].join(", ")
-  puts "Message: #{message}"
-end
-
+add_comment_to_pull_request(client, subject_id, markdown_body)

--- a/.github/actions/project-analyzer/run.sh
+++ b/.github/actions/project-analyzer/run.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+bundle version
+
+# get the list of files between $GITHUB_SHA and default branch in $GITHUB_WORKSPACE
+FILES=$(git -C $GITHUB_WORKSPACE diff $DEFAULT_BRANCH..$GITHUB_SHA --name-only -- _data/projects)
+
+bundle exec ruby /project_analyzer.rb $FILES

--- a/.github/actions/project-analyzer/run.sh
+++ b/.github/actions/project-analyzer/run.sh
@@ -2,7 +2,4 @@
 
 bundle version
 
-# get the list of files between $GITHUB_SHA and default branch in $GITHUB_WORKSPACE
-FILES=$(git -C $GITHUB_WORKSPACE diff $DEFAULT_BRANCH..$GITHUB_SHA --name-only -- _data/projects)
-
-bundle exec ruby /project_analyzer.rb $FILES
+bundle exec ruby /project_analyzer.rb

--- a/.github/actions/project-analyzer/run.sh
+++ b/.github/actions/project-analyzer/run.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+cd /
+
 bundle version
 
 bundle exec ruby /project_analyzer.rb

--- a/.github/workflows/project-analyzer.yml
+++ b/.github/workflows/project-analyzer.yml
@@ -1,0 +1,13 @@
+name: Analyze Projects
+
+on: pull_request
+
+jobs:
+  cleanupArchivedProjects:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Analyze modified project files
+      uses: ./.github/actions/project-analyzer
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/project-analyzer.yml
+++ b/.github/workflows/project-analyzer.yml
@@ -3,7 +3,7 @@ name: Analyze Projects
 on: pull_request
 
 jobs:
-  cleanupArchivedProjects:
+  analyze:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/project-analyzer.yml
+++ b/.github/workflows/project-analyzer.yml
@@ -11,3 +11,4 @@ jobs:
       uses: ./.github/actions/project-analyzer
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SHIFTBOT_TOKEN: ${{ secrets.SHIFTBOT_TOKEN }}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,9 +17,3 @@ Metrics/AbcSize:
 
 Metrics/MethodLength:
   Max: 59
-
-Style/GlobalVars:
-  Exclude:
-    - '.github/actions/cleanup-archived-projects/cleanup_projects.rb'
-    - '.github/actions/update-stats/update_stats.rb'
-


### PR DESCRIPTION
This PR adds an action that runs on every `pull_request` event and does a few things:

 - check the PR adds or modifies any files under `_data/projects`
 - parses the files and checks they are valid
 - for GitHub projects, run additional checks that
   - the repository exists and is valid
   - the `label` specified is in use
   - the `label` and `link` are in sync when the project links directly to the label

This is codifying several checks that I've been manually doing up until now, and it'd be great to not have to do this to save time. Ideally this comment will help contributors fix things without needing to dig into the Actions logs to see why something failed...
 