### PR TITLE
Add the Openverse project

### DIFF
--- a/_data/projects/Openverse.yml
+++ b/_data/projects/Openverse.yml
@@ -14,4 +14,4 @@ tags:
 - airflow
 upforgrabs:
   name: help wanted
-  link: https://github.com/search?q=label%3A%22good+first+issue%22+state%3Aopen+is%3Aissue+repo%3Awordpress%2Fopenverse+repo%3Awordpress%2Fopenverse-frontend+repo%3Awordpress%2Fopenverse-api+repo%3Awordpress%2Fopenverse-catalog+label%3A%22help+wanted%22+state%3Aopen+repo%3Awordpress%2Fopenverse&type=Issues
+  link: https://github.com/wordpress/openverse/labels/help%20wanted

--- a/_data/projects/Openverse.yml
+++ b/_data/projects/Openverse.yml
@@ -14,4 +14,4 @@ tags:
 - airflow
 upforgrabs:
   name: help wanted
-  link: https://github.com/wordpress/openverse/labels/help%20wanted
+  link: https://github.com/WordPress/openverse/labels/help%20wanted

--- a/_data/projects/Openverse.yml
+++ b/_data/projects/Openverse.yml
@@ -1,0 +1,17 @@
+
+name: Openverse
+desc: A search-engine for openly-licensed media, part of the WordPress project
+site: https://wordpress.org/openverse
+tags:
+- python
+- postgresql
+- postgres
+- django
+- sqlalchemy
+- javascript
+- typescript
+- vue
+- airflow
+upforgrabs:
+  name: help wanted
+  link: https://github.com/search?q=label%3A%22good+first+issue%22+state%3Aopen+is%3Aissue+repo%3Awordpress%2Fopenverse+repo%3Awordpress%2Fopenverse-frontend+repo%3Awordpress%2Fopenverse-api+repo%3Awordpress%2Fopenverse-catalog+label%3A%22help+wanted%22+state%3Aopen+repo%3Awordpress%2Fopenverse&type=Issues


### PR DESCRIPTION
Openverse is a search engine for openly-licensed media, part of the WordPress ecosystem.

As the project is comprised of 4 different repositories, I've used the following GitHub search result as the `upforgrabs` link. Please let me know if that is acceptable.