### PR TITLE
refactor dark mode feature into separate module

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,4 +1,4 @@
-<a id="view-mode-a" title="dark-mode"><img id="view-mode" src="/images/Dim-Night.png" onclick=" view_mode() ;"></a>
+<a id="view-mode-a" title="dark-mode"><img id="view-mode" src="/images/Dim-Night.png"/></a>
 <header>
    
     <a id="forkme_banner" href="https://github.com/up-for-grabs/up-for-grabs.net">View on GitHub</a>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -86,31 +86,5 @@
 
   ga('create', 'UA-45897756-1', 'auto');
   ga('send', 'pageview');
-
-  var r = document.querySelector(":root") ;
-  var rs = getComputedStyle(r) ;
-  let root = document.documentElement;
-  var condition=true ;
-  function view_mode()
-  {
-    if(condition)
-    {
-      root.style.setProperty("--body-back","#111111")
-      root.style.setProperty("--body-color","#eeeded")
-      root.style.setProperty("--abs","rgb(37, 37, 37)")
-      condition=false ;
-      document.getElementById("view-mode").src="/images/sun-light.png" ;
-      document.getElementById("view-mode-a").title="light-mode"
-    }
-    else
-    {
-      root.style.setProperty("--body-back","#f9f9f9")
-      root.style.setProperty("--body-color","#303030")
-      root.style.setProperty("--abs","#FFF")
-      condition=true
-      document.getElementById("view-mode").src="/images/Dim-Night.png" ;
-      document.getElementById("view-mode-a").title="dark-mode"
-    }
-  }
 </script>
 <!-- End Google Analytics -->

--- a/javascripts/dark-mode.js
+++ b/javascripts/dark-mode.js
@@ -1,0 +1,47 @@
+/* eslint block-scoped-var: "off" */
+
+/// <reference types="node" />
+
+// required for loading into a NodeJS context
+if (typeof define !== 'function') {
+  var define = require('amdefine')(module);
+}
+
+define([], () => {
+  let condition = true;
+
+  var r = document.querySelector(':root');
+  if (!r) {
+    return;
+  }
+
+  const viewModeElement = document.getElementById('view-mode');
+  if (!viewModeElement) {
+    return;
+  }
+
+  const viewModeAnchor = document.getElementById('view-mode-a');
+  if (!viewModeAnchor) {
+    return;
+  }
+
+  const root = document.documentElement;
+
+  viewModeAnchor.addEventListener('click', () => {
+    if (condition) {
+      root.style.setProperty('--body-back', '#111111');
+      root.style.setProperty('--body-color', '#eeeded');
+      root.style.setProperty('--abs', 'rgb(37, 37, 37)');
+      condition = false;
+      viewModeElement.setAttribute('src', '/images/sun-light.png');
+      viewModeAnchor.title = 'light-mode';
+    } else {
+      root.style.setProperty('--body-back', '#f9f9f9');
+      root.style.setProperty('--body-color', '#303030');
+      root.style.setProperty('--abs', '#FFF');
+      condition = true;
+      viewModeElement.setAttribute('src', '/images/Dim-Night.png');
+      viewModeAnchor.title = 'dark-mode';
+    }
+  });
+});

--- a/javascripts/dark-mode.js
+++ b/javascripts/dark-mode.js
@@ -1,7 +1,5 @@
 /* eslint block-scoped-var: "off" */
 
-/// <reference types="node" />
-
 // required for loading into a NodeJS context
 if (typeof define !== 'function') {
   var define = require('amdefine')(module);
@@ -10,38 +8,42 @@ if (typeof define !== 'function') {
 define([], () => {
   let condition = true;
 
-  var r = document.querySelector(':root');
-  if (!r) {
-    return;
-  }
-
-  const viewModeElement = document.getElementById('view-mode');
-  if (!viewModeElement) {
-    return;
-  }
-
-  const viewModeAnchor = document.getElementById('view-mode-a');
-  if (!viewModeAnchor) {
-    return;
-  }
-
-  const root = document.documentElement;
-
-  viewModeAnchor.addEventListener('click', () => {
-    if (condition) {
-      root.style.setProperty('--body-back', '#111111');
-      root.style.setProperty('--body-color', '#eeeded');
-      root.style.setProperty('--abs', 'rgb(37, 37, 37)');
-      condition = false;
-      viewModeElement.setAttribute('src', '/images/sun-light.png');
-      viewModeAnchor.title = 'light-mode';
-    } else {
-      root.style.setProperty('--body-back', '#f9f9f9');
-      root.style.setProperty('--body-color', '#303030');
-      root.style.setProperty('--abs', '#FFF');
-      condition = true;
-      viewModeElement.setAttribute('src', '/images/Dim-Night.png');
-      viewModeAnchor.title = 'dark-mode';
+  function setupDarkModeListener() {
+    var r = document.querySelector(':root');
+    if (!r) {
+      return;
     }
-  });
+
+    const viewModeElement = document.getElementById('view-mode');
+    if (!viewModeElement) {
+      return;
+    }
+
+    const viewModeAnchor = document.getElementById('view-mode-a');
+    if (!viewModeAnchor) {
+      return;
+    }
+
+    const root = document.documentElement;
+
+    viewModeAnchor.addEventListener('click', () => {
+      if (condition) {
+        root.style.setProperty('--body-back', '#111111');
+        root.style.setProperty('--body-color', '#eeeded');
+        root.style.setProperty('--abs', 'rgb(37, 37, 37)');
+        condition = false;
+        viewModeElement.setAttribute('src', '/images/sun-light.png');
+        viewModeAnchor.title = 'light-mode';
+      } else {
+        root.style.setProperty('--body-back', '#f9f9f9');
+        root.style.setProperty('--body-color', '#303030');
+        root.style.setProperty('--abs', '#FFF');
+        condition = true;
+        viewModeElement.setAttribute('src', '/images/Dim-Night.png');
+        viewModeAnchor.title = 'dark-mode';
+      }
+    });
+  }
+
+  return setupDarkModeListener;
 });

--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -12,6 +12,8 @@ define([
   // chosen is listed here as a dependency because it's used from a jQuery
   // selector, and needs to be ready before this code runs
   'chosen',
+  // this will auto-run and apply the event listeners for dark mode checks
+  'dark-mode',
 ], ($, loadProjects, ProjectsService, fetchIssueCount, _, sammy) => {
   let compiledtemplateFn = null,
     projectsPanel = null;

--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -9,14 +9,24 @@ define([
   'fetchIssueCount',
   'underscore',
   'sammy',
+  // this will auto-run and apply the event listeners for dark mode checks
+  'dark-mode',
   // chosen is listed here as a dependency because it's used from a jQuery
   // selector, and needs to be ready before this code runs
   'chosen',
-  // this will auto-run and apply the event listeners for dark mode checks
-  'dark-mode',
-], ($, loadProjects, ProjectsService, fetchIssueCount, _, sammy) => {
+], (
+  $,
+  loadProjects,
+  ProjectsService,
+  fetchIssueCount,
+  _,
+  sammy,
+  setupDarkModeListener
+) => {
   let compiledtemplateFn = null,
     projectsPanel = null;
+
+  setupDarkModeListener();
 
   const getFilterUrl = function () {
     return location.href.indexOf('/#/filters') > -1


### PR DESCRIPTION
Follow-up to #2885

To allow this feature to be included in our linting and test tools, I've moved it into it's own script and added it to the dependencies for `main` so it gets loaded and launched on startup.

This will clash with #3060 but I think I can merge those changes into how the app currently launches. I need to write some docs on this area as clearly the AMD bits are not well understood.