### PR TITLE
Fix Forks badge cursor on project cards (#5397)

### DIFF
--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -237,7 +237,7 @@ button {
   height: 55px;
   z-index: 999;
   background: transparent;
-  cursor: pointer;
+  cursor: default;
 }
 
 .theme-selector .visually-hidden {
@@ -265,7 +265,7 @@ button {
   overflow: hidden;
   z-index: 999;
   display: none;
-  cursor: pointer;
+  cursor: default;
   -moz-transform: rotate(270deg);
   -webkit-transform: rotate(270deg);
   -o-transform: rotate(270deg);
@@ -286,7 +286,7 @@ button {
 #back2Top:hover {
   background-color: #2D7BA9;
   color: #ffffff;
-  cursor: pointer;
+  cursor: default;
 }
 
 #forkme_banner {
@@ -523,7 +523,7 @@ a,
   display: inline-block;
   vertical-align: baseline;
   zoom: 1;
-  cursor: pointer;
+  cursor: default;
   display: inline;
   vertical-align: auto;
   -webkit-transition: color 0.3s;
@@ -550,7 +550,7 @@ a.big-button,
   -o-transition: all, 0.2s;
   transition: all, 0.2s;
   color: #fff;
-  cursor: pointer;
+  cursor: default;
   font-size: 12px;
   line-height: 24px;
   padding: 8px 17px;
@@ -1061,7 +1061,7 @@ ul.tags li {
   padding: 0.25rem 1rem;
   line-height: 26px;
   outline: none;
-  cursor: pointer;
+  cursor: default;
   min-width: 90px;
   border-radius: 5px;
 }
@@ -1138,7 +1138,7 @@ ul.tags li {
     overflow: hidden;
     z-index: 999;
     display: none;
-    cursor: pointer;
+    cursor: default;
     -moz-transform: rotate(270deg);
     -webkit-transform: rotate(270deg);
     -o-transform: rotate(270deg);

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -14,7 +14,7 @@
 }
 
 /* Dark Mode Preference has been selected */
-[data-theme-preference=dark]:root {
+[data-theme-preference='dark']:root {
   --body-back: #1a2025;
   --body-color: #eeeded;
   --abs: rgb(39 47 55);
@@ -237,7 +237,7 @@ button {
   height: 55px;
   z-index: 999;
   background: transparent;
-  cursor: default;
+  cursor: pointer;
 }
 
 .theme-selector .visually-hidden {
@@ -265,7 +265,7 @@ button {
   overflow: hidden;
   z-index: 999;
   display: none;
-  cursor: default;
+  cursor: pointer;
   -moz-transform: rotate(270deg);
   -webkit-transform: rotate(270deg);
   -o-transform: rotate(270deg);
@@ -274,19 +274,18 @@ button {
   position: fixed;
   bottom: 50px;
   right: 50px;
-  background-color: #DDD;
+  background-color: #ddd;
   color: #555;
   text-align: center;
   font-size: 23px;
   text-decoration: none;
   transition: 0.3s;
-
 }
 
 #back2Top:hover {
-  background-color: #2D7BA9;
+  background-color: #2d7ba9;
   color: #ffffff;
-  cursor: default;
+  cursor: pointer;
 }
 
 #forkme_banner {
@@ -403,7 +402,7 @@ strong {
 ul,
 ol,
 dl {
-  margin-bottom: 15px
+  margin-bottom: 15px;
 }
 
 ul li {
@@ -460,7 +459,7 @@ footer * {
 
 .container:before,
 .container:after {
-  content: " ";
+  content: ' ';
   display: table;
 }
 
@@ -482,7 +481,7 @@ footer * {
 }
 
 #main-container .block:first-child,
-#main-container .block+.block {
+#main-container .block + .block {
   border-top: 0;
 }
 
@@ -523,7 +522,7 @@ a,
   display: inline-block;
   vertical-align: baseline;
   zoom: 1;
-  cursor: default;
+  cursor: pointer;
   display: inline;
   vertical-align: auto;
   -webkit-transition: color 0.3s;
@@ -537,7 +536,7 @@ a.main,
 a:hover,
 .as-link.main,
 .as-link:hover {
-  color: #2E7BA9;
+  color: #2e7ba9;
 }
 
 a.big-button,
@@ -550,7 +549,7 @@ a.big-button,
   -o-transition: all, 0.2s;
   transition: all, 0.2s;
   color: #fff;
-  cursor: default;
+  cursor: pointer;
   font-size: 12px;
   line-height: 24px;
   padding: 8px 17px;
@@ -628,7 +627,7 @@ a:focus {
 
 hr {
   border: 0;
-  border-bottom: 1px dotted #CCC;
+  border-bottom: 1px dotted #ccc;
   margin: 25px 0;
 }
 
@@ -734,10 +733,10 @@ form {
   font-size: 28px !important;
   width: 40%;
   position: absolute;
-  background: #2E7BA9;
-  color: #E4F0F8;
+  background: #2e7ba9;
+  color: #e4f0f8;
   text-align: center;
-  padding: .5em 1em;
+  padding: 0.5em 1em;
   margin: 0 auto 0;
   right: 2em;
   top: 25%;
@@ -754,11 +753,11 @@ form {
 
 .ribbon:before,
 .ribbon:after {
-  content: "";
+  content: '';
   position: absolute;
   display: block;
   bottom: -1em;
-  border: 1.5em solid #225B7D;
+  border: 1.5em solid #225b7d;
   z-index: -1;
 }
 
@@ -776,11 +775,11 @@ form {
 
 .ribbon .ribbon-content:before,
 .ribbon .ribbon-content:after {
-  content: "";
+  content: '';
   position: absolute;
   display: block;
   border-style: solid;
-  border-color: #163A50 transparent transparent transparent;
+  border-color: #163a50 transparent transparent transparent;
   bottom: -1em;
 }
 
@@ -862,9 +861,9 @@ form {
 }
 
 .projects .label {
-  background: #2E7BA9;
+  background: #2e7ba9;
   border-radius: 2px;
-  color: #FFF;
+  color: #fff;
   display: inline-block;
   font-size: 12px;
   white-space: nowrap;
@@ -872,7 +871,7 @@ form {
 }
 
 .projects .label a {
-  color: #FFF;
+  color: #fff;
   display: inline-block;
   padding: 2px 10px;
 }
@@ -887,7 +886,7 @@ form {
   background: none white;
   border: 1px solid white;
   border-radius: 8px;
-  color: #2E7BA9;
+  color: #2e7ba9;
   display: inline-block;
   height: 16px;
   line-height: 16px;
@@ -1055,20 +1054,20 @@ ul.tags li {
 }
 
 .radio-btn {
-  background-color: #2E7BA9;
-  color: #FFF;
+  background-color: #2e7ba9;
+  color: #fff;
   font-size: 14px;
   padding: 0.25rem 1rem;
   line-height: 26px;
   outline: none;
-  cursor: default;
+  cursor: pointer;
   min-width: 90px;
   border-radius: 5px;
 }
 
 .radio-btn:hover {
   box-shadow: 3px 3px 10px rgba(54, 132, 248, 0.5);
-  transition-duration: .1s;
+  transition-duration: 0.1s;
   transform: translateY(-1px);
 }
 
@@ -1115,13 +1114,12 @@ ul.tags li {
   visibility: visible;
 }
 
-
 .fork-count-svg {
   align-self: center;
   fill: currentColor;
 }
 
-@media screen and (max-width : 670px) {
+@media screen and (max-width: 670px) {
   #view-mode {
     position: fixed;
     width: 44px;
@@ -1138,7 +1136,7 @@ ul.tags li {
     overflow: hidden;
     z-index: 999;
     display: none;
-    cursor: default;
+    cursor: pointer;
     -moz-transform: rotate(270deg);
     -webkit-transform: rotate(270deg);
     -o-transform: rotate(270deg);
@@ -1149,7 +1147,7 @@ ul.tags li {
     bottom: 18px;
     margin-right: 10px;
     border-radius: 50%;
-    background-color: #DDD;
+    background-color: #ddd;
     color: #555;
     display: flex !important;
     align-items: center;


### PR DESCRIPTION

Currently, the "Forks" badge on project cards looks clickable (pointer cursor) but does not actually link anywhere.  
This can be confusing to users expecting it to open the repository or forks list.

This PR updates the cursor style to use the default (non-clickable) cursor, so the badge no longer gives a misleading impression.


Closes #5397


- Before: pointer cursor over the Forks badge

![cur_before](https://github.com/user-attachments/assets/41cf9c19-f5de-4071-a2f7-2734a9de7f02)

- After: default cursor over the Forks badge

![cur_after](https://github.com/user-attachments/assets/35d16693-7238-4e57-977a-82db383d76f6)


- Ran `bundle exec jekyll serve` locally to verify the cursor change.
- Checked that other badges and links remain unaffected.
