### PR TITLE
Add RDoc::Generator::SolarFish

### DIFF
--- a/_data/projects/rdoc-generator-solarfish.yml
+++ b/_data/projects/rdoc-generator-solarfish.yml
@@ -1,0 +1,12 @@
+name: RDoc::Generator::SolarFish
+desc: Single-page HTML5 generator for Ruby RDoc.
+site: https://github.com/rbdoc/rdoc-generator-solarfish
+tags:
+- ruby
+- html
+- css
+- scss
+- sass
+upforgrabs:
+  name: help wanted
+  link: https://github.com/rbdoc/rdoc-generator-solarfish/labels/help%20wanted


### PR DESCRIPTION
Add [RDoc::Generator::SolarFish](https://github.com/rbdoc/rdoc-generator-solarfish), single-page HTML5 generator for Ruby RDoc.