### PR TITLE
Adding NotesApp-KMM-Clean Project to the List

### DIFF
--- a/_data/projects/NotesApp-KMM-CLEAN
+++ b/_data/projects/NotesApp-KMM-CLEAN
@@ -1,0 +1,16 @@
+name: Notes App (KMM/CLEAN)
+desc: Notes App is a simple app to takes notes of everyday tasks. It's based on KMM (Kotlin Multiplatform Mobile). The main objective of this repo is to keep track of the new trends in the KMM space, since it's a fairly new arena, and use it as a reference point for the new projects.
+site: https://example.org/your-project-link-here
+tags:
+  - kmm
+  - kotlin-multiplatform-mobile
+  - android
+  - ios
+  - kotlin
+  - swift
+  - kotlin-andoid
+  - swift-ios
+  - notesapp
+upforgrabs:
+  name: up for grabs
+  link: https://github.com/Ahsan221B/NotesAppKMMCLEAN/labels/up%20for%20grabs

--- a/_data/projects/NotesApp-KMM-CLEAN
+++ b/_data/projects/NotesApp-KMM-CLEAN
@@ -1,6 +1,6 @@
 name: Notes App (KMM/CLEAN)
 desc: Notes App is a simple app to takes notes of everyday tasks. It's based on KMM (Kotlin Multiplatform Mobile). The main objective of this repo is to keep track of the new trends in the KMM space, since it's a fairly new arena, and use it as a reference point for the new projects.
-site: https://example.org/your-project-link-here
+site: https://github.com/Ahsan221B/NotesAppKMMCLEAN/
 tags:
   - kmm
   - kotlin-multiplatform-mobile


### PR DESCRIPTION
I believe my project would be a great fit for the Up for Grabs program because it will allow different Native Mobile App Developers to collect and bring something out of the KMM. It will allow new comers to follow a more modern architecture right off the bat and allow seasonal developers to define a great architecture that could be generalized for both Android and iOS development.

Please let me know if you have any feedback, whatsoever, about the template.