### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <a href="https://up-for-grabs.net/"><img width="814" src="https://user-images.githubusercontent.com/359239/67390578-50f83a00-f573-11e9-835d-02eb9e019afb.png"></a>
 
-This repository contains the content for the Up-For-Grabs website.
+This repository contains the content for the [Up-For-Grabs website](https://up-for-grabs.net/), a list of projects with curated tasks for new contributors.
 
 ## List your project
 


### PR DESCRIPTION
Problem: It was not intuitive for me that the banner image and top link was clickable, and that to see the projects I should go to the website as opposed to look through the repo.

Solution: Facilitate the visitor finding the right information, *open source friendly to new contributors resource lists*, by repeating link to website, with a description matching the website.