### PR TITLE
bump dockerfile base images to ruby 2.7

### DIFF
--- a/.github/actions/cleanup-archived-projects/Dockerfile
+++ b/.github/actions/cleanup-archived-projects/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6-stretch
+FROM ruby:2.7-stretch
 
 # Labels for GitHub to read the action
 LABEL "com.github.actions.name"="Cleanup archived projects"

--- a/.github/actions/update-stats/Dockerfile
+++ b/.github/actions/update-stats/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6-stretch
+FROM ruby:2.7-stretch
 
 # Labels for GitHub to read the action
 LABEL "com.github.actions.name"="Update project stats"


### PR DESCRIPTION
This should fix the errors when trying to install the required gems:

```
  Resolving dependencies...
  Bundler could not find compatible versions for gem "ruby":
    In Gemfile:
      ruby
  
      up_for_grabs_tooling was resolved to 0.1.0, which depends on
        octokit (>= 5.6, < 6.0) was resolved to 5.6.1, which depends on
          ruby (>= 2.7.0)
  The command '/bin/sh -c bundle install' returned a non-zero code: 6
```