### PR TITLE
fix: stop persisting project order in sessionStorage

### DIFF
--- a/javascripts/project-ordering.js
+++ b/javascripts/project-ordering.js
@@ -35,37 +35,7 @@ define(['underscore'], (/** @type {import('underscore')} */ _) => {
       project.stats ? project.stats['issue-count'] > 0 : true
     );
 
-    const canStoreOrdering =
-      JSON &&
-      window.sessionStorage &&
-      'getItem' in window.sessionStorage &&
-      'setItem' in window.sessionStorage;
-
-    if (!canStoreOrdering) {
-      return projects;
-    }
-
-    const projectsLength = projects.length;
-
-    /** @type {Array<number> | null} */
-    let ordering = null;
-
-    const orderingValue = window.sessionStorage.getItem('projectOrder');
-    if (orderingValue) {
-      ordering = JSON.parse(orderingValue);
-
-      // This prevents anyone's page from crashing if a project is removed
-      if (ordering && ordering.length !== projectsLength) {
-        ordering = null;
-      }
-    }
-
-    if (!ordering) {
-      ordering = computeOrder(projectsLength);
-      if (canStoreOrdering) {
-        window.sessionStorage.setItem('projectOrder', JSON.stringify(ordering));
-      }
-    }
+    const ordering = computeOrder(projects.length);
 
     return _.map(ordering, (i) => projects[i]);
   }

--- a/tests/spec/project-ordering-spec.js
+++ b/tests/spec/project-ordering-spec.js
@@ -4,58 +4,25 @@
 
 const orderAllProjects = require('../../javascripts/project-ordering');
 
-const { sessionStorage: originalSessionStorage } = globalThis;
-
 describe('orderAllProjects', () => {
-  beforeEach(() => {
-    sessionStorage.removeItem('projectOrder');
-  });
-
   it('returns something when no projects received', () => {
-    expect(orderAllProjects([])).toHaveLength(0);
+    expect(orderAllProjects([], () => [])).toHaveLength(0);
   });
 
   describe('when items received', () => {
     const input = [{ id: 1 }, { id: 2 }, { id: 3 }];
 
-    it('will return items in different order when nothing in storage', () => {
+    it('returns items in computeOrder order', () => {
       const computeOrder = jest.fn().mockReturnValue([0, 2, 1]);
 
-      expect(orderAllProjects(input, computeOrder)).not.toMatchObject(input);
+      expect(orderAllProjects(input, computeOrder)).toMatchObject([
+        { id: 1 },
+        { id: 3 },
+        { id: 2 },
+      ]);
 
       expect(computeOrder).toHaveBeenCalledTimes(1);
       expect(computeOrder).toHaveBeenCalledWith(3);
-    });
-
-    it('will return items in matching order when stored order is same length', () => {
-      sessionStorage.setItem('projectOrder', JSON.stringify([0, 1, 2]));
-
-      const computeOrder = jest.fn();
-
-      expect(orderAllProjects(input, computeOrder)).toMatchObject(input);
-
-      expect(computeOrder).not.toHaveBeenCalled();
-    });
-
-    it('will return items in different order when stored order is different length', () => {
-      sessionStorage.setItem('projectOrder', JSON.stringify([0, 1]));
-
-      const computeOrder = jest.fn().mockReturnValue([0, 2, 1]);
-
-      expect(orderAllProjects(input, computeOrder)).not.toMatchObject(input);
-
-      expect(computeOrder).toHaveBeenCalled();
-    });
-
-    it('will store order in session storage for future lookups', () => {
-      const someOrderValue = [0, 2, 1];
-      const computeOrder = jest.fn().mockReturnValue(someOrderValue);
-
-      orderAllProjects(input, computeOrder);
-
-      expect(window.sessionStorage.getItem('projectOrder')).toEqual(
-        JSON.stringify(someOrderValue)
-      );
     });
   });
 
@@ -84,28 +51,6 @@ describe('orderAllProjects', () => {
       ];
 
       expect(orderAllProjects(items, () => [0, 1, 2])).toHaveLength(3);
-    });
-  });
-
-  describe('when no local storage available', () => {
-    beforeEach(() => {
-      Object.defineProperty(globalThis, 'sessionStorage', {
-        value: null,
-      });
-    });
-
-    afterEach(() => {
-      globalThis.sessionStorage = originalSessionStorage;
-    });
-
-    it('will return items in same order', () => {
-      const input = [{ id: 1 }, { id: 2 }];
-
-      const computeOrder = jest.fn();
-
-      expect(orderAllProjects(input, computeOrder)).toMatchObject(input);
-
-      expect(computeOrder).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary
- remove `sessionStorage` reads/writes from `orderAllProjects`
- always derive ordering from the provided `computeOrder` function
- simplify/refresh unit tests to match the new behavior

This addresses #5515 by removing client-side storage as the source of project render order.

## Testing
- npm test -- project-ordering-spec
