### PR TITLE
Removing the background behind main headings

### DIFF
--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -202,7 +202,7 @@ h1 {
 }
 
 .block h1 {
-  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='5' height='5'%3E%3Crect width='5' height='5' fill='transparent'/%3E%3Cpath d='M0 5L5 0ZM6 4L4 6ZM-1 1L1 -1Z' stroke='%23888' stroke-width='1'/%3E%3C/svg%3E");
+  
   text-align: center;
   /* text-shadow:
     1px 1px 0 #225B7D; */


### PR DESCRIPTION
The background behind main headings in the website seems a bit dull and removing it makes the content blocks look neater. However this is subjected to the personal opinions/taste of the authorisers.
Before - 
![image](https://user-images.githubusercontent.com/114301176/197102473-93bbd3f4-9b3c-4a45-a279-b9cefe0bc562.png)

After-
![image](https://user-images.githubusercontent.com/114301176/197102558-71246e41-71ab-4dff-8124-6ee03dbfd3ec.png)
