### PR TITLE
Adding LitmusChaos to Up For Grabs

### DIFF
--- a/_data/projects/LitmusChaos.yaml
+++ b/_data/projects/LitmusChaos.yaml
@@ -3,14 +3,14 @@ name: LitmusChaos
 desc: Litmus is a toolset to do cloud-native chaos engineering
 site: https://github.com/litmuschaos/litmus
 tags:
-- devOps
-- SRE
-- CNCF
-- MayaData
-- Kubernetes
-- Litmus
-- OpenEBS
-- Docker
+- devops
+- sre
+- cncf
+- mayadata
+- kubernetes
+- litmus
+- openebs
+- docker
 - chaos-engineering
 upforgrabs:
   name: good first issue

--- a/_data/projects/LitmusChaos.yaml
+++ b/_data/projects/LitmusChaos.yaml
@@ -1,0 +1,17 @@
+---
+name: LitmusChaos
+desc: Litmus is a toolset to do cloud-native chaos engineering
+site: https://github.com/litmuschaos/litmus
+tags:
+- devOps
+- SRE
+- CNCF
+- MayaData
+- Kubernetes
+- Litmus
+- OpenEBS
+- Docker
+- chaos-engineering
+upforgrabs:
+  name: good first issue
+  link: https://github.com/litmuschaos/litmus/labels/good%20first%20issue


### PR DESCRIPTION
This adds Litmus Chaos to the list of up for grabs repositories

Litmus is a toolset to do cloud-native chaos engineering. Litmus provides tools to orchestrate chaos on Kubernetes to help SREs find weaknesses in their deployments. SREs use Litmus to run chaos experiments initially in the staging environment and eventually in production to find bugs, vulnerabilities. Fixing the weaknesses leads to increased resilience of the system.

More Details about the Litmus could be found [here on the official website](http://litmuschaos.io/)

Signed-off-by: Sayan Mondal <sayanmondal342@gmail.com>