### PR TITLE
Update label used for Mermaid

### DIFF
--- a/_data/projects/Mermaid.yml
+++ b/_data/projects/Mermaid.yml
@@ -7,8 +7,8 @@ tags:
 - diagrams
 - charts
 upforgrabs:
-  name: Help wanted!
-  link: https://github.com/mermaid-js/mermaid/labels/Help%20wanted%21
+  name: Good first issue!
+  link: https://github.com/mermaid-js/mermaid/labels/Good%20first%20issue%21
 stats:
   issue-count: 85
   last-updated: '2021-01-25T01:16:48Z'


### PR DESCRIPTION
Hello! 👋

The old "Help wanted!" label has been removed from the [mermaid](https://github.com/mermaid-js/mermaid/labels) repo. It appears that they now they use "Good first issue!" instead.

See:

- [Help wanted!](https://github.com/mermaid-js/mermaid/labels/Help%20wanted%21)
- [Good first issue!](https://github.com/mermaid-js/mermaid/labels/Good%20first%20issue%21)