### PR TITLE
Add Monster Hunter Now Events to the Project List

### DIFF
--- a/_data/projects/monster-hunter-now-events.yml
+++ b/_data/projects/monster-hunter-now-events.yml
@@ -1,0 +1,15 @@
+name: Monster Hunter Now Events
+desc: A javascript powered calendar subscription for events that Monster Hunter Now is running.
+site: https://github.com/seriouslysean/monster-hunter-now-events
+tags:
+  - calendar-ics
+  - chatgpt-api
+  - hacktoberfest
+  - ics
+  - javascript
+  - monster-hunter-now
+  - monster-hunter
+  - nodejs
+upforgrabs:
+  name: good first issue
+  link: https://github.com/seriouslysean/monster-hunter-now-events/labels/good%20first%20issue

--- a/_data/projects/monster-hunter-now-events.yml
+++ b/_data/projects/monster-hunter-now-events.yml
@@ -9,7 +9,7 @@ tags:
   - javascript
   - monster-hunter-now
   - monster-hunter
-  - nodejs
+  - node.js
 upforgrabs:
   name: good first issue
   link: https://github.com/seriouslysean/monster-hunter-now-events/labels/good%20first%20issue


### PR DESCRIPTION
I verified all the links work and point to logical locations.

Site: https://github.com/seriouslysean/monster-hunter-now-events
Issues: https://github.com/seriouslysean/monster-hunter-now-events/labels/good%20first%20issue