### PR TITLE
Use automation account for stats workflow

### DIFF
--- a/.github/workflows/update-project-stats.yml
+++ b/.github/workflows/update-project-stats.yml
@@ -1,6 +1,8 @@
 on:
   schedule:
   - cron: 0 14 * * *
+  workflow_dispatch:
+
 name: Update project stats
 jobs:
   cleanupArchivedProjects:

--- a/.github/workflows/update-project-stats.yml
+++ b/.github/workflows/update-project-stats.yml
@@ -10,5 +10,5 @@ jobs:
     - uses: actions/checkout@main
     - uses: ./.github/actions/update-stats
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.SHIFTBOT_TOKEN }}
         APPLY_CHANGES: 1

--- a/.github/workflows/update-project-stats.yml
+++ b/.github/workflows/update-project-stats.yml
@@ -11,4 +11,4 @@ jobs:
     - uses: ./.github/actions/update-stats
       env:
         GITHUB_TOKEN: ${{ secrets.SHIFTBOT_TOKEN }}
-        APPLY_CHANGES: 1
+        APPLY_CHANGES: 0


### PR DESCRIPTION
This change is related to how workflows from the `github-actions` token are no longer allowed to run other workflows.

I've switched this over to a token belonging to @shiftbot which I've meant to do for a while, but also disabled `APPLY_CHANGES` to prevent it from submitting PR. Hopefully we can get it back into a good place and figure out what happened with https://github.com/up-for-grabs/up-for-grabs.net/pull/3054