### PR TITLE
adding a new tag that indicates the reviewers have questions

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -5,6 +5,7 @@ pulls:
   daysUntilClose: 1
   onlyLabels:
     - 'needs work'
+    - 'has questions'
   exemptLabels:
     - discussion
   staleLabel: stale


### PR DESCRIPTION
I've been very happy with our `stale` integration that expires PRs after a period of inactivity, and I'd like to add the new label `has questions` to the list.

I've been using this label to indicate that the reviewer has asked questions to help understand the context behind a PR. This is different to using `discussion` to indicate that we understand a PR, but we're gathering feedback about a PR from others to confirm the PR is the right solution to a problem.