### PR TITLE
update project stats in background

### DIFF
--- a/.github/workflows/review-project-changes.yml
+++ b/.github/workflows/review-project-changes.yml
@@ -28,7 +28,6 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
           GIT_REMOTE_URL: ${{ github.event.pull_request.head.repo.clone_url }}
           GITHUB_TOKEN: ${{ secrets.SHIFTBOT_TOKEN }}
 

--- a/.github/workflows/update-project-stats-scheduled.yml
+++ b/.github/workflows/update-project-stats-scheduled.yml
@@ -24,6 +24,7 @@ jobs:
         run: bundle exec ruby scripts/update_stats_only.rb
         env:
           GITHUB_TOKEN: ${{ secrets.SHIFTBOT_TOKEN }}
+          APPLY_CHANGES: true
 
       - name: Preview git difference
         run: |

--- a/.github/workflows/update-project-stats-scheduled.yml
+++ b/.github/workflows/update-project-stats-scheduled.yml
@@ -1,0 +1,67 @@
+name: Update project stats (scheduled)
+
+on:
+  workflow_dispatch: 
+  schedule:
+    # runs at 1300 daily
+    - cron: '0 13 * * *'
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@a2bbe5b1b236842c1cb7dd11e8e3b51e0a616acc
+        with:
+          bundler-cache: true
+          cache-version: 0
+
+      - name: Update stats for all projects
+        run: bundle exec ruby scripts/update_stats_only.rb
+        env:
+          GITHUB_TOKEN: ${{ secrets.SHIFTBOT_TOKEN }}
+
+      - name: Preview git difference
+        run: |
+          git status
+          git diff _data/projects/
+
+      - name: Commit the changes (if any)
+        id: git_commit
+        run: |
+          echo 'BASE=$(git rev-parse HEAD)' >> "$GITHUB_OUTPUT"
+          git status
+          changes=$(git diff --name-only _data/projects/ | wc -l)
+          if [[ $changes -eq 0 ]]; then
+            echo "There are no changes to commit. Exiting..."
+            echo 'CHANGES=false' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo 'CHANGES=true' >> "$GITHUB_OUTPUT"
+
+          git config user.name "shiftbot"
+          git config user.email "12331315+shiftbot@users.noreply.github.com"
+
+          git add _data/projects/
+          git commit -m "Update project stats (`date`)"
+          echo 'HEAD=$(git rev-parse HEAD)' >> "$GITHUB_OUTPUT"
+
+      - name: Validate all changed projects
+        run: bundle exec ruby scripts/review_changes.rb
+        if: ${{ steps.git_commit.outputs.CHANGES }}
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          GITHUB_TOKEN: ${{ secrets.SHIFTBOT_TOKEN }}
+
+      # TODO: git push
+      - name: Push the changes to the default branch (if any)
+        if: ${{ steps.git_commit.outputs.CHANGES }}
+        id: git_push
+        run: |
+          echo "TODO: push changes to default branch"

--- a/.github/workflows/update-project-stats.yml
+++ b/.github/workflows/update-project-stats.yml
@@ -22,7 +22,7 @@ jobs:
           bundler-cache: true
           cache-version: 0
       - name: Run script to update stats for all projects
-        run: bundle exec ruby scripts/update_stats.rb
+        run: bundle exec ruby scripts/update_stats_only.rb && bundle exec ruby scripts/publish_update_stats_branch.rb
         env:
           GITHUB_TOKEN: ${{ secrets.SHIFTBOT_TOKEN }}
           APPLY_CHANGES: ${{ inputs.apply-changes }}

