### PR TITLE
Add DeepfakeHTTP

### DIFF
--- a/_data/projects/DeepfakeHTTP.yaml
+++ b/_data/projects/DeepfakeHTTP.yaml
@@ -24,5 +24,5 @@ tags:
 - qa-automation
 - mocks
 upforgrabs:
-  name: Help wanted
+  name: help wanted
   link: https://github.com/xnbox/DeepfakeHTTP/issues?q=label%3A%22help+wanted%22+

--- a/_data/projects/DeepfakeHTTP.yaml
+++ b/_data/projects/DeepfakeHTTP.yaml
@@ -1,0 +1,28 @@
+---
+name: DeepfakeHTTP
+desc: DeepfakeHTTP is a web server that uses HTTP dumps as a source for responses
+site: https://github.com/xnbox/DeepfakeHTTP
+tags:
+- testing
+- mock
+- api
+- graphql
+- http
+- qa
+- demo
+- rest
+- rest-api
+- stub
+- test-automation
+- http-server
+- poc
+- dump
+- testing-tools
+- dummy
+- restful-api
+- spies
+- qa-automation
+- mocks
+upforgrabs:
+  name: Help wanted
+  link: https://github.com/xnbox/DeepfakeHTTP/issues?q=label%3A%22help+wanted%22+


### PR DESCRIPTION
DeepfakeHTTP is a web server that uses HTTP dumps as a source for responses.

https://github.com/xnbox/DeepfakeHTTP
https://github.com/xnbox/DeepfakeHTTP/issues?q=label%3A%22help+wanted%22+