### PR TITLE
Add httpexpect

### DIFF
--- a/_data/projects/httpexpect.yml
+++ b/_data/projects/httpexpect.yml
@@ -1,0 +1,13 @@
+name: httpexpect
+desc: End-to-end HTTP and REST API testing for Go.
+site: https://github.com/gavv/httpexpect
+tags:
+- go
+- testing
+- http
+- rest
+- json
+- websocket
+upforgrabs:
+  name: help wanted
+  link: https://github.com/gavv/httpexpect/labels/help%20wanted


### PR DESCRIPTION
httpexpect is a Go library for end-to-end HTTP API testing.