### PR TITLE
add support for opening in Codespaces

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,26 @@
+{
+	"name": "Custom Jekyll",
+
+	"settings": {
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
+	"extensions": [
+		"ms-azuretools.vscode-docker",
+		"rebornix.Ruby"
+	],
+
+	// reuse our existing docker-compose setup
+	"dockerComposeFile": [
+		"docker-compose.yml"
+	],
+
+	// indicate the service we want to connect to
+	"service": "app",
+
+	// this is the default directory to use when connected
+	"workspaceFolder": "/workspace",
+
+	// open the port from the jekyll server here
+	"forwardPorts": [ 4000 ],
+}

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules/
+vendor/

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,8 @@ ENV LC_ALL C.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 
+RUN echo "Testing program is on PATH"
+RUN bash --version
+
 EXPOSE 4000
 CMD bundle install && bundle exec jekyll serve -d /_site --watch --force_polling -H 0.0.0.0 -P 4000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
-app:
-  build: .
-  ports:
-    - '4000:4000'
-  volumes:
-    - .:/app
+version: "3"
+services:
+  app:
+    build: .
+    ports:
+      - "4000:4000"
+    volumes:
+      - ".:/app"


### PR DESCRIPTION
Following on from #2077 I was able to get this project working in Codespaces with this bit of setup:

 - updating the `docker-compose.yml` to a later version
 - adding the `.devcontainer.json` file to use this `docker-compose` setup 

If you have access to the Codepsaces beta, here's how you see this work:

 - Under "Code" in the header of the repository, select "Open with Codespaces"

 - Find the "Remote Explorer" icon in the left sidebar

![remote-containers](https://user-images.githubusercontent.com/359239/82674041-1a71c300-9c19-11ea-8f73-c80be59b91bd.png)

 - In the lower part of the left column, you'll see the Codespaces detail and the port this container has open. Click on 4000 to open the site in a new browser tab.

![open-port](https://user-images.githubusercontent.com/359239/82674429-a97edb00-9c19-11ea-9001-11f75f5f8e60.png)

  - You might have to wait a moment because the container installs dependencies and builds the site at this point, but eventually you should see the Up for Grabs site hosted on Codespaces

![website-on-codespaces](https://user-images.githubusercontent.com/359239/82674042-1a71c300-9c19-11ea-9fa6-12ab54021b2b.png)

It'd be great to get hot reloading working properly, but you can see that changes to the projects are updated after refreshing the page

![edit-and-refresh](https://user-images.githubusercontent.com/359239/82674037-19d92c80-9c19-11ea-92cb-a2bf678f6fd2.png)

