### PR TITLE
Add LinkFree Generator

### DIFF
--- a/_data/projects/linkfree-gen.yml
+++ b/_data/projects/linkfree-gen.yml
@@ -1,0 +1,15 @@
+---
+name: LinkFree Generator
+desc: A form to generate your own self-hosted linktree
+site: https://github.com/chriskthomas/linkfree-generator
+tags:
+- javascript
+- php
+- open-source
+- static-site-generator
+- website-generator
+- social-links
+- upforgrabs
+upforgrabs:
+  name: help wanted
+  link: https://github.com/chriskthomas/linkfree-generator/labels/help%20wanted


### PR DESCRIPTION
Add LinkFree Generator, the simplest self-hosted linktree alternative.

I think that this is a good contribution because the code base is extremely simple and easy to understand for newcomers. This is about as simple as one can get while still making something useful. There are already a few users and I hope that the project can grow more with new features after the recent source code release.