### PR TITLE
Mellium has moved to Codeberg

### DIFF
--- a/_data/projects/mellium.yml
+++ b/_data/projects/mellium.yml
@@ -9,7 +9,7 @@ tags:
 - im
 upforgrabs:
   name: good first issue
-  link: https://github.com/mellium/xmpp/labels/good%20first%20issue
+  link: https://codeberg.org/mellium/xmpp/issues?labels=57316
 stats:
   issue-count: 13
   last-updated: '2022-06-05T13:08:55Z'


### PR DESCRIPTION
The Mellium project is in the process of moving to Codeberg and just moved the issue tracker over.