### PR TITLE
chore/security: Update jQuery 3.4.1 -> 3.6.0

### DIFF
--- a/javascripts/app.js
+++ b/javascripts/app.js
@@ -6,7 +6,7 @@ requirejs.config({
     // external scripts hosted on CDN
     underscore:
       '//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.13.2/underscore-min',
-    jquery: '//cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min',
+    jquery: '//cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min',
     sammy: '//cdnjs.cloudflare.com/ajax/libs/sammy.js/0.7.6/sammy.min',
     chosen: '//cdnjs.cloudflare.com/ajax/libs/chosen/1.8.7/chosen.jquery.min',
     showdown: '//cdnjs.cloudflare.com/ajax/libs/showdown/2.0.0/showdown.min',


### PR DESCRIPTION
Closes https://github.com/up-for-grabs/up-for-grabs.net/issues/3262 

Increases Lighthouse best practice score for the website from an 83 to a 92 by passing the Audit for `Avoids front-end JavaScript libraries with known security vulnerabilities`.


I ran the project locally on docker, seemed fine. Would be nice for someone to double check.

https://blog.jquery.com/2021/03/02/jquery-3-6-0-released/