### PR TITLE
Add Mautic

### DIFF
--- a/_data/projects/mautic.yml
+++ b/_data/projects/mautic.yml
@@ -1,0 +1,11 @@
+name: Mautic
+desc: An open source marketing automation platform.
+site: https://www.mautic.org
+tags:
+  - mautic
+  - marketing
+  - marketing-automation
+  - php
+upforgrabs:
+  name: good first issue
+  link: https://github.com/mautic/mautic/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22

--- a/_data/projects/mautic.yml
+++ b/_data/projects/mautic.yml
@@ -8,4 +8,4 @@ tags:
   - php
 upforgrabs:
   name: good first issue
-  link: https://github.com/mautic/mautic/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
+  link: https://github.com/mautic/mautic/labels/good%20first%20issue


### PR DESCRIPTION
We would love to add Mautic to your site.

- available maintainers who are interested in guiding new contributors ✅ 
- the project curates a list of small tasks which are ideal for new contributors ✅ 
- maintainers are happy and willing to review and work with new contributors to help them learn more about open source ✅ 

Question: If we also wanted to add our documentation / dev docs, could we do that as well?  Would that mean a separate PR or can we include more than one repo?