### PR TITLE
switch checkout steps to v2

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,13 +10,14 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Build Docker container
       run: docker build .
+
   javascript:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: npm install, lint, and test
       run: |
         npm install
@@ -29,7 +30,7 @@ jobs:
   site:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Ruby 2.6
       uses: actions/setup-ruby@v1
       with:


### PR DESCRIPTION
This PR bumps our checkout step to `checkout@v2` which has some significant improvements for large repositories. 

Not sure how much it'll benefit us, but this might handle #1967 better.