### PR TITLE
Add Nasqueron

### DIFF
--- a/_data/projects/nasqueron.yml
+++ b/_data/projects/nasqueron.yml
@@ -15,6 +15,3 @@ tags:
 upforgrabs:
   name: good first issue
   link: https://devcentral.nasqueron.org/tag/good-first-issue/
-stats:
-  issue-count: 33
-  last-updated: 2023-05-27T16:31:03Z

--- a/_data/projects/nasqueron.yml
+++ b/_data/projects/nasqueron.yml
@@ -1,0 +1,20 @@
+---
+name: Nasqueron
+desc: Budding community of creative people, writers, developers and thinkers
+site: https://join.nasqueron.org/
+tags:
+- php
+- rust
+- python
+- javascript
+- node.js
+- docker
+- automation
+- devops
+- infrastructure
+upforgrabs:
+  name: good first issue
+  link: https://devcentral.nasqueron.org/tag/good-first-issue/
+stats:
+  issue-count: 33
+  last-updated: 2023-05-27T16:31:03Z


### PR DESCRIPTION
Tasks are curated on a column-based board on a Phabricator instance.