### PR TITLE
Re-add System.IO.Abstractions

### DIFF
--- a/_data/projects/system-io-abstractions.yml
+++ b/_data/projects/system-io-abstractions.yml
@@ -1,0 +1,12 @@
+---
+name: System.IO.Abstractions
+desc: Just like System.Web.Abstractions, but for System.IO. Yay for testable IO access!
+site: https://github.com/TestableIO/System.IO.Abstractions
+tags:
+- c#
+- ".net"
+- io
+- testing
+upforgrabs:
+  name: 'flag: good-first-issue'
+  link: https://github.com/TestableIO/System.IO.Abstractions/labels/flag%3A%20good-first-issue


### PR DESCRIPTION
This reverts #3089 and also updates the up-for-grabs label.

/cc @shiftkey 