--- a/scripts/publish_update_stats_branch.rb
+++ b/scripts/publish_update_stats_branch.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'safe_yaml'
+require 'uri'
+require 'octokit'
+require 'pathname'
+require 'graphql/client'
+require 'graphql/client/http'
+
+require 'up_for_grabs_tooling'
+
+current_repo = ENV.fetch('GITHUB_REPOSITORY', nil)
+
+start = Time.now
+
+root_directory = ENV.fetch('GITHUB_WORKSPACE', nil)
+apply_changes = ENV.fetch('APPLY_CHANGES', false)
+token = ENV.fetch('GITHUB_TOKEN', nil)
+
+client = Octokit::Client.new(access_token: token)
+prs = client.pulls current_repo
+
+found_pr = prs.find { |pr| pr.title == 'Updated project stats' && pr.user.login == 'shiftbot' }
+
+if found_pr
+  warn "There is a current PR open to update stats ##{found_pr.number} - review and merge that before we go again"
+  exit 0
+end
+
+unless apply_changes
+  warn 'APPLY_CHANGES environment variable unset, exiting instead of making a new PR'
+  exit 0
+end
+
+clean = true
+
+branch_name = Time.now.strftime('updated-stats-%Y%m%d')
+
+Dir.chdir(root_directory) do
+  warn 'before setting git config changes'
+  system('git config --global user.name "shiftbot"')
+  system('git config --global user.email "12331315+shiftbot@users.noreply.github.com"')
+
+  warn 'after setting git config changes'
+
+  system("git remote set-url origin 'https://x-access-token:#{token}@github.com/#{current_repo}.git'")
+  # Git now warns when the remote URL is changed, and we need to opt-in for continuing to work with this repository
+  system("git config --global --add safe.directory #{Dir.pwd}")
+
+  warn 'after changing git remote url'
+
+  clean = system('git diff --quiet > /dev/null')
+
+  warn 'after git diff'
+
+  unless clean
+    system("git checkout -b #{branch_name}")
+    warn 'after git checkout'
+    system('git add _data/projects/')
+    warn 'after git add'
+    system("git commit -m 'regenerated project stats'")
+    warn 'after git commit'
+    system("git push origin #{branch_name}")
+    warn 'after git push'
+  end
+end
+
+unless clean
+  body = 'This PR regenerates the stats for all repositories that use a single label in a single GitHub repository'
+
+  client.create_pull_request(current_repo, 'gh-pages', branch_name, 'Updated project stats', body) if found_pr.nil?
+end
+
+finish = Time.now
+delta = finish - start
+
+warn "Operation took #{delta}s"
+
+exit 0

--- a/scripts/review_changes.rb
+++ b/scripts/review_changes.rb
@@ -225,7 +225,7 @@ end
 
 head_sha = ENV.fetch('HEAD_SHA', nil)
 base_sha = ENV.fetch('BASE_SHA', nil)
-git_remote_url = ENV.fetch('GIT_REMOTE_URL', nil)
+git_remote_url = ENV.fetch('GIT_REMOTE_URL', "https://github.com/up-for-grabs/up-for-grabs.net")
 dir = ENV.fetch('GITHUB_WORKSPACE', nil)
 
 range = "#{base_sha}...#{head_sha}"

--- a/scripts/review_changes.rb
+++ b/scripts/review_changes.rb
@@ -225,7 +225,7 @@ end
 
 head_sha = ENV.fetch('HEAD_SHA', nil)
 base_sha = ENV.fetch('BASE_SHA', nil)
-git_remote_url = ENV.fetch('GIT_REMOTE_URL', "https://github.com/up-for-grabs/up-for-grabs.net")
+git_remote_url = ENV.fetch('GIT_REMOTE_URL', 'https://github.com/up-for-grabs/up-for-grabs.net')
 dir = ENV.fetch('GITHUB_WORKSPACE', nil)
 
 range = "#{base_sha}...#{head_sha}"

--- a/scripts/update_stats_only.rb
+++ b/scripts/update_stats_only.rb
@@ -9,7 +9,7 @@ require 'graphql/client/http'
 
 require 'up_for_grabs_tooling'
 
-def update(project, apply_changes: false)
+def update(project, apply_changes: true)
   return unless project.github_project?
 
   result = GitHubRepositoryLabelActiveCheck.run(project)
