### PR TITLE
Add GitHub Readme Contribution Merger project

### DIFF
--- a/_data/projects/github-readme-contribution-merger.yml
+++ b/_data/projects/github-readme-contribution-merger.yml
@@ -1,0 +1,12 @@
+name: GitHub Readme Contribution Merger
+desc: Merge multiple GitHub users' contribution graphs into a single SVG heatmap for your readme.
+site: https://github-contribution-merger.vercel.app
+tags:
+  - github
+  - svg
+  - javascript
+  - contributions
+  - readme
+upforgrabs:
+  name: good first issue
+  link: https://github.com/apoorvdarshan/github-readme-contribution-merger/labels/good%20first%20issue


### PR DESCRIPTION
## Summary

- Adds [GitHub Readme Contribution Merger](https://github.com/apoorvdarshan/github-readme-contribution-merger) to the project list
- A tool to merge multiple GitHub users' contribution graphs into a single SVG heatmap for readme files
- Label: `good first issue`

## Test plan

- [ ] Verify YAML is valid and follows the project template
- [ ] Verify the label link resolves to the correct GitHub labels page