### PR TITLE
Add Brain Marks - a Swift project

### DIFF
--- a/_data/projects/brain-marks.yml
+++ b/_data/projects/brain-marks.yml
@@ -1,0 +1,11 @@
+name: Brain Marks
+desc: Open source iOS app to save and categorize tweets. Written with SwiftUI and uses the Twitter API.
+site: https://github.com/mikaelacaron/brain-marks
+tags:
+  - swift
+  - swiftui
+  - ios
+  - twitter
+upforgrabs:
+  name: good first issue
+  link: https://github.com/mikaelacaron/brain-marks/labels/good%20first%20issue


### PR DESCRIPTION
* Add Brain Marks, an open source iOS app that allows users to save and categorize their tweets. This project is written with SwiftUI and uses the Twitter API