### PR TITLE
pass through correct field from library result for potential inactive project

### DIFF
--- a/.github/actions/cleanup-archived-projects/cleanup_projects.rb
+++ b/.github/actions/cleanup-archived-projects/cleanup_projects.rb
@@ -79,7 +79,7 @@ def verify_project(project)
 
   return { project: project, deprecated: true, reason: 'missing' } if result[:reason] == 'missing'
 
-  return { project: project, deprecated: false, reason: 'lack-of-activity', updated_at: result[:updated_at] } if result[:reason] == 'lack-of-activity'
+  return { project: project, deprecated: false, reason: 'lack-of-activity', last_updated: result[:last_updated] } if result[:reason] == 'lack-of-activity'
 
   return { project: project, deprecated: false, reason: 'redirect', old_location: result[:old_location], location: result[:location] } if result[:reason] == 'redirect'
 


### PR DESCRIPTION
In https://github.com/up-for-grabs/tooling/pull/201 we used `last_updated` instead of `updated_at` which is why the first result shown was undefined. 

This should correct that issue and attach the right metadata to the workflow run.