### PR TITLE
Fix click on popular tags

### DIFF
--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -156,13 +156,24 @@ define([
     projectsPanel.find('ul.popular-tags li a').each((i, elem) => {
       $(elem).on('click', function () {
         selTags = $('.tags-filter').val() || [];
-        selectedTag = preparePopTagName($(this).text() || '');
+        selectedTag = preparePopTagName(
+          Array.from(this.childNodes)
+            .find(
+              (node) =>
+                node.nodeType === Node.TEXT_NODE && node.textContent.trim()
+            )
+            ?.textContent?.trim() || ''
+        );
         if (selectedTag) {
           tagID = allTags
             .map((tag) => tag.name.toLowerCase())
             .indexOf(selectedTag);
           if (tagID !== -1) {
-            selTags.push(selectedTag);
+            if (selTags.includes(selectedTag)) {
+              selTags.splice(selTags.indexOf(selectedTag), 1);
+            } else {
+              selTags.push(selectedTag);
+            }
             location.href = updateQueryStringParameter(
               getFilterUrl(),
               'tags',
@@ -181,7 +192,7 @@ define([
   */
   let preparePopTagName = function (name) {
     if (name === '') return '';
-    return name.toLowerCase().split(' ')[0];
+    return name.toLowerCase();
   };
 
   /**


### PR DESCRIPTION
Fixes #5216

This PR restores the functionality of clicking on Popular Tags by correcting a bug in tag parsing. It also enables a second click to remove the tag from the filter list.

The existing code uses code to handle the project count element nested within the anchor containing the tag. This new code is more conservative by extracting the tag from the first TEXT_NODE, to avoid making assumptions about other child elements which was necessary by using innerText.

Unlike #5217, this PR does not conflict with the existing event listener or the override already-filtered tags introduced by #1121 (and later fixed in #1179). If the other approach is preferred, it should be amended to remove the popular handling from main.js .