### PR TITLE
Fix upforgrabs link for Openfire

### DIFF
--- a/_data/projects/Openfire.yml
+++ b/_data/projects/Openfire.yml
@@ -12,4 +12,4 @@ tags:
 - server
 upforgrabs:
   name: Teaser Tasks
-  link: https://issues.igniterealtime.org/issues/?filter=11915
+  link: https://igniterealtime.atlassian.net/issues/?filter=10004


### PR DESCRIPTION
Old URL didn't work anymore.