### PR TITLE
bring PR validation into repository using actions

### DIFF
--- a/.github/workflows/review-project-changes.yml
+++ b/.github/workflows/review-project-changes.yml
@@ -1,0 +1,27 @@
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+name: Review project changes
+jobs:
+  reviewProjectChanges:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout PR tip
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+          cache-version: 0
+
+      - name: Run script to review changed projects
+        run: bundle exec ruby scripts/review_changes.rb
+        env:
+          BASE_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.base.sha }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}

--- a/scripts/review_changes.rb
+++ b/scripts/review_changes.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'safe_yaml'
+require 'uri'
+require 'octokit'
+require 'pathname'
+require 'graphql/client'
+require 'graphql/client/http'
+
+require 'open3'
+
+require 'up_for_grabs_tooling'
+
+start = Time.now
+
+base_sha = ENV.fetch('BASE_SHA', nil)
+head_sha = ENV.fetch('HEAD_SHA', nil)
+dir = ENV.fetch('GITHUB_WORKSPACE', nil)
+
+range = "#{base_sha}...#{head_sha}"
+
+warn "Inspecting projects files that have changed for '#{range}' at '#{dir}'"
+
+result = run "git -C '#{dir}' diff #{range} --name-only -- _data/projects/"
+unless result[:exit_code].zero?
+  warn "Unable to compute diff range: #{range}..."
+  lwarn "stderr: #{result[:stderr]}"
+end
+
+raw_files = result[:stdout].split("\n")
+
+files = raw_files.map(&:chomp)
+
+if files.empty?
+  logger.info 'No project files have been included in this PR...'
+  break
+end
+
+logger.info "Found files in this PR to process: '#{files}'"
+
+markdown_body = PullRequestValidator.generate_comment(dir, files, initial_message: true)
+
+logger.info "Comment to submit: #{markdown_body}"
+
+finish = Time.now
+delta = finish - start
+
+warn "Operation took #{delta}s"
+
+exit 0


### PR DESCRIPTION
This integration was previously running on a webhook and external service (because it pre-dates `pull_request_target`) but I've had to decommission that service and at this point I don't feel like recreating it.

So to start this off I'm going to integrate the read-only version and ensure this passes for some test PRs. Then I'll look at enabling the PR messaging that the original version did.