### PR TITLE
Add Sentry's .NET SDK project

### DIFF
--- a/_data/projects/sentry.yml
+++ b/_data/projects/sentry.yml
@@ -1,0 +1,10 @@
+name: Sentry .NET SDK
+desc: Client libraries for Sentry, an error reporting and performance monitoring platform, for usage from .NET and popular application frameworks
+site: https://getsentry.github.io/sentry-dotnet
+tags:
+  - crash-reporting
+  - error-logging
+  - performance-monitoring
+upforgrabs:
+  name: up-for-grabs
+  link: https://github.com/getsentry/sentry-dotnet/labels/up-for-grabs


### PR DESCRIPTION
Added Sentry to the list.

cc https://github.com/getsentry/sentry-dotnet/issues/665