### PR TITLE
Updated tag used for Bitwarden Mobile

### DIFF
--- a/_data/projects/bitwarden-mobile.yml
+++ b/_data/projects/bitwarden-mobile.yml
@@ -15,8 +15,5 @@ tags:
 - xamarin
 - bitwarden
 upforgrabs:
-  name: help wanted
-  link: https://github.com/bitwarden/mobile/labels/help%20wanted
-stats:
-  issue-count: 1
-  last-updated: '2022-09-22T13:06:41Z'
+  name: good first issue
+  link: https://github.com/bitwarden/mobile/labels/good%20first%20issue


### PR DESCRIPTION
Makes more sense to use the label "good first issue" which is used across all Bitwarden repositories