### PR TITLE
fix: make forks badge cursor non-clickable

### DIFF
--- a/src/components/search/ForkCount.vue
+++ b/src/components/search/ForkCount.vue
@@ -8,7 +8,7 @@ const props = defineProps<{
 .fork-count {
   display: flex;
   height: max-content;
-  cursor: pointer;
+  cursor: default;
   position: relative;
 
   color: rgb(255, 255, 255);

--- a/tests/spec/fork-count-style-spec.js
+++ b/tests/spec/fork-count-style-spec.js
@@ -1,0 +1,15 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+describe('ForkCount styles', () => {
+  it('uses a non-clickable cursor for the forks badge', () => {
+    const componentPath = path.join(
+      __dirname,
+      '../../src/components/search/ForkCount.vue'
+    );
+    const source = fs.readFileSync(componentPath, 'utf8');
+
+    expect(source).toContain('cursor: default;');
+    expect(source).not.toContain('cursor: pointer;');
+  });
+});


### PR DESCRIPTION
## Summary
- switch the forks badge cursor from `pointer` to `default` so it no longer looks like a clickable link
- add a focused Jest spec to assert the forks badge style remains non-clickable

## Validation
- `npx jest --config ./jest.config.js --runTestsByPath tests/spec/fork-count-style-spec.js --coverage=false`
- `npm run lint`

Closes #5397
