### PR TITLE
Added functionality to popular-tags

### DIFF
--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -155,21 +155,13 @@ define([
 
     projectsPanel.find('ul.popular-tags li a').each((i, elem) => {
       $(elem).on('click', function () {
-        selTags = $('.tags-filter').val() || [];
-        selectedTag = preparePopTagName($(this).text() || '');
-        if (selectedTag) {
-          tagID = allTags
-            .map((tag) => tag.name.toLowerCase())
-            .indexOf(selectedTag);
-          if (tagID !== -1) {
-            selTags.push(selectedTag);
-            location.href = updateQueryStringParameter(
-              getFilterUrl(),
-              'tags',
-              encodeURIComponent(selTags)
-            );
-          }
-        }
+        const tagName = preparePopTagName($(this).text()) || '';
+        console.log(tagName);
+
+        projectsPanel.find('select.tags-filter')
+          .val(tagName)
+          .trigger('chosen:updated')
+          .trigger('change');
       });
     });
   };

--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -156,7 +156,6 @@ define([
     projectsPanel.find('ul.popular-tags li a').each((i, elem) => {
       $(elem).on('click', function () {
         const tagName = preparePopTagName($(this).text()) || '';
-        console.log(tagName);
 
         projectsPanel.find('select.tags-filter')
           .val(tagName)


### PR DESCRIPTION
The popular tags on the website (i.e javascript, python, .net, c#, web and java) have no functionality.
The changes made allow those tags to filter projects when clicked.