### PR TITLE
Add Mellium

### DIFF
--- a/_data/projects/mellium.yml
+++ b/_data/projects/mellium.yml
@@ -1,0 +1,12 @@
+---
+name: Mellium
+desc: An implementation of XMPP (Jabber) in Go.
+site: https://mellium.im
+tags:
+- go
+- jabber
+- xmpp
+- im
+upforgrabs:
+  name: good first issue
+  link: https://github.com/mellium/xmpp/labels/good%20first%20issue


### PR DESCRIPTION
The [mellium.im/xmpp](https://pkg.go.dev/mellium.im/xmpp?tab=doc) package is an XMPP library in Go. It has various supporting libraries and tools grouped under the [Mellium] project umbrella.

[Mellium]: https://mellium.im/