### PR TITLE
Add roc-go

### DIFF
--- a/_data/projects/RocGo.yml
+++ b/_data/projects/RocGo.yml
@@ -1,0 +1,13 @@
+---
+name: Roc Go
+desc: Go bindings for Roc Toolkit
+site: https://github.com/roc-streaming/roc-go
+tags:
+- go
+- bindings
+- audio
+- streaming
+- networking
+upforgrabs:
+  name: help wanted
+  link: https://github.com/roc-streaming/roc-go/labels/help%20wanted

--- a/_data/projects/RocGo.yml
+++ b/_data/projects/RocGo.yml
@@ -1,6 +1,6 @@
 ---
 name: Roc Go
-desc: Go bindings for Roc Toolkit
+desc: Go bindings for Roc Toolkit (real-time audio streaming)
 site: https://github.com/roc-streaming/roc-go
 tags:
 - go


### PR DESCRIPTION
[roc-go](https://github.com/roc-streaming/roc-go) provides Go bindings for [Roc Toolkit](https://github.com/roc-streaming/roc-toolkit).

We recently released the first version of the bindings and now are looking for help, mostly with adding more tests.