### PR TITLE
Update upforgrabs URL for Spark

### DIFF
--- a/_data/projects/Spark.yml
+++ b/_data/projects/Spark.yml
@@ -13,4 +13,4 @@ tags:
 - client
 upforgrabs:
   name: Teaser Tasks
-  link: https://issues.igniterealtime.org/issues/?filter=11913
+  link: https://igniterealtime.atlassian.net/issues/?filter=10005


### PR DESCRIPTION
The old URL doesn't work anymore.