### PR TITLE
fix: update dead and placeholder site URLs (11 files)

### DIFF
--- a/_data/projects/Bolt.yml
+++ b/_data/projects/Bolt.yml
@@ -1,7 +1,7 @@
 ---
 name: Bolt
 desc: A URL Shortener written in C# using ASP.NET Core
-site: https://bolturl.herokuapp.com
+site: https://github.com/monke8555/Bolt
 tags:
 - c#
 - ".net-core"

--- a/_data/projects/ClickHouse.yml
+++ b/_data/projects/ClickHouse.yml
@@ -1,7 +1,7 @@
 ---
 name: ClickHouse
 desc: ClickHouse is a fast open-source OLAP database management system
-site: https://clickhouse.tech/
+site: https://clickhouse.com
 tags:
 - sql
 - big-data

--- a/_data/projects/iotest.yml
+++ b/_data/projects/iotest.yml
@@ -1,7 +1,7 @@
 ---
 name: test.io
 desc: Socket.io online test tool
-site: http://io-tester.herokuapp.com/
+site: https://github.com/yavrumian/test.io
 tags:
 - socket.io
 - test

--- a/_data/projects/ipfs.yml
+++ b/_data/projects/ipfs.yml
@@ -1,7 +1,7 @@
 ---
 name: IPFS
 desc: 'The InterPlanetary File System: The Permanent Web'
-site: https://ipfs.io
+site: https://ipfs.tech
 tags:
 - javascript
 - go

--- a/_data/projects/npjs-basic.yml
+++ b/_data/projects/npjs-basic.yml
@@ -1,7 +1,7 @@
 ---
 name: npjs-basic
 desc: A numpy-like library for npm
-site: https://example.org/your-project-link-here
+site: https://github.com/hrishibawane/npjs-basic
 tags:
 - javascript
 - node.js

--- a/_data/projects/sentry.yml
+++ b/_data/projects/sentry.yml
@@ -3,7 +3,7 @@ name: Sentry .NET SDK
 desc: >-
   Client libraries for Sentry, an error reporting and performance monitoring platform, for usage from
   .NET and popular application frameworks
-site: https://getsentry.github.io/sentry-dotnet
+site: https://docs.sentry.io/platforms/dotnet/
 tags:
 - crash-reporting
 - error-logging

--- a/_data/projects/shogun.yml
+++ b/_data/projects/shogun.yml
@@ -2,7 +2,7 @@
 name: Shogun Machine Learning Toolbox
 desc: "Shogun is a unified and efficient machine learning library. \nWe support multiple languages and
   platforms, have an efficient core in C++ and a great community.\n"
-site: http://shogun.ml/
+site: https://github.com/shogun-toolbox/shogun
 tags:
 - machine-learning
 - ml

--- a/_data/projects/signs.yml
+++ b/_data/projects/signs.yml
@@ -3,7 +3,7 @@ name: Sinhala Fingerspelling Alphabet Learning Tool
 desc: >-
   A hand pose based web application developed as a training tool for people learning the Sinhala (Sri
   Lankan) fingerspelling alphabet
-site: https://example.org/your-project-link-here
+site: https://github.com/aawgit/signs-web
 tags:
 - reactjs
 - mediapipe

--- a/_data/projects/sortingVisualizer.yml
+++ b/_data/projects/sortingVisualizer.yml
@@ -2,7 +2,7 @@
 name: Sorting Visualizer
 desc: >-
   A web-based tool to visualize popular sorting algorithms with animations, built using React and Material-UI.
-site: https://github.com/your-username/sorting-visualizer
+site: https://github.com/Mr-G-D/Sorting-Visualizer
 tags:
 - sorting
 - visualization

--- a/_data/projects/water-css.yml
+++ b/_data/projects/water-css.yml
@@ -1,7 +1,7 @@
 ---
 name: water.css
 desc: A just-add-css collection of styles to make simple websites just a little nicer.
-site: https://watercss.netlify.com/
+site: https://watercss.kognise.dev/
 tags:
 - css
 - sass

--- a/_data/projects/xUnit.net.yml
+++ b/_data/projects/xUnit.net.yml
@@ -1,7 +1,7 @@
 ---
 name: xUnit.net
 desc: A free, open source, community-focused unit testing tool for the .NET Framework.
-site: https://xunit.github.io/
+site: https://xunit.net
 tags:
 - unit-testing
 - testing


### PR DESCRIPTION
## Problem

Several project listings had broken or incorrect `site` URLs discovered during a systematic scan of the `_data/projects/` directory:

- **Hijacked domain**: `shogun.ml` now redirects to a casino spam site
- **Placeholder URLs**: 3 files were submitted with the template's example URLs never replaced (`example.org/your-project-link-here`, `github.com/your-username/...`)
- **Dead Heroku URLs**: 2 projects used Heroku free-tier URLs that were shut down in Dec 2022
- **Moved domains**: 4 projects moved to new URLs (`ipfs.io` → `ipfs.tech`, `clickhouse.tech` → `clickhouse.com`, `watercss.netlify.com` → `watercss.kognise.dev`, `xunit.github.io` → `xunit.net`)
- **Dead GitHub Pages**: `getsentry.github.io/sentry-dotnet` (404)

## Changes

| File | Before | After |
|------|--------|-------|
| `shogun.yml` | `http://shogun.ml/` (hijacked→casino) | `https://github.com/shogun-toolbox/shogun` |
| `signs.yml` | `https://example.org/your-project-link-here` | `https://github.com/aawgit/signs-web` |
| `npjs-basic.yml` | `https://example.org/your-project-link-here` | `https://github.com/hrishibawane/npjs-basic` |
| `sortingVisualizer.yml` | `https://github.com/your-username/sorting-visualizer` | `https://github.com/Mr-G-D/Sorting-Visualizer` |
| `ipfs.yml` | `https://ipfs.io` | `https://ipfs.tech` |
| `ClickHouse.yml` | `https://clickhouse.tech/` | `https://clickhouse.com` |
| `water-css.yml` | `https://watercss.netlify.com/` | `https://watercss.kognise.dev/` |
| `xUnit.net.yml` | `https://xunit.github.io/` | `https://xunit.net` |
| `Bolt.yml` | `https://bolturl.herokuapp.com` | `https://github.com/monke8555/Bolt` |
| `iotest.yml` | `http://io-tester.herokuapp.com/` | `https://github.com/yavrumian/test.io` |
| `sentry.yml` | `https://getsentry.github.io/sentry-dotnet` | `https://docs.sentry.io/platforms/dotnet/` |

## Verification

- [x] All replacement URLs verified returning HTTP 200
- [x] YAML syntax unchanged (single-line `site:` field replacement only)
- [x] No unrelated modifications
- [x] `upforgrabs.link` URLs all remain valid (not changed)