### PR TITLE
Add navbar navigation between homepage sections and limit initial projects list

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -30,10 +30,11 @@
         data-placeholder="Select a project..."
       >
         <% _.each(names, function(entry, key){ %>
-        <option value="<%-key%>"><%- entry.name%></option>
+          <option value="<%-key%>"><%- entry.name%></option>
         <% }) %>
       </select>
     </div>
+
     <div class="filters-panel cf">
       <label class="filter-label" for="label">Filter by label: </label>
       <select
@@ -43,10 +44,11 @@
         data-placeholder="Select a label..."
       >
         <% _.each(labels, function(entry, key){ %>
-        <option value="<%-key%>"><%- entry.name%></option>
+          <option value="<%-key%>"><%- entry.name%></option>
         <% }) %>
       </select>
     </div>
+
     <div class="filters-panel cf">
       <label class="filter-label" for="tag">Filter by tags: </label>
       <select
@@ -56,118 +58,146 @@
         data-placeholder="Select a tag..."
       >
         <% _.each(tags, function(entry, key){ %>
-        <option value="<%-entry.name%>">
-          <%- entry.name%> (<%-entry.frequency%>)
-        </option>
+          <option value="<%-entry.name%>">
+            <%- entry.name%> (<%-entry.frequency%>)
+          </option>
         <% }) %>
       </select>
     </div>
+
     <div class="filters-panel cf">
       <label class="filter-label">Popular tags:</label>
       <ul class="popular-tags">
         <% _.each(popularTags, function(entry, key){ %>
-        <li>
-          <a title="Popular Tag: <%-entry.name%>" tabindex="0"
-            ><%-entry.name%>
-            <span class="popular-tags__frequency"
-              >(<%-entry.frequency%>)</span
-            ></a
-          >
-        </li>
+          <li>
+            <a title="Popular Tag: <%-entry.name%>" tabindex="0">
+              <%-entry.name%>
+              <span class="popular-tags__frequency">
+                (<%-entry.frequency%>)
+              </span>
+            </a>
+          </li>
         <% }) %>
       </ul>
     </div>
   </menu>
+
   <div class="projects">
