### PR TITLE
Revert "adding a new tag that indicates the reviewers have questions"

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -5,7 +5,6 @@ pulls:
   daysUntilClose: 1
   onlyLabels:
     - 'needs work'
-    - 'has questions'
   exemptLabels:
     - discussion
   staleLabel: stale


### PR DESCRIPTION
Reverts up-for-grabs/up-for-grabs.net#1706

I misread the documentation at the time and didn't notice this comment:

> `# Only issues or pull requests with all of these labels are check if stale. Defaults to [] (disabled)`

The `all` here is the bit that I overlooked.

What I think has happened here is that it's only going to look at issues which have both labels, and because they only have one label they're being skipped from cleanup.

Let's back this out for now and see if we can figure out a better solution.