### PR TITLE
Update gitlab.yml

### DIFF
--- a/_data/projects/gitlab.yml
+++ b/_data/projects/gitlab.yml
@@ -11,7 +11,7 @@ tags:
 - javascript
 - vuejs
 - web
-- golang
+- go
 - terraform
 - devops
 - devsecops

--- a/_data/projects/gitlab.yml
+++ b/_data/projects/gitlab.yml
@@ -1,17 +1,21 @@
 ---
 name: GitLab
 desc: >-
-  GitLab is the first single application for the entire DevOps lifecycle.  Everyone can contribute to
+  GitLab is the most comprehensive AI-powered DevSecOps Platform. Everyone can contribute to
   GitLab
 site: https://about.gitlab.com
 tags:
-- oss
 - git
-- issues
 - ruby
 - rails
 - javascript
+- vuejs
 - web
+- golang
+- terraform
+- devops
+- devsecops
+- ai
 upforgrabs:
-  name: Accepting merge requests
-  link: https://gitlab.com/groups/gitlab-org/-/issues?state=opened&label_name[]=Accepting%20merge%20requests
+  name: Seeking Community Contributions
+  link: https://gitlab.com/groups/gitlab-org/-/issues/?sort=created_date&state=opened&label_name%5B%5D=Seeking%20community%20contributions&first_page_size=100


### PR DESCRIPTION
GitLab changed the label used to identify issues that are explicitly open to community contribution. At GitLab, all others issues are also open to contribute to, but the chance of those getting accepted by the maintainers has not been validated yet.