### PR TITLE
bugfix: remove any configured i18n paths

### DIFF
--- a/scripts/review_changes.rb
+++ b/scripts/review_changes.rb
@@ -7,6 +7,10 @@ require 'pathname'
 require 'graphql/client'
 require 'graphql/client/http'
 
+require 'i18n'
+# this clears the default paths, which are related to activesupport and unrelated to json_schemer
+I18n.load_path.clear
+
 require 'open3'
 
 require 'up_for_grabs_tooling'


### PR DESCRIPTION
This fixes the automation error when reviewing projects where it tries to resolve some i18n messages:

```
raise InvalidLocaleData.new(filename, e.inspect)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	from /home/runner/work/up-for-grabs.net/up-for-grabs.net/vendor/bundle/ruby/3.3.0/gems/i18n-1.14.6/lib/i18n/backend/base.rb:261:in `load_yml'
	from /home/runner/work/up-for-grabs.net/up-for-grabs.net/vendor/bundle/ruby/3.3.0/gems/i18n-1.14.6/lib/i18n/backend/base.rb:243:in `load_file'
	from /home/runner/work/up-for-grabs.net/up-for-grabs.net/vendor/bundle/ruby/3.3.0/gems/i18n-1.14.6/lib/i18n/backend/base.rb:[17](https://github.com/up-for-grabs/up-for-grabs.net/actions/runs/12070605627/job/33660473978?pr=4928#step:4:18):in `block in load_translations'
	from /home/runner/work/up-for-grabs.net/up-for-grabs.net/vendor/bundle/ruby/3.3.0/gems/i[18](https://github.com/up-for-grabs/up-for-grabs.net/actions/runs/12070605627/job/33660473978?pr=4928#step:4:19)n-1.14.6/lib/i18n/backend/base.rb:16:in `each'
	from /home/runner/work/up-for-grabs.net/up-for-grabs.net/vendor/bundle/ruby/3.3.0/gems/i18n-1.14.6/lib/i18n/backend/base.rb:16:in `load_translations'
	from /home/runner/work/up-for-grabs.net/up-for-grabs.net/vendor/bundle/ruby/3.3.0/gems/i18n-1.14.6/lib/i18n/backend/simple.rb:84:in `init_translations'
	from /home/runner/work/up-for-grabs.net/up-for-grabs.net/vendor/bundle/ruby/3.3.0/gems/i18n-1.14.6/lib/i18n/backend/simple.rb:94:in `lookup'
	from /home/runner/work/up-for-grabs.net/up-for-grabs.net/vendor/bundle/ruby/3.3.0/gems/i18n-1.14.6/lib/i18n/backend/base.rb:72:in `exists?'
	from /home/runner/work/up-for-grabs.net/up-for-grabs.net/vendor/bundle/ruby/3.3.0/gems/i18n-1.14.6/lib/i18n.rb:270:in `exists?'
	from /home/runner/work/up-for-grabs.net/up-for-grabs.net/vendor/bundle/ruby/3.3.0/gems/json_schemer-2.3.0/lib/json_schemer/result.rb:59:in `i18n?'
	from /home/runner/work/up-for-grabs.net/up-for-grabs.net/vendor/bundle/ruby/3.3.0/gems/json_schemer-2.3.0/lib/json_schemer/result.rb:46:in `error'
	from /home/runner/work/up-for-grabs.net/up-for-grabs.net/vendor/bundle/ruby/3.3.0/gems/json_schemer-2.3.0/lib/json_schemer/result.rb:115:in `to_classic'
	from /home/runner/work/up-for-grabs.net/up-for-grabs.net/vendor/bundle/ruby/3.3.0/gems/json_schemer-2.3.0/lib/json_schemer/result.rb:179:in `block in classic'
	from /home/runner/work/up-for-grabs.net/up-for-grabs.net/vendor/bundle/ruby/3.3.0/bundler/gems/tooling-e515105703e1/lib/validators/schema.rb:28:in `each'
	from /home/runner/work/up-for-grabs.net/up-for-grabs.net/vendor/bundle/ruby/3.3.0/bundler/gems/tooling-e515105703e1/lib/validators/schema.rb:28:in `each'
	from /home/runner/work/up-for-grabs.net/up-for-grabs.net/vendor/bundle/ruby/3.3.0/bundler/gems/tooling-e515105703e1/lib/validators/schema.rb:28:in `to_a'
	from /home/runner/work/up-for-grabs.net/up-for-grabs.net/vendor/bundle/ruby/3.3.0/bundler/gems/tooling-e515105703e1/lib/validators/schema.rb:28:in `validate'
	from scripts/review_changes.rb:95:in `review_project'
	from scripts/review_changes.rb:88:in `block in generate_review_comment'
	from scripts/review_changes.rb:88:in `map'
	from scripts/review_changes.rb:88:in `generate_review_comment'
	from scripts/review_changes.rb:[27](https://github.com/up-for-grabs/up-for-grabs.net/actions/runs/12070605627/job/33660473978?pr=4928#step:4:28)9:in `<main>'
```

These files are not relevant to the script, so I'm not sure why they're being pulled in here...