### PR TITLE
Add codespell integration for spell checking

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,17 @@
+name: Codespell Check
+
+on:
+  pull_request:
+    branches:
+      - gh-pages
+
+jobs:
+  codespell:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install codespell
+        run: pip install codespell
+      - name: Run codespell
+        run: codespell

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install codespell
         run: pip install codespell
       - name: Run codespell

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,7 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "prettier.enable": true
 }


### PR DESCRIPTION
This pull request adds codespell integration to the project, enabling automated spell checking for common misspellings in the source code. By running codespell on each pull request targeting the gh-pages branch.

closes #4555 