### PR TITLE
Updated tag used for Bitwarden Server

### DIFF
--- a/_data/projects/bitwarden-server.yml
+++ b/_data/projects/bitwarden-server.yml
@@ -14,7 +14,5 @@ tags:
 - cross-platform
 - bitwarden
 upforgrabs:
-  name: help wanted
-  link: https://github.com/bitwarden/server/labels/help%20wanted
-stats:
-  issue-count: 0
+  name: good first issue
+  link: https://github.com/bitwarden/server/labels/good%20first%20issue


### PR DESCRIPTION
Makes more sense to use the label "good first issue" which is used across all Bitwarden repositories