@@ -73,76 +73,19 @@ def update(project, apply_changes: false)
 end
 
 current_repo = ENV.fetch('GITHUB_REPOSITORY', nil)
+root_directory = ENV.fetch('GITHUB_WORKSPACE', nil)
 
 warn "Inspecting projects files for '#{current_repo}'"
 
 start = Time.now
 
-root_directory = ENV.fetch('GITHUB_WORKSPACE', nil)
-apply_changes = ENV.fetch('APPLY_CHANGES', false)
-token = ENV.fetch('GITHUB_TOKEN', nil)
-
-client = Octokit::Client.new(access_token: token)
-prs = client.pulls current_repo
-
-found_pr = prs.find { |pr| pr.title == 'Updated project stats' && pr.user.login == 'shiftbot' }
-
-if found_pr
-  warn "There is a current PR open to update stats ##{found_pr.number} - review and merge that before we go again"
-  exit 0
-end
-
 projects = Project.find_in_directory(root_directory)
 
 warn 'Iterating on project updates'
 
-projects.each { |p| update(p, apply_changes:) }
+projects.each { |p| update(p) }
 
 warn 'Completed iterating on project updates'
-
-unless apply_changes
-  warn 'APPLY_CHANGES environment variable unset, exiting instead of making a new PR'
-  exit 0
-end
-
-clean = true
-
-branch_name = Time.now.strftime('updated-stats-%Y%m%d')
-
-Dir.chdir(root_directory) do
-  warn 'before setting git config changes'
-  system('git config --global user.name "shiftbot"')
-  system('git config --global user.email "12331315+shiftbot@users.noreply.github.com"')
-
-  warn 'after setting git config changes'
-
-  system("git remote set-url origin 'https://x-access-token:#{token}@github.com/#{current_repo}.git'")
-  # Git now warns when the remote URL is changed, and we need to opt-in for continuing to work with this repository
-  system("git config --global --add safe.directory #{Dir.pwd}")
-
-  warn 'after changing git remote url'
-
-  clean = system('git diff --quiet > /dev/null')
-
-  warn 'after git diff'
-
-  unless clean
-    system("git checkout -b #{branch_name}")
-    warn 'after git checkout'
-    system('git add _data/projects/')
-    warn 'after git add'
-    system("git commit -m 'regenerated project stats'")
-    warn 'after git commit'
-    system("git push origin #{branch_name}")
-    warn 'after git push'
-  end
-end
-
-unless clean
-  body = 'This PR regenerates the stats for all repositories that use a single label in a single GitHub repository'
-
-  client.create_pull_request(current_repo, 'gh-pages', branch_name, 'Updated project stats', body) if found_pr.nil?
-end
 
 finish = Time.now
 delta = finish - start

--- a/scripts/update_stats_only.rb
+++ b/scripts/update_stats_only.rb
@@ -9,7 +9,7 @@ require 'graphql/client/http'
 
 require 'up_for_grabs_tooling'
 
-def update(project, apply_changes: true)
+def update(project, apply_changes: false)
   return unless project.github_project?
 
   result = GitHubRepositoryLabelActiveCheck.run(project)
@@ -74,6 +74,7 @@ end
 
 current_repo = ENV.fetch('GITHUB_REPOSITORY', nil)
 root_directory = ENV.fetch('GITHUB_WORKSPACE', nil)
+apply_changes = ENV.fetch('APPLY_CHANGES', false)
 
 warn "Inspecting projects files for '#{current_repo}'"
 
@@ -83,7 +84,7 @@ projects = Project.find_in_directory(root_directory)
 
 warn 'Iterating on project updates'
 
-projects.each { |p| update(p) }
+projects.each { |p| update(p, apply_changes:) }
 
 warn 'Completed iterating on project updates'
 


### PR DESCRIPTION
This PR starts to shift the "update project stats" to a scheduled workflow, which will commit to the default branch when it validates instead of sending through a PR to review.