### PR TITLE
Correcting Label Link for Arc.yml

### DIFF
--- a/_data/projects/Arc.yml
+++ b/_data/projects/Arc.yml
@@ -8,4 +8,4 @@ tags:
   - tar
 upforgrabs:
   name: up-for-grabs
-  link: https://github.com/mholt/archiver/issues?q=is%3Aopen+is%3Aissue+label%3Aup-for-grabs
+  link: https://github.com/mholt/archiver/labels/up-for-grabs


### PR DESCRIPTION
@coolaj86 While reviewing I missed that the Label link was wrong. Correcting that with this PR.