### PR TITLE
Fix CiviWiki link (old domain is now a scam site)

### DIFF
--- a/_data/projects/CiviWiki.yml
+++ b/_data/projects/CiviWiki.yml
@@ -1,7 +1,7 @@
 ---
 name: CiviWiki
 desc: Building a Better Democracy for the Internet Age
-site: https://www.civiwiki.org/
+site: https://civi.wiki
 tags:
 - python
 - django


### PR DESCRIPTION
The old civiwiki.org domain was acquired by a domain harvester and now serves a scam website.