-    <% let count=0 %> <% _.each(projects, function(project) { %> <%
-    count=count+1%>
-    <div class="data-box" class="<% if ( project.stats ) { %>counted<% } %>">
-      <div>
+    <% let count = 0 %>
+    <% _.each(projects, function(project, index) { %>
+      <% count = count + 1 %>
+      <div
+        class="data-box project-card <%= index >= 9 ? 'hidden-project' : '' %> <% if (project.stats) { %>counted<% } %>"
+      >
         <div>
-          <div colspan="2" class="title">
-            <span class="proj"
-              ><a href="<%-project.site %>" target="_blank"
-                ><%-project.name %></a
-              ></span
-            >
-          </div>
-        </div>
-        <div>
-          <div class="details stats">
-            <p class="label">
-              <a
-                href="<%- project.upforgrabs.link %>"
-                title="View open issues for <%-project.name %>"
-                target="_blank"
-                tabindex="-1"
-              >
-                <%-project.upforgrabs.name %> <% if (project.stats &&
-                project.stats['last-updated']) { const now=new Date(); let
-                lastUpdated=new Date(project.stats['last-updated']); let
-                since=relativeTime(now, lastUpdated); %>
-                <span class="count" title="Last updated <%- since %>"
-                  ><%-project.stats['issue-count']%></span
-                >
-                <% } else if (project.stats) { %>
-                <span class="count" title="No recent activity"
-                  ><%-project.stats['issue-count']%></span
-                >
-                <% } %>
-              </a>
-            </p>
-            <% if (project.stats) { %>
-            <div class="fork-count" title="Number of forks">
-              <svg
-                aria-hidden="true"
-                height="16"
-                viewBox="0 0 16 16"
-                version="1.1"
-                width="16"
-                data-view-component="true"
-                class="fork-count-svg"
-              >
-                <path
-                  d="M5 5.372v.878c0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75v-.878a2.25 2.25 0 1 1 1.5 0v.878a2.25 2.25 0 0 1-2.25 2.25h-1.5v2.128a2.251 2.251 0 1 1-1.5 0V8.5h-1.5A2.25 2.25 0 0 1 3.5 6.25v-.878a2.25 2.25 0 1 1 1.5 0ZM5 3.25a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Zm6.75.75a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm-3 8.75a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Z"
-                ></path>
-              </svg>
-              <%-project.stats['fork-count']%>
-              <span class="tooltip">Forks</span>
+          <div>
+            <div colspan="2" class="title">
+              <span class="proj">
+                <a href="<%-project.site %>" target="_blank">
+                  <%-project.name %>
+                </a>
+              </span>
             </div>
-            <% } %>
           </div>
-          <div class="details">
-            <% if (project.desc) { %>
-            <span class="desc"> <%=project.desc%> </span>
-            <% } %>
+          <div>
+            <div class="details stats">
+              <p class="label">
+                <a
+                  href="<%- project.upforgrabs.link %>"
+                  title="View open issues for <%-project.name %>"
+                  target="_blank"
+                  tabindex="-1"
+                >
+                  <%-project.upforgrabs.name %>
+                  <% if (project.stats && project.stats['last-updated']) { 
+                       const now = new Date();
+                       let lastUpdated = new Date(project.stats['last-updated']);
+                       let since = relativeTime(now, lastUpdated); %>
+                    <span
+                      class="count"
+                      title="Last updated <%- since %>"
+                    >
+                      <%-project.stats['issue-count']%>
+                    </span>
+                  <% } else if (project.stats) { %>
+                    <span
+                      class="count"
+                      title="No recent activity"
+                    >
+                      <%-project.stats['issue-count']%>
+                    </span>
+                  <% } %>
+                </a>
+              </p>
+
+              <% if (project.stats) { %>
+                <div class="fork-count" title="Number of forks">
+                  <svg
+                    aria-hidden="true"
+                    height="16"
+                    viewBox="0 0 16 16"
+                    version="1.1"
+                    width="16"
+                    data-view-component="true"
+                    class="fork-count-svg"
+                  >
+                    <path
+                      d="M5 5.372v.878c0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75v-.878a2.25 2.25 0 1 1 1.5 0v.878a2.25 2.25 0 0 1-2.25 2.25h-1.5v2.128a2.251 2.251 0 1 1-1.5 0V8.5h-1.5A2.25 2.25 0 0 1 3.5 6.25v-.878a2.25 2.25 0 1 1 1.5 0ZM5 3.25a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Zm6.75.75a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm-3 8.75a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Z"
+                    ></path>
+                  </svg>
+                  <%-project.stats['fork-count']%>
+                  <span class="tooltip">Forks</span>
+                </div>
+              <% } %>
+            </div>
+
+            <div class="details">
+              <% if (project.desc) { %>
+                <span class="desc"><%=project.desc%></span>
+              <% } %>
+            </div>
           </div>
         </div>
+
+        <div class="details-tags">
+          <% if (project.tags) { %>
+            <ul class="tags" aria-label="project tags">
+              <% _.each(project.tags, function(tag, i) { %>
+                <li>
+                  <a
+                    href="#/filters?tags=<%-encodeURIComponent(tag)%>"
+                    tabindex="-1"
+                  >
+                    <%-tag%>
+                  </a>
+                </li>
+              <% }) %>
+            </ul>
+          <% } %>
+        </div>
       </div>
-      <div class="details-tags">
-        <% if (project.tags) { %>
-        <ul class="tags" aria-label="project tags">
-          <% _.each(project.tags, function(tag, i) { %>
-          <li>
-            <a href="#/filters?tags=<%-encodeURIComponent(tag)%>" tabindex="-1"
-              ><%-tag%></a
-            >
-          </li>
-          <% }) %>
-        </ul>
-        <% } %>
-      </div>
-    </div>
     <% }) %>
   </div>
-  <% if(count==0) { %>
-  <p style="font-size: 1.5em;font-weight: 600;line-height: 30px;">
-    No projects found with this description...
-  </p>
-  <p><%} %></p>
+
+  <% if (count == 0) { %>
+    <p style="font-size: 1.5em; font-weight: 600; line-height: 30px;">
+      No projects found with this description...
+    </p>
+  <% } else if (count > 9) { %>
+    <div class="see-more-container">
+      <button id="see-more-btn" class="see-more-btn">
+        See More (<span id="remaining-count"><%= count - 9 %></span> more projects)
+      </button>
+    </div>
+  <% } %>
+  <p></p>
 </script>
+
 <script
   src="{{ site.github.url }}javascripts/lib/require.js"
   data-main="javascripts/app"
 ></script>
+
 <!-- Google Analytics -->
 <script>
   (function (i, s, o, g, r, a, m) {

--- a/index.html
+++ b/index.html
@@ -2,6 +2,12 @@
 layout: default
 ---
 
+<nav class="ufg-navbar">
+  <a href="#i-want-to-get-involved">I want to get involved</a>
+  <a href="#projects">Projects</a>
+  <a href="#i-maintain-a-project">I want to maintain a project</a>
+</nav>
+
 <section id="i-want-to-get-involved" class="block">
   {% include before.html %}
 </section>
@@ -14,3 +20,5 @@ layout: default
 <section id="i-maintain-a-project" class="block">
   {% include after.html %}
 </section>
+
+

--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -154,23 +154,46 @@ define([
       });
 
     projectsPanel.find('ul.popular-tags li a').each((i, elem) => {
-      $(elem).on('click', function () {
-        selTags = $('.tags-filter').val() || [];
-        selectedTag = preparePopTagName($(this).text() || '');
+      $(elem).on('click', function (e) {
+        e.preventDefault();
+        const selTags = $('.tags-filter').val() || [];
+        // Get the tag name from the title attribute which has the clean name
+        const titleText = $(this).attr('title') || '';
+        const selectedTag = titleText.replace('Popular Tag: ', '').trim();
+        
         if (selectedTag) {
-          tagID = allTags
-            .map((tag) => tag.name.toLowerCase())
-            .indexOf(selectedTag);
-          if (tagID !== -1) {
-            selTags.push(selectedTag);
-            location.href = updateQueryStringParameter(
-              getFilterUrl(),
-              'tags',
-              encodeURIComponent(selTags)
-            );
+          // Find the matching tag in allTags
+          const matchingTag = allTags.find(
+            (tag) => tag.name.toLowerCase() === selectedTag.toLowerCase()
+          );
+          
+          if (matchingTag) {
+            const actualTagName = matchingTag.name;
+            // Check if tag is not already selected
+            if (selTags.indexOf(actualTagName) === -1) {
+              selTags.push(actualTagName);
+            }
+            // Update the select element and trigger chosen update
+            $('.tags-filter').val(selTags).trigger('chosen:updated').change();
           }
         }
       });
+    });
+
+    // Handle "See More" button functionality
+    projectsPanel.find('#see-more-btn').on('click', function () {
+      const hiddenProjects = projectsPanel.find('.project-card.hidden-project');
+      const projectsToShow = hiddenProjects.slice(0, 9);
+      
+      projectsToShow.removeClass('hidden-project');
+      
+      const remainingCount = hiddenProjects.length - projectsToShow.length;
+      
+      if (remainingCount <= 0) {
+        $(this).parent('.see-more-container').hide();
+      } else {
+        projectsPanel.find('#remaining-count').text(remainingCount);
+      }
     });
   };
 

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -931,6 +931,41 @@ ul.tags li {
   color: var(--body-color);
 }
 
+/* Navbar Feature */
+html {
+  scroll-behavior: smooth;
+}
+
+.ufg-navbar {
+  position: -webkit-sticky; /* Safari */
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  background-color: var(--body-back); /* White/Light in default, Dark in dark mode */
+  border-bottom: 1px solid var(--container-border);
+  padding: 1rem 0;
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+}
+
+.ufg-navbar a {
+  text-decoration: none;
+  color: var(--heading-color); /* Blue in default */
+  font-weight: 500;
+}
+
+.ufg-navbar a:hover,
+.ufg-navbar a:focus {
+  text-decoration: underline;
+}
+
+#i-want-to-get-involved,
+#projects,
+#i-maintain-a-project {
+  scroll-margin-top: 80px;
+}
+
 @media (max-width: 768px) {
   body {
     padding: 0 0;
@@ -1099,4 +1134,39 @@ ul.tags li {
     font-size: 28px;
     transition: 0.3s;
   }
+}
+
+/* Navbar Feature */
+html {
+  scroll-behavior: smooth;
+}
+
+.ufg-navbar {
+  position: -webkit-sticky; /* Safari */
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  background-color: var(--body-back);
+  border-bottom: 1px solid var(--container-border);
+  padding: 1rem 0;
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+}
+
+.ufg-navbar a {
+  text-decoration: none;
+  color: var(--heading-color);
+  font-weight: 500;
+}
+
+.ufg-navbar a:hover,
+.ufg-navbar a:focus {
+  text-decoration: underline;
+}
+
+#i-want-to-get-involved,
+#projects,
+#i-maintain-a-project {
+  scroll-margin-top: 80px;
 }

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -280,7 +280,6 @@ button {
   font-size: 23px;
   text-decoration: none;
   transition: 0.3s;
-
 }
 
 #back2Top:hover {
@@ -377,7 +376,7 @@ strong {
 ul,
 ol,
 dl {
-  margin-bottom: 15px
+  margin-bottom: 15px;
 }
 
 ul li {
@@ -456,7 +455,7 @@ footer * {
 }
 
 #main-container .block:first-child,
-#main-container .block+.block {
+#main-container .block + .block {
   border-top: 0;
 }
 
@@ -703,7 +702,7 @@ form {
   padding: 20px;
 }
 
-/* https://css-tricks.com/snippets/css/ribbon/ */
+/* Ribbon */
 .ribbon {
   font-size: 28px !important;
   width: 40%;
@@ -777,6 +776,8 @@ form {
   height: 70px;
   background: url('../images/icon_download.png') no-repeat 0% 90%;
 }
+
+/* Projects grid + cards */
 
 .projects {
   padding-block: 3em;
@@ -884,6 +885,8 @@ form {
   width: 16px;
 }
 
+/* Tag chips */
+
 .popular-tags,
 .tags {
   display: flex;
@@ -941,7 +944,7 @@ html {
   position: sticky;
   top: 0;
   z-index: 1000;
-  background-color: var(--body-back); /* White/Light in default, Dark in dark mode */
+  background-color: var(--body-back);
   border-bottom: 1px solid var(--container-border);
   padding: 1rem 0;
   display: flex;
@@ -951,7 +954,7 @@ html {
 
 .ufg-navbar a {
   text-decoration: none;
-  color: var(--heading-color); /* Blue in default */
+  color: var(--heading-color);
   font-weight: 500;
 }
 
@@ -965,6 +968,8 @@ html {
 #i-maintain-a-project {
   scroll-margin-top: 80px;
 }
+
+/* Responsive adjustments */
 
 @media (max-width: 768px) {
   body {
@@ -1023,6 +1028,8 @@ html {
   }
 }
 
+/* Filter button row */
+
 .radio-btn-row {
   display: flex;
   flex-direction: row;
@@ -1057,6 +1064,8 @@ html {
   margin-bottom: 20px;
 }
 
+/* Stats + tooltip */
+
 .projects .stats {
   display: flex;
   flex-direction: row;
@@ -1073,7 +1082,6 @@ html {
   padding: 2px 4px;
   font-size: x-small;
 
-  /* Position the tooltip */
   position: absolute;
   top: 13px;
   right: -17px;
@@ -1092,11 +1100,48 @@ html {
   visibility: visible;
 }
 
-
 .fork-count-svg {
   align-self: center;
   fill: currentColor;
 }
+
+/* Project pagination styles (friend's changes) */
+
+.hidden-project {
+  display: none !important;
+}
+
+.see-more-container {
+  text-align: center;
+  margin: 30px 0;
+  padding: 20px 0;
+}
+
+.see-more-btn {
+  background-color: var(--heading-color);
+  color: white;
+  border: none;
+  padding: 12px 30px;
+  font-size: 16px;
+  font-weight: 600;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  box-shadow: 0 2px 5px var(--box-shadow-color);
+}
+
+.see-more-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px var(--box-shadow-color);
+  opacity: 0.9;
+}
+
+.see-more-btn:active {
+  transform: translateY(0);
+  box-shadow: 0 2px 3px var(--box-shadow-color);
+}
+
+/* Mobile back-to-top & view-mode */
 
 @media screen and (max-width : 670px) {
   #view-mode {
@@ -1134,39 +1179,4 @@ html {
     font-size: 28px;
     transition: 0.3s;
   }
-}
-
-/* Navbar Feature */
-html {
-  scroll-behavior: smooth;
-}
-
-.ufg-navbar {
-  position: -webkit-sticky; /* Safari */
-  position: sticky;
-  top: 0;
-  z-index: 1000;
-  background-color: var(--body-back);
-  border-bottom: 1px solid var(--container-border);
-  padding: 1rem 0;
-  display: flex;
-  justify-content: center;
-  gap: 1.5rem;
-}
-
-.ufg-navbar a {
-  text-decoration: none;
-  color: var(--heading-color);
-  font-weight: 500;
-}
-
-.ufg-navbar a:hover,
-.ufg-navbar a:focus {
-  text-decoration: underline;
-}
-
-#i-want-to-get-involved,
-#projects,
-#i-maintain-a-project {
-  scroll-margin-top: 80px;
 }


### PR DESCRIPTION
Added a sticky navbar that scrolls to “I want to get involved”, “Projects”, “I maintain a project”.

Limited visible projects to the first 9 with a “See More (N more projects)” button.

Users can jump to relevant sections without manual scrolling.

Projects section is more readable on first load.