### PR TITLE
Fix project link for Opencast Editor

### DIFF
--- a/_data/projects/opencast-editor.yml
+++ b/_data/projects/opencast-editor.yml
@@ -9,7 +9,7 @@ tags:
 - opencast
 upforgrabs:
   name: good first issue
-  link: https://github.com/opencast/opencast/labels/good%20first%20issue
+  link: https://github.com/opencast/opencast-editor/labels/good%20first%20issue
 stats:
   issue-count: 16
   last-updated: '2022-10-06T16:59:01Z'


### PR DESCRIPTION
The PR #3454 had a small error and was pointing towards Opencast (https://github.com/opencast/opencast). This commit fixes the link, now it points to the Opencast Editor (https://github.com/opencast/opencast-editor).