### PR TITLE
Adding Scribe-iOS

### DIFF
--- a/_data/projects/scribe-ios.yml
+++ b/_data/projects/scribe-ios.yml
@@ -1,0 +1,13 @@
+name: Scribe-iOS
+desc: Keyboards for language learners with translation, verb conjugation and more!
+site: https://github.com/scribe-org/Scribe-iOS
+tags:
+  - swift
+  - ios
+  - language-learning
+  - wikidata
+  - keyboard
+  - grammar
+upforgrabs:
+  name: good first issue
+  link: https://github.com/scribe-org/Scribe-iOS/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22

--- a/_data/projects/scribe-ios.yml
+++ b/_data/projects/scribe-ios.yml
@@ -10,4 +10,4 @@ tags:
   - grammar
 upforgrabs:
   name: good first issue
-  link: https://github.com/scribe-org/Scribe-iOS/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
+  link: https://github.com/scribe-org/Scribe-iOS/labels/good%20first%20issue


### PR DESCRIPTION
Hi all 👋 Am hoping to get Scribe-iOS onto Up for Grabs :) I've been working on the project for a bit over half a year at this point, and slowly have been getting contributors. Scribe uses Wikidata as a backend, so I've been in active communication with many at Wikimedia about it, and it's  recently been added to the [featured projects for new Wikimedia developers](https://www.mediawiki.org/wiki/New_Developers). It's still very early on for it, but feedback has been great so far, and I'd love to find contributors for both iOS and the WIP Android version.

Would be happy to hear your all's feedback on adding it, and hope the suggested `.yml` file meets the specifications!