### PR TITLE
include filtering of "zero issues" projects alongside ordering

### DIFF
--- a/javascripts/project-ordering.js
+++ b/javascripts/project-ordering.js
@@ -25,12 +25,16 @@ if (typeof define !== 'function') {
 
 define(['underscore'], (/** @type {import('underscore')} */ _) => {
   function orderAllProjects(
-    /** @type {Array<Project>} */ projects,
+    /** @type {Array<Project>} */ sourceProjects,
     /** @type {(length: number) => Array<number>} */ computeOrder
   ) {
-    if (projects.length === 0) {
-      return projects;
+    if (sourceProjects.length === 0) {
+      return sourceProjects;
     }
+
+    const projects = sourceProjects.filter((project) =>
+      project.stats ? project.stats['issue-count'] > 0 : true
+    );
 
     const canStoreOrdering =
       JSON &&

--- a/javascripts/project-ordering.js
+++ b/javascripts/project-ordering.js
@@ -46,6 +46,8 @@ define(['underscore'], (/** @type {import('underscore')} */ _) => {
       return projects;
     }
 
+    const projectsLength = projects.length;
+
     /** @type {Array<number> | null} */
     let ordering = null;
 
@@ -54,13 +56,13 @@ define(['underscore'], (/** @type {import('underscore')} */ _) => {
       ordering = JSON.parse(orderingValue);
 
       // This prevents anyone's page from crashing if a project is removed
-      if (ordering && ordering.length !== projects.length) {
+      if (ordering && ordering.length !== projectsLength) {
         ordering = null;
       }
     }
 
     if (!ordering) {
-      ordering = computeOrder(projects.length);
+      ordering = computeOrder(projectsLength);
       if (canStoreOrdering) {
         window.sessionStorage.setItem('projectOrder', JSON.stringify(ordering));
       }

--- a/javascripts/project-ordering.js
+++ b/javascripts/project-ordering.js
@@ -1,7 +1,21 @@
 /* eslint block-scoped-var: "off" */
 
-/** @typedef {{name:string,desc:string,site:string,tags: Array<string>, upforgrabs: {name:string,link:string}, stats: {issueCount: number,lastUpdated
-: string}}} Project */
+/**
+ * @typedef {{
+ *   name:string,
+ *   desc:string,
+ *   site:string,
+ *   tags: Array<string>,
+ *   upforgrabs: {
+ *     name:string,
+ *     link:string
+ *   },
+ *   stats: {
+ *     'issue-count': number,
+ *     'last-updated': string
+ *   }
+ * }} Project
+ * */
 
 // required for loading into a NodeJS context
 if (typeof define !== 'function') {

--- a/javascripts/projectsService.js
+++ b/javascripts/projectsService.js
@@ -165,12 +165,8 @@ define(['underscore', 'tag-builder', 'project-ordering'], (
     const namesMap = {};
     const labelsMap = {};
 
-    const allProjects = orderAllProjects(_projectsData.projects, (length) =>
+    const projects = orderAllProjects(_projectsData.projects, (length) =>
       _.shuffle(_.range(length))
-    );
-
-    const projects = _.filter(allProjects, (project) =>
-      project.stats ? project.stats['issue-count'] > 0 : true
     );
 
     _.each(_projectsData.tags, (tag) => {

--- a/tests/spec/project-ordering-spec.js
+++ b/tests/spec/project-ordering-spec.js
@@ -59,6 +59,34 @@ describe('orderAllProjects', () => {
     });
   });
 
+  describe('stats filtering', () => {
+    it('when stats missing, item is included', () => {
+      const items = [{ id: 1 }, { id: 2 }, { id: 3 }];
+
+      expect(orderAllProjects(items, () => [0, 2, 1])).toHaveLength(3);
+    });
+
+    it('when stats present and zero issue count, item is ignored', () => {
+      const items = [
+        { id: 1 },
+        { id: 2, stats: { 'issue-count': 0 } },
+        { id: 3 },
+      ];
+
+      expect(orderAllProjects(items, () => [0, 1])).toHaveLength(2);
+    });
+
+    it('when stats missing and issue count greater than zero, item is included', () => {
+      const items = [
+        { id: 1 },
+        { id: 2, stats: { 'issue-count': 3 } },
+        { id: 3 },
+      ];
+
+      expect(orderAllProjects(items, () => [0, 1, 2])).toHaveLength(3);
+    });
+  });
+
   describe('when no local storage available', () => {
     beforeEach(() => {
       Object.defineProperty(globalThis, 'sessionStorage', {


### PR DESCRIPTION
Follow-up to #3116 and merging this logic inside `project-ordering`:

```js
    const projects = sourceProjects.filter((project) =>
      project.stats ? project.stats['issue-count'] > 0 : true
    );
```

Also added some tests to document the behaviour too.