### PR TITLE
cleanup all mentions of ruby 3.2

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,1 +1,3 @@
-BUNDLE_PATH: ./vendor/bundle
+---
+BUNDLE_PATH: "./vendor/bundle"
+BUNDLE_FROZEN: "false"

--- a/.github/workflows/cleanup-stale-projects.yml
+++ b/.github/workflows/cleanup-stale-projects.yml
@@ -19,9 +19,8 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@a6e6f86333f0a2523ece813039b8b4be04560854
         with:
-          ruby-version: '3.2'
           bundler-cache: true
-          cache-version: 0
+
       - name: Run script to cleanup inactive projects
         run: bundle exec ruby scripts/cleanup_projects.rb
         env:

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -23,9 +23,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@a6e6f86333f0a2523ece813039b8b4be04560854
         with:
-          ruby-version: '3.2' # Not needed with a .ruby-version file
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-          cache-version: 0 # Increment this number if you need to re-download cached gems
+          bundler-cache: true
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/review-project-changes.yml
+++ b/.github/workflows/review-project-changes.yml
@@ -17,7 +17,6 @@ jobs:
         uses: ruby/setup-ruby@a6e6f86333f0a2523ece813039b8b4be04560854
         with:
           bundler-cache: true
-          cache-version: 0
 
       - name: Run script to review changed projects
         id: run_script

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,7 +212,6 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
     uri (0.13.0)
-    wdm (0.1.1)
     webrick (1.8.1)
 
 PLATFORMS
@@ -250,15 +249,13 @@ DEPENDENCIES
   jekyll
   json_schemer
   octokit
-  raka
   rubocop
   safe_yaml
   up_for_grabs_tooling!
-  wdm (>= 0.1.0)
   webrick
 
 RUBY VERSION
    ruby 3.3.3p89
 
 BUNDLED WITH
-   2.5.11
+   2.5.17


### PR DESCRIPTION
On top of updating all those references, we see some weirdness with the lockfile.

This might help:

```
 bundle update --bundler
```