### PR TITLE
fix(astro): sync search form state with query parameters

### DIFF
--- a/src/components/Progress.astro
+++ b/src/components/Progress.astro
@@ -14,9 +14,10 @@
       Favour active projects but allow searching further back
     </li>
     <li>Finish refreshing visual style of site</li>
-    <li>Synchronize form parameters with query string state</li>
-    <li>Port existing tests over to new codebase (and add more)</li>
-    <li>Offload search into web worker</li>
+    <li class="done">Synchronize form parameters with query string state</li>
+    <li class="done">
+      Port existing tests over to new codebase (and add more)
+    </li>
     <li>Render most popular tags</li>
     <li>Render dark mode stylings</li>
     <li>

--- a/src/components/search/SearchResults.test.ts
+++ b/src/components/search/SearchResults.test.ts
@@ -102,7 +102,7 @@ test('SearchResults fetches and displays initial count of projects', async () =>
   expect(resultsCount.text()).toBe('2 projects found');
 });
 
-test('SearchResults updates count when filter returns additional results', async () => {
+test('SearchResults updates count when filter returns additional results and text is in query string', async () => {
   const wrapper = mount(SearchResults, {
     props: {
       initialProjects: [projectWithoutStats],
@@ -119,4 +119,27 @@ test('SearchResults updates count when filter returns additional results', async
 
   const resultsCount = wrapper.find('.results-count');
   expect(resultsCount.text()).toBe('0 projects found');
+
+  expect(window.location.search).toContain('q=foo');
+});
+
+test('SearchResults updates count when filter returns additional results and text is in query string', async () => {
+  const wrapper = mount(SearchResults, {
+    props: {
+      initialProjects: [projectWithoutStats],
+    },
+    global: {
+      plugins: [VueQueryPlugin],
+    },
+  });
+
+  const textInput = wrapper.find('#last-updated');
+  await textInput.setValue('7');
+
+  await flushPromises();
+
+  const resultsCount = wrapper.find('.results-count');
+  expect(resultsCount.text()).toBe('0 projects found');
+
+  expect(window.location.search).toContain('lastUpdated=7');
 });

--- a/src/components/search/SearchResults.vue
+++ b/src/components/search/SearchResults.vue
@@ -11,6 +11,9 @@ import { type WebsiteProject } from '../data/schema';
 
 import ProjectEntry from './ProjectEntry.vue';
 
+const QUERY_PARAM = 'q';
+const LAST_UPDATED_PARAM = 'lastUpdated';
+
 const props = defineProps<{
   initialProjects: Array<WebsiteProject>;
 }>();
@@ -21,6 +24,26 @@ const searchText = defineModel('searchText', { default: '' });
 const lastUpdatedDays = defineModel('lastUpdatedDays', {
   default: InitialDaysActive,
 });
+
+function updateQueryString() {
+  const params = new URLSearchParams(window.location.search);
+
+  const query = searchText.value.trim();
+  if (query.length > 0) {
+    params.set(QUERY_PARAM, query);
+  } else {
+    params.delete(QUERY_PARAM);
+  }
+
+  params.set(LAST_UPDATED_PARAM, String(lastUpdatedDays.value));
+
+  const queryString = params.toString();
+  const nextUrl = queryString
+    ? `${window.location.pathname}?${queryString}${window.location.hash}`
+    : `${window.location.pathname}${window.location.hash}`;
+
+  window.history.replaceState({}, '', nextUrl);
+}
 
 function parseLastUpdated(key: string | number): Date | Error {
   if (typeof key === 'number') {
@@ -59,10 +82,35 @@ const { data, error, isPending, isError, refetch } = useQuery({
   enabled: isMounted,
 });
 
-onMounted(() => (isMounted.value = true));
+onMounted(() => {
+  isMounted.value = true;
 
-watch(searchText, () => refetch());
-watch(lastUpdatedDays, () => refetch());
+  const params = new URLSearchParams(window.location.search);
+
+  const initialQuery = params.get(QUERY_PARAM);
+  if (initialQuery) {
+    searchText.value = initialQuery;
+  }
+
+  const lastUpdatedParam = params.get(LAST_UPDATED_PARAM);
+  if (lastUpdatedParam) {
+    const parsedValue = parseInt(lastUpdatedParam, 10);
+    if (!Number.isNaN(parsedValue)) {
+      lastUpdatedDays.value = parsedValue;
+    }
+  }
+  updateQueryString();
+});
+
+watch(searchText, () => {
+  updateQueryString();
+  refetch();
+});
+
+watch(lastUpdatedDays, () => {
+  updateQueryString();
+  refetch();
+});
 </script>
 
 <style>
@@ -131,8 +179,7 @@ menu {
 
         <select v-model="lastUpdatedDays" aria-labelledby="activity-filter">
           <option value="7">1 week</option>
-          <option selected value="30">1 month</option>
-          <!-- TODO: how to keep selected in sync with items? onMount? -->
+          <option value="30">1 month</option>
           <option value="180">6 months</option>
           <option value="365">1 year</option>
           <option value="730">2 years</option>

--- a/src/components/search/SearchResults.vue
+++ b/src/components/search/SearchResults.vue
@@ -177,7 +177,11 @@ menu {
           >Choose projects active within the previous</label
         >
 
-        <select v-model="lastUpdatedDays" aria-labelledby="activity-filter">
+        <select
+          v-model="lastUpdatedDays"
+          id="last-updated"
+          aria-labelledby="activity-filter"
+        >
           <option value="7">1 week</option>
           <option value="30">1 month</option>
           <option value="180">6 months</option>


### PR DESCRIPTION
## Summary
- initialize the Astro search form from URL query params (`q` and `lastUpdated`)
- keep input/select UI in sync with that restored state
- update the URL via `history.replaceState` whenever filters change

## Validation
- `npx eslint -c eslint-new.config.mjs src/components/search/SearchResults.vue`

Fixes #5508
