### PR TITLE
Add Eclipse OpenJ9 and Eclipse OMR projects

### DIFF
--- a/_data/projects/eclipse-omr.yaml
+++ b/_data/projects/eclipse-omr.yaml
@@ -14,4 +14,4 @@ tags:
   - gc
 upforgrabs:
   name: good first issue
-  link: https://github.com/eclipse/openj9/labels/good%20first%20issue
+  link: https://github.com/eclipse/omr/labels/good%20first%20issue

--- a/_data/projects/eclipse-omr.yaml
+++ b/_data/projects/eclipse-omr.yaml
@@ -1,0 +1,17 @@
+name: Eclipse OMR
+desc: Reliable components for building language runtimes
+site: https://www.eclipse.org/omr
+tags:
+  - c++
+  - c
+  - interpreter
+  - compiler
+  - runtime
+  - jvm
+  - virtual-machine
+  - jit
+  - garbage-collector
+  - gc
+upforgrabs:
+  name: good first issue
+  link: https://github.com/eclipse/openj9/labels/good%20first%20issue

--- a/_data/projects/eclipse-openj9.yaml
+++ b/_data/projects/eclipse-openj9.yaml
@@ -1,0 +1,18 @@
+name: Eclipse OpenJ9
+desc: A fast and efficient JVM that delivers power and performance when you need it most.
+site: https://www.eclipse.org/openj9
+tags:
+  - java
+  - c++
+  - c
+  - interpreter
+  - compiler
+  - runtime
+  - jvm
+  - virtual-machine
+  - jit
+  - garbage-collector
+  - gc
+upforgrabs:
+  name: good first issue
+  link: https://github.com/eclipse/openj9/labels/good%20first%20issue


### PR DESCRIPTION
Hoping to add our 2 projects to the list. We are very active and have many 'good first issues' in both repositories with many developers eager to help newcomers.