### PR TITLE
Fix forks badge cursor to not appear clickable

### DIFF
--- a/src/components/search/ForkCount.vue
+++ b/src/components/search/ForkCount.vue
@@ -8,7 +8,7 @@ const props = defineProps<{
 .fork-count {
   display: flex;
   height: max-content;
-  cursor: pointer;
+  cursor: default;
   position: relative;
 
   color: rgb(255, 255, 255);

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -1079,7 +1079,7 @@ ul.tags li {
   display: flex;
   margin-top: 10px;
   height: max-content;
-  cursor: pointer;
+  cursor: default;
   position: relative;
 }
 


### PR DESCRIPTION
## Summary

Fixes #5397

- Changed `cursor: pointer` to `cursor: default` on the `.fork-count` class in both the legacy stylesheet (`stylesheets/stylesheet.css`) and the new Astro Vue component (`src/components/search/ForkCount.vue`)
- The fork count badge is not a link or interactive element, so it should not show a pointer cursor

## Test plan

- [ ] Hover over the forks badge on a project card and verify the cursor is a normal arrow, not a pointer hand