### PR TITLE
restore apply_changes environment variable in action

### DIFF
--- a/.github/actions/cleanup-archived-projects/cleanup_projects.rb
+++ b/.github/actions/cleanup-archived-projects/cleanup_projects.rb
@@ -21,7 +21,7 @@ def existing_pull_request?(current_repo)
   end
 end
 
-def cleanup_deprecated_projects(root, current_repo, projects)
+def cleanup_deprecated_projects(root, current_repo, projects, apply_changes)
   client = Octokit::Client.new(access_token: ENV['GITHUB_TOKEN'])
 
   list = ''
@@ -121,7 +121,7 @@ deprecated_projects.each do |r|
 end
 
 if deprecated_projects.any?
-  cleanup_deprecated_projects(root, current_repo, deprecated_projects)
+  cleanup_deprecated_projects(root, current_repo, deprecated_projects, ENV['APPLY_CHANGES'])
 else
   puts 'No deprecated projects found...'
 end


### PR DESCRIPTION
In #1645 I incorrectly removed the `apply_changes` variable, and it wasn't needed until [this run](https://github.com/up-for-grabs/up-for-grabs.net/commit/93756b51749ce8542fe942b0a906a4d17ac99fb4/checks?check_suite_id=336617554) of the `Cleanup stale projects` action.