### PR TITLE
Add fixes for opentelemetry names

### DIFF
--- a/_data/projects/opentelemetry-collector-contrib.yml
+++ b/_data/projects/opentelemetry-collector-contrib.yml
@@ -1,5 +1,5 @@
 ---
-name: opentelemetry-collector
+name: opentelemetry-collector-contrib
 desc: >-
   Contrib repository for the OpenTelemetry Collector. OpenTelemetry provides a single set of APIs, libraries,
   agents, and collector services to capture distributed traces and metrics from your application. You

--- a/_data/projects/opentelemetry-cpp.yml
+++ b/_data/projects/opentelemetry-cpp.yml
@@ -21,7 +21,7 @@ tags:
 - jaeger
 - application-insights
 upforgrabs:
-  name: help wanted
-  link: https://github.com/open-telemetry/opentelemetry-cpp/labels/help%20wanted
+  name: good first issue
+  link: https://github.com/open-telemetry/opentelemetry-cpp/labels/good%20first%20issue
 stats:
   issue-count: 0

--- a/_data/projects/opentelemetry-dotnet-contrib.yml
+++ b/_data/projects/opentelemetry-dotnet-contrib.yml
@@ -1,5 +1,5 @@
 ---
-name: opentelemetry-dotnet
+name: opentelemetry-dotnet-contrib
 desc: >-
   The OpenTelemetry .NET Contrib project. OpenTelemetry provides a single set of APIs, libraries, agents,
   and collector services to capture distributed traces and metrics from your application. You can analyze

--- a/_data/projects/opentelemetry-dotnet-instrumentation.yml
+++ b/_data/projects/opentelemetry-dotnet-instrumentation.yml
@@ -1,5 +1,5 @@
 ---
-name: opentelemetry-java-instrumentation
+name: opentelemetry-dotnet-instrumentation
 desc: >-
   OpenTelemetry auto-instrumentation and instrumentation libraries for .NET. OpenTelemetry is a working
   name of a combined OpenCensus and OpenTracing project. It provides a single set of APIs, libraries,

--- a/_data/projects/opentelemetry-go-contrib.yml
+++ b/_data/projects/opentelemetry-go-contrib.yml
@@ -1,5 +1,5 @@
 ---
-name: opentelemetry-go
+name: opentelemetry-go-contrib
 desc: >-
   The OpenTelemetry Go Contrib project. OpenTelemetry provides a single set of APIs, libraries, agents,
   and collector services to capture distributed traces and metrics from your application. You can analyze

--- a/_data/projects/opentelemetry-java-contrib.yml
+++ b/_data/projects/opentelemetry-java-contrib.yml
@@ -1,5 +1,5 @@
 ---
-name: opentelemetry-java
+name: opentelemetry-java-contrib
 desc: >-
   The OpenTelemetry Java Contrib project. OpenTelemetry provides a single set of APIs, libraries, agents,
   and collector services to capture distributed traces and metrics from your application. You can analyze

--- a/_data/projects/opentelemetry-js-contrib.yml
+++ b/_data/projects/opentelemetry-js-contrib.yml
@@ -1,5 +1,5 @@
 ---
-name: opentelemetry-js
+name: opentelemetry-js-contrib
 desc: >-
   The OpenTelemetry JavaScript Contrib project. OpenTelemetry provides a single set of APIs, libraries,
   agents, and collector services to capture distributed traces and metrics from your application. You

--- a/_data/projects/opentelemetry-operator.yml
+++ b/_data/projects/opentelemetry-operator.yml
@@ -20,7 +20,7 @@ tags:
 - jaeger
 - application-insights
 upforgrabs:
-  name: help wanted
-  link: https://github.com/open-telemetry/opentelemetry-operator/labels/help%20wanted
+  name: good first issue
+  link: https://github.com/open-telemetry/opentelemetry-operator/labels/good%20first%20issue
 stats:
   issue-count: 0

--- a/_data/projects/opentelemetry-python-contrib.yml
+++ b/_data/projects/opentelemetry-python-contrib.yml
@@ -1,5 +1,5 @@
 ---
-name: opentelemetry-python
+name: opentelemetry-python-contrib
 desc: >-
   The OpenTelemetry Python Contrib project. OpenTelemetry provides a single set of APIs, libraries, agents,
   and collector services to capture distributed traces and metrics from your application. You can analyze

--- a/_data/projects/opentelemetry.io.yml
+++ b/_data/projects/opentelemetry.io.yml
@@ -21,7 +21,7 @@ tags:
 - jaeger
 - application-insights
 upforgrabs:
-  name: help wanted
-  link: https://github.com/open-telemetry/opentelemetry.io/labels/help%20wanted
+  name: good first issue
+  link: https://github.com/open-telemetry/opentelemetry.io/labels/good%20first%20issue
 stats:
   issue-count: 0


### PR DESCRIPTION
A few of the opentelemetry projects had a wrong name in the file (copy&paste error) 