### PR TITLE
Patch seneca

### DIFF
--- a/_data/projects/seneca.yml
+++ b/_data/projects/seneca.yml
@@ -8,5 +8,7 @@ tags:
 - api
 - microservices
 upforgrabs:
-  name: New Contributor
-  link: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Asenecajs+label%3A%22new+contributor%22+
+  name: Review
+  link: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Asenecajs
+stats: 
+  issue-count: 12

--- a/_data/projects/seneca.yml
+++ b/_data/projects/seneca.yml
@@ -8,5 +8,5 @@ tags:
 - api
 - microservices
 upforgrabs:
-  name: Review
+  name: Doc
   link: https://github.com/senecajs/seneca/labels/doc

--- a/_data/projects/seneca.yml
+++ b/_data/projects/seneca.yml
@@ -4,7 +4,6 @@ desc: A microservices toolkit for Node.js
 site: http://senecajs.org/
 tags:
 - javascript
-- typescript
 - node.js
 - api
 - microservices

--- a/_data/projects/seneca.yml
+++ b/_data/projects/seneca.yml
@@ -9,4 +9,4 @@ tags:
 - microservices
 upforgrabs:
   name: Review
-  link: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Asenecajs
+  link: https://github.com/senecajs/seneca/labels/doc

--- a/_data/projects/seneca.yml
+++ b/_data/projects/seneca.yml
@@ -4,6 +4,7 @@ desc: A microservices toolkit for Node.js
 site: http://senecajs.org/
 tags:
 - javascript
+- typescript
 - node.js
 - api
 - microservices

--- a/_data/projects/seneca.yml
+++ b/_data/projects/seneca.yml
@@ -10,5 +10,3 @@ tags:
 upforgrabs:
   name: Review
   link: https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Asenecajs
-stats: 
-  issue-count: 12

--- a/_data/projects/seneca.yml
+++ b/_data/projects/seneca.yml
@@ -8,5 +8,5 @@ tags:
 - api
 - microservices
 upforgrabs:
-  name: Doc
+  name: doc
   link: https://github.com/senecajs/seneca/labels/doc


### PR DESCRIPTION
New Contributor tag on Github has been removed.  Was switched to Review. 
URL changed to land on Seneca general issues page. 
