### PR TITLE
extract `TagBuilder` module and wrap in tests

### DIFF
--- a/javascripts/projectsService.js
+++ b/javascripts/projectsService.js
@@ -15,7 +15,7 @@ if (typeof define !== 'function') {
   var define = require('amdefine')(module);
 }
 
-define(['underscore'], (_) => {
+define(['underscore', 'tag-builder'], (_, TagBuilder) => {
   const applyTagsFilter = function (projects, tagsArray, tags) {
     if (typeof tags === 'string') {
       tags = tags.split(',');
@@ -136,38 +136,6 @@ define(['underscore'], (_) => {
 
     // the above statements returns n arrays in an array, which we flatten here and return then
     return _.flatten(results, (arr1, arr2) => arr1.append(arr2));
-  };
-
-  const TagBuilder = function () {
-    const _tagsMap = {};
-    let _orderedTagsMap = null;
-
-    this.addTag = function (tag, projectName) {
-      const tagLowerCase = tag.toLowerCase();
-      if (!_.has(_tagsMap, tagLowerCase)) {
-        _tagsMap[tagLowerCase] = {
-          name: tag,
-          frequency: 0,
-          projects: [],
-        };
-      }
-      const _entry = _tagsMap[tagLowerCase];
-      _entry.frequency += 1;
-      _entry.projects.push(projectName);
-    };
-
-    this.getTagsMap = function () {
-      // https://stackoverflow.com/questions/16426774/underscore-sortby-based-on-multiple-attributes
-      if (_orderedTagsMap == null) {
-        _orderedTagsMap = _(_tagsMap)
-          .chain()
-          .sortBy((tag, key) => key)
-          .sortBy((tag) => tag.frequency * -1)
-          .value();
-      }
-
-      return _orderedTagsMap;
-    };
   };
 
   const extractTags = function (projectsData) {

--- a/javascripts/tag-builder.js
+++ b/javascripts/tag-builder.js
@@ -1,0 +1,56 @@
+/* eslint block-scoped-var: "off" */
+
+/** @typedef {{name: string, frequency: number, projects: Array<unknown>}} TagValue */
+
+// required for loading into a NodeJS context
+if (typeof define !== 'function') {
+  /* eslint-disable-next-line no-var */
+  var define = require('amdefine')(module);
+}
+
+define(['underscore'], (/** @type {import('underscore')} */ _) => {
+  class TagBuilder {
+    constructor() {
+      /** @type {Map<string,TagValue>} */
+      const tagsMap = new Map();
+      /** @type {Array<TagValue>} */
+      let _orderedTagsMap = [];
+
+      this.addTag = function (
+        /** @type {string} */ tag,
+        /** @type {string} */ projectName
+      ) {
+        const tagLowerCase = tag.toLowerCase();
+        const existing = tagsMap.get(tagLowerCase);
+        if (existing) {
+          existing.projects.push(projectName);
+          tagsMap.set(tagLowerCase, {
+            ...existing,
+            frequency: (existing.frequency += 1),
+          });
+        } else {
+          tagsMap.set(tagLowerCase, {
+            name: tag,
+            frequency: 1,
+            projects: [projectName],
+          });
+        }
+      };
+
+      this.getTagsMap = function () {
+        // https://stackoverflow.com/questions/16426774/underscore-sortby-based-on-multiple-attributes
+        if (_orderedTagsMap.length === 0) {
+          _orderedTagsMap = _([...tagsMap.values()])
+            .chain()
+            .sortBy((item) => item.frequency * -1)
+            .sortBy((item) => item.name)
+            .value();
+        }
+
+        return _orderedTagsMap;
+      };
+    }
+  }
+
+  return TagBuilder;
+});

--- a/javascripts/tag-builder.js
+++ b/javascripts/tag-builder.js
@@ -42,8 +42,8 @@ define(['underscore'], (/** @type {import('underscore')} */ _) => {
         if (_orderedTagsMap.length === 0) {
           _orderedTagsMap = _([...tagsMap.values()])
             .chain()
-            .sortBy((item) => item.frequency * -1)
             .sortBy((item) => item.name)
+            .sortBy((item) => item.frequency * -1)
             .value();
         }
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,9 @@ module.exports = {
   transform: {
     '^.+\\.jsx?$': 'babel-jest'
   },
+  moduleNameMapper: {
+    'tag-builder': '<rootDir>javascripts/tag-builder.js'
+  },
   automock: false,
   setupFiles: [
     './tests/setupJest.js'

--- a/tests/spec/TagBuilderSpec.js
+++ b/tests/spec/TagBuilderSpec.js
@@ -26,4 +26,31 @@ describe('ProjectsService', () => {
       },
     ]);
   });
+
+
+  it('orders tags by frequency', () => {
+    tagBuilder.addTag('tag-3', 'tag-3-first');
+    tagBuilder.addTag('tag-3', 'tag-3-third');
+    tagBuilder.addTag('tag-3', 'tag-3-second');
+    tagBuilder.addTag('tag-2', 'tag-2-first');
+    tagBuilder.addTag('tag-2', 'tag-2-second');
+    tagBuilder.addTag('tag-1', 'tag-1-first');
+    expect(tagBuilder.getTagsMap()).toEqual([
+      {
+        name: 'tag-3',
+        frequency: 3,
+        projects: ['tag-3-first', 'tag-3-third', 'tag-3-second'],
+      },
+      {
+        name: 'tag-2',
+        frequency: 2,
+        projects: ['tag-2-first', 'tag-2-second'],
+      },
+      {
+        name: 'tag-1',
+        frequency: 1,
+        projects: ['tag-1-first'],
+      },
+    ]);
+  });
 });

--- a/tests/spec/TagBuilderSpec.js
+++ b/tests/spec/TagBuilderSpec.js
@@ -27,7 +27,6 @@ describe('ProjectsService', () => {
     ]);
   });
 
-
   it('orders tags by frequency', () => {
     tagBuilder.addTag('tag-3', 'tag-3-first');
     tagBuilder.addTag('tag-3', 'tag-3-third');

--- a/tests/spec/TagBuilderSpec.js
+++ b/tests/spec/TagBuilderSpec.js
@@ -1,0 +1,29 @@
+const TagBuilder = require('../../javascripts/tag-builder');
+
+describe('ProjectsService', () => {
+  let tagBuilder;
+
+  beforeEach(() => {
+    tagBuilder = new TagBuilder();
+  });
+
+  it('can add a tag to the builder', () => {
+    tagBuilder.addTag('tag', 'some-project');
+    expect(tagBuilder.getTagsMap()).toEqual([
+      { name: 'tag', frequency: 1, projects: ['some-project'] },
+    ]);
+  });
+
+  it('can merge projects into same tag', () => {
+    tagBuilder.addTag('tag', 'some-project');
+    tagBuilder.addTag('tag', 'another-project');
+    tagBuilder.addTag('tag', 'yet-another-project');
+    expect(tagBuilder.getTagsMap()).toEqual([
+      {
+        name: 'tag',
+        frequency: 3,
+        projects: ['some-project', 'another-project', 'yet-another-project'],
+      },
+    ]);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs",
     "allowJs": true,
     "checkJs": true,


### PR DESCRIPTION
This PR breaks a small piece of `ProjectService` out to it's own module, wraps it in tests and updates the syntax to use a Map as a backing store.