### PR TITLE
fix: upgrade 54 project site URLs from http:// to https://

### DIFF
--- a/_data/projects/ApplicationInsights-dotnet.yml
+++ b/_data/projects/ApplicationInsights-dotnet.yml
@@ -2,7 +2,7 @@
 name: ApplicationInsights-dotnet
 desc: >-
   Azure Application Insights SDK for .NET. Includes public API surface, serialization and channel implementation
-site: http://go.microsoft.com/fwlink/?LinkId=392727
+site: https://go.microsoft.com/fwlink/?LinkId=392727
 tags:
 - ".net"
 - monitoring

--- a/_data/projects/Babel.yml
+++ b/_data/projects/Babel.yml
@@ -1,7 +1,7 @@
 ---
 name: Babel
 desc: The compiler for writing next generation JavaScript.
-site: http://babeljs.io/
+site: https://babeljs.io/
 tags:
 - javascript
 - web

--- a/_data/projects/Flarum.yml
+++ b/_data/projects/Flarum.yml
@@ -1,7 +1,7 @@
 ---
 name: Flarum
 desc: Forums made simple.
-site: http://flarum.org
+site: https://flarum.org
 tags:
 - web
 - php

--- a/_data/projects/GUN-extensions.yml
+++ b/_data/projects/GUN-extensions.yml
@@ -3,7 +3,7 @@ name: gun extensions
 desc: >-
   GUN is an extensible, realtime, decentralized, offline-first, graph database engine.  These tasks are
   for extensions.  Core code is available at https://github.com/amark/gun.
-site: http://gun.js.org/
+site: https://gun.js.org/
 tags:
 - javascript
 - database

--- a/_data/projects/HHVM.yml
+++ b/_data/projects/HHVM.yml
@@ -1,7 +1,7 @@
 ---
 name: HipHopVM
 desc: Compiler and Runtime for PHP and Hack languages
-site: http://hhvm.com
+site: https://hhvm.com
 tags:
 - c++
 - php

--- a/_data/projects/Hilary.yml
+++ b/_data/projects/Hilary.yml
@@ -1,7 +1,7 @@
 ---
 name: Hilary
 desc: Open Academic Environment project back-end
-site: http://oaeproject.org/
+site: https://oaeproject.org/
 tags:
 - javascript
 - node.js

--- a/_data/projects/Homebrew-Core.yml
+++ b/_data/projects/Homebrew-Core.yml
@@ -1,7 +1,7 @@
 ---
 name: Homebrew-Core
 desc: Core formulae for the Homebrew package manager
-site: http://brew.sh/
+site: https://brew.sh/
 tags:
 - ruby
 - osx

--- a/_data/projects/Homebrew.yml
+++ b/_data/projects/Homebrew.yml
@@ -1,7 +1,7 @@
 ---
 name: Homebrew
 desc: Homebrew is a package manager for OS X.
-site: http://brew.sh/
+site: https://brew.sh/
 tags:
 - ruby
 - osx

--- a/_data/projects/Hoodie.yml
+++ b/_data/projects/Hoodie.yml
@@ -1,7 +1,7 @@
 ---
 name: Hoodie
 desc: Backend for Offline First Applications
-site: http://hood.ie
+site: https://hood.ie
 tags:
 - javascript
 - web

--- a/_data/projects/LearnDocker.yml
+++ b/_data/projects/LearnDocker.yml
@@ -3,7 +3,7 @@ name: Learn Docker
 desc: >-
   This repository walks you through the basics of Docker and Containers. It contains all commands for
   getting started with Docker!
-site: http://github.com/josharsh/LearnDocker
+site: https://github.com/josharsh/LearnDocker
 tags:
 - oss
 - docker

--- a/_data/projects/Numbas.yml
+++ b/_data/projects/Numbas.yml
@@ -4,7 +4,7 @@ desc: >-
   An e-assessment system aimed at mathematical disciplines. It produces SCORM packages - everything happens
   on the client in JavaScript! The package compiler is written in Python. There's plenty for someone with
   a good knowledge of maths to work on.
-site: http://www.numbas.org.uk/contributing-to-numbas/
+site: https://www.numbas.org.uk/contributing-to-numbas/
 tags:
 - python
 - javascript

--- a/_data/projects/axelrod.yml
+++ b/_data/projects/axelrod.yml
@@ -1,7 +1,7 @@
 ---
 name: Axelrod-Python
 desc: A research tool to run Iterated Prisoner's Dilemma tournaments.
-site: http://axelrod.readthedocs.io/en/latest/
+site: https://axelrod.readthedocs.io/en/latest/
 tags:
 - oss
 - python

--- a/_data/projects/bpython.yml
+++ b/_data/projects/bpython.yml
@@ -1,7 +1,7 @@
 ---
 name: bpython
 desc: A fancy interface to the Python interpreter
-site: http://bpython-interpreter.org/
+site: https://bpython-interpreter.org/
 tags:
 - python
 upforgrabs:

--- a/_data/projects/check-it-out.yml
+++ b/_data/projects/check-it-out.yml
@@ -1,7 +1,7 @@
 ---
 name: check-it-out
 desc: A command line interface for Git Checkout
-site: http://checkit.club
+site: https://checkit.club
 tags:
 - git
 - github

--- a/_data/projects/dancer2.yml
+++ b/_data/projects/dancer2.yml
@@ -1,7 +1,7 @@
 ---
 name: Dancer2
 desc: Fast, flexible, modern Perl web framework
-site: http://www.perldancer.org/
+site: https://www.perldancer.org/
 tags:
 - perl
 - web

--- a/_data/projects/datafu.yml
+++ b/_data/projects/datafu.yml
@@ -1,6 +1,6 @@
 name: Apache DataFu
 desc: DataFu is a collection of libraries for working with large-scale data in Hadoop.
-site: http://datafu.apache.org/
+site: https://datafu.apache.org/
 tags:
 - scala
 - apache

--- a/_data/projects/deepstream.io.yml
+++ b/_data/projects/deepstream.io.yml
@@ -1,7 +1,7 @@
 ---
 name: deepstream.io
 desc: A Scalable Server for Realtime Web Apps
-site: http://deepstream.io/
+site: https://deepstream.io/
 tags:
 - node.js
 - tcp

--- a/_data/projects/dotnet-api-docs.yml
+++ b/_data/projects/dotnet-api-docs.yml
@@ -1,7 +1,7 @@
 ---
 name: ".NET API Docs"
 desc: API documentation for .NET
-site: http://github.com/dotnet/dotnet-api-docs
+site: https://github.com/dotnet/dotnet-api-docs
 tags:
 - ".net"
 - documentation

--- a/_data/projects/dotnet-docs-desktop.yml
+++ b/_data/projects/dotnet-docs-desktop.yml
@@ -1,7 +1,7 @@
 ---
 name: ".NET WPF & WinForms Docs"
 desc: 'Documentation for .NET Desktop tehcnologies: Windows Forms and WPF'
-site: http://github.com/dotnet/docs-desktop
+site: https://github.com/dotnet/docs-desktop
 tags:
 - ".net"
 - documentation

--- a/_data/projects/dotnet-docs.yml
+++ b/_data/projects/dotnet-docs.yml
@@ -1,7 +1,7 @@
 ---
 name: ".NET Docs"
 desc: Documentation for .NET
-site: http://github.com/dotnet/docs
+site: https://github.com/dotnet/docs
 tags:
 - ".net"
 - documentation

--- a/_data/projects/edumips64.yml
+++ b/_data/projects/edumips64.yml
@@ -1,7 +1,7 @@
 ---
 name: EduMIPS64
 desc: A cross-platform educational MIPS64 CPU simulator.
-site: http://www.edumips.org
+site: https://www.edumips.org
 tags:
 - java
 - simulator

--- a/_data/projects/emscripten.yml
+++ b/_data/projects/emscripten.yml
@@ -1,7 +1,7 @@
 ---
 name: Emscripten
 desc: A compiler from C and C++ to JavaScript/asm.js
-site: http://emscripten.org
+site: https://emscripten.org
 tags:
 - oss
 - compiler

--- a/_data/projects/filehelpers.yml
+++ b/_data/projects/filehelpers.yml
@@ -3,7 +3,7 @@ name: FileHelpers Library
 desc: >-
   FileHelpers is a free and easy to use .NET library to import or export data from fixed length or delimited
   records in files, strings or streams.
-site: http://www.filehelpers.net
+site: https://www.filehelpers.net
 tags:
 - csv
 - flatfiles

--- a/_data/projects/formo.yml
+++ b/_data/projects/formo.yml
@@ -3,7 +3,7 @@ name: Formo
 desc: >-
   Formo allows you to use your configuration file as a dynamic object. Turn your web.config or application
   settings into a rich, dynamic object.
-site: http://github.com/ChrisMissal/Formo
+site: https://github.com/ChrisMissal/Formo
 tags:
 - c#
 - configuration

--- a/_data/projects/friendica.yml
+++ b/_data/projects/friendica.yml
@@ -3,7 +3,7 @@ name: Friendica
 desc: >-
   Friendica is a communications platform for integrated social communications utilising decentralised
   communications and linkage to several indie social projects - as well as popular mainstream providers.
-site: http://friendi.ca
+site: https://friendi.ca
 tags:
 - oss
 - web

--- a/_data/projects/grails.yml
+++ b/_data/projects/grails.yml
@@ -1,7 +1,7 @@
 ---
 name: Grails
 desc: Grails Web Framework
-site: http://grails.org/
+site: https://grails.org/
 tags:
 - grails
 - groovy

--- a/_data/projects/jesterj.yml
+++ b/_data/projects/jesterj.yml
@@ -1,7 +1,7 @@
 ---
 name: JesterJ
 desc: Free Open Source Search focused Document Ingestion system.
-site: http://www.jesterj.org/
+site: https://www.jesterj.org/
 tags:
 - search
 - etl

--- a/_data/projects/johnny-five.yml
+++ b/_data/projects/johnny-five.yml
@@ -1,7 +1,7 @@
 ---
 name: Johnny-Five
 desc: JavaScript Robotics and IoT programming framework
-site: http://johnny-five.io
+site: https://johnny-five.io
 tags:
 - javascript
 - iot

--- a/_data/projects/kotlin.yml
+++ b/_data/projects/kotlin.yml
@@ -1,7 +1,7 @@
 ---
 name: Kotlin
 desc: Kotlin Programming Language
-site: http://kotlinlang.org
+site: https://kotlinlang.org
 tags:
 - java
 - jvm

--- a/_data/projects/leaflet.yml
+++ b/_data/projects/leaflet.yml
@@ -1,7 +1,7 @@
 ---
 name: Leaflet
 desc: JavaScript library for mobile-friendly interactive maps
-site: http://leafletjs.com
+site: https://leafletjs.com
 tags:
 - javascript
 - maps

--- a/_data/projects/libreoffice-crash-reports.yml
+++ b/_data/projects/libreoffice-crash-reports.yml
@@ -1,7 +1,7 @@
 ---
 name: LibreOffice Crash Reports
 desc: Django-based website with statistics about LibreOffice crash reports
-site: http://crashreport.libreoffice.org/stats/
+site: https://crashreport.libreoffice.org/stats/
 tags:
 - libreoffice
 - office

--- a/_data/projects/linkin.yml
+++ b/_data/projects/linkin.yml
@@ -1,7 +1,7 @@
 ---
 name: Linkin
 desc: Linkin is a customizable self hosted link tree platform
-site: http://linkindemo.vercel.app/
+site: https://linkindemo.vercel.app/
 tags:
 - reactjs
 - nextjs

--- a/_data/projects/moment-timezone.yml
+++ b/_data/projects/moment-timezone.yml
@@ -1,7 +1,7 @@
 ---
 name: Moment-Timezone
 desc: Time zone add-on for moment.js
-site: http://momentjs.com/timezone
+site: https://momentjs.com/timezone
 tags:
 - javascript
 - date

--- a/_data/projects/momentjs.yml
+++ b/_data/projects/momentjs.yml
@@ -1,7 +1,7 @@
 ---
 name: Moment.js
 desc: Parse, validate, manipulate, and display dates in JavaScript.
-site: http://momentjs.com
+site: https://momentjs.com
 tags:
 - javascript
 - date

--- a/_data/projects/momentjscom.yml
+++ b/_data/projects/momentjscom.yml
@@ -1,7 +1,7 @@
 ---
 name: momentjs.com
 desc: Web site and documentation content for moment.js
-site: http://momentjs.com
+site: https://momentjs.com
 tags:
 - javascript
 - date

--- a/_data/projects/monument-cli.yml
+++ b/_data/projects/monument-cli.yml
@@ -1,7 +1,7 @@
 ---
 name: monument-cli
 desc: the CLI for rapid development with monument
-site: http://monument.ansble.com
+site: https://monument.ansble.com
 tags:
 - javascript
 - cli

--- a/_data/projects/monument.yml
+++ b/_data/projects/monument.yml
@@ -1,7 +1,7 @@
 ---
 name: monument
 desc: event driven lightweight application framework for node
-site: http://monument.ansble.com
+site: https://monument.ansble.com
 tags:
 - javascript
 - server

--- a/_data/projects/mpf.yml
+++ b/_data/projects/mpf.yml
@@ -5,7 +5,7 @@ desc: >-
   to run real pinball machines. It allows both casual builders and hard-core programmers to create the
   software to run their pinball machines—whether it’s new game code for an existing pinball machine, a
   “re-theme” of an old machine, or totally custom / homebrew machine built from scratch.
-site: http://missionpinball.org/
+site: https://missionpinball.org/
 tags:
 - python
 - pinball

--- a/_data/projects/numbas-editor.yml
+++ b/_data/projects/numbas-editor.yml
@@ -4,7 +4,7 @@ desc: >-
   An editor for Numbas, an e-assessment system aimed at mathematical disciplines. The editor is written
   in Django, with knockout.js for the frontend. There's plenty for someone with a good knowledge of maths,
   or an interest in UX, to work on.
-site: http://www.numbas.org.uk/contributing-to-numbas/
+site: https://www.numbas.org.uk/contributing-to-numbas/
 tags:
 - python
 - javascript

--- a/_data/projects/openra.yml
+++ b/_data/projects/openra.yml
@@ -3,7 +3,7 @@ name: OpenRA
 desc: >-
   A modern Open Source cross-platform reimplementation of the Command & Conquer Red Alert engine written
   in C# using OpenGL.
-site: http://www.openra.net
+site: https://www.openra.net
 tags:
 - ".net"
 - mono

--- a/_data/projects/origodb.yml
+++ b/_data/projects/origodb.yml
@@ -1,7 +1,7 @@
 ---
 name: OrigoDB Core
 desc: In-memory database for .NET
-site: http://origodb.com
+site: https://origodb.com
 tags:
 - ".net"
 - in-memory

--- a/_data/projects/osem.yml
+++ b/_data/projects/osem.yml
@@ -1,7 +1,7 @@
 ---
 name: Open Source Event Manager
 desc: Event Management App Tailored to Free Software Conferences
-site: http://osem.io/
+site: https://osem.io/
 tags:
 - ruby
 - rails

--- a/_data/projects/pandas.yml
+++ b/_data/projects/pandas.yml
@@ -1,7 +1,7 @@
 ---
 name: pandas
 desc: Powerful Python data analysis toolkit.
-site: http://pandas.pydata.org/
+site: https://pandas.pydata.org/
 tags:
 - python
 - data

--- a/_data/projects/pickles.yml
+++ b/_data/projects/pickles.yml
@@ -3,7 +3,7 @@ name: Pickles
 desc: >-
   The open source Living Documentation generator turns your feature files into a web site so that non-technical
   people can easily read the scenarios.
-site: http://www.picklesdoc.com/
+site: https://www.picklesdoc.com/
 tags:
 - c#
 - ".net"

--- a/_data/projects/pitivi.yml
+++ b/_data/projects/pitivi.yml
@@ -1,7 +1,7 @@
 ---
 name: Pitivi
 desc: Simple and powerful video editor based on GStreamer
-site: http://pitivi.org
+site: https://pitivi.org
 tags:
 - python
 - video

--- a/_data/projects/react-test.yml
+++ b/_data/projects/react-test.yml
@@ -1,7 +1,7 @@
 ---
 name: React Test
 desc: An expressive testing library for React. This is not made by facebook/react team.
-site: http://react-test.dev/
+site: https://react-test.dev/
 tags:
 - reactjs
 - test

--- a/_data/projects/seneca.yml
+++ b/_data/projects/seneca.yml
@@ -1,7 +1,7 @@
 ---
 name: seneca
 desc: A microservices toolkit for Node.js
-site: http://senecajs.org/
+site: https://senecajs.org/
 tags:
 - javascript
 - node.js

--- a/_data/projects/serilog.yml
+++ b/_data/projects/serilog.yml
@@ -3,7 +3,7 @@ name: Serilog
 desc: >-
   Simple .NET logging with fully-structured events. Serilog combines the best features of traditional
   and structured diagnostic logging in an easy-to-use package
-site: http://serilog.net
+site: https://serilog.net
 tags:
 - logging
 - events

--- a/_data/projects/sharerjs.yml
+++ b/_data/projects/sharerjs.yml
@@ -1,7 +1,7 @@
 ---
 name: Sharer.js
 desc: Create your own social share buttons. No JQuery
-site: http://ellisonleao.github.io/sharer.js
+site: https://ellisonleao.github.io/sharer.js
 tags:
 - javascript
 - date

--- a/_data/projects/solidity.yml
+++ b/_data/projects/solidity.yml
@@ -1,7 +1,7 @@
 ---
 name: Solidity
 desc: The Solidity Contract-Oriented Programming Language
-site: http://github.com/ethereum/solidity
+site: https://github.com/ethereum/solidity
 tags:
 - ethereum
 - solidity

--- a/_data/projects/solr.yml
+++ b/_data/projects/solr.yml
@@ -1,7 +1,7 @@
 ---
 name: Apache Solr
 desc: Solr is the popular, blazing-fast, open source enterprise search platform built on Apache Lucene™.
-site: http://lucene.apache.org/solr/
+site: https://lucene.apache.org/solr/
 tags:
 - solr
 - apache

--- a/_data/projects/streamplify.yml
+++ b/_data/projects/streamplify.yml
@@ -1,7 +1,7 @@
 ---
 name: streamplify
 desc: Java 8 combinatorics-related streams and other utilities
-site: http://streamplify.beryx.org
+site: https://streamplify.beryx.org
 tags:
 - java
 - streams

--- a/_data/projects/ubos.yml
+++ b/_data/projects/ubos.yml
@@ -1,7 +1,7 @@
 ---
 name: UBOS
 desc: Linux distro for Personal Servers and indie IoT devices
-site: http://ubos.net/
+site: https://ubos.net/
 tags:
 - apache
 - apps

--- a/_data/projects/vuejs.yml
+++ b/_data/projects/vuejs.yml
@@ -1,7 +1,7 @@
 ---
 name: Vue.js
 desc: Simple yet powerful library for building modern web interfaces.
-site: http://vuejs.org
+site: https://vuejs.org
 tags:
 - javascript
 - user-interface


### PR DESCRIPTION
## Problem

54 project listings use `http://` for their `site:` URL despite the sites supporting HTTPS. This causes mixed-content warnings and is a security concern for visitors following these links.

## Solution

Upgraded all 54 `site:` URLs from `http://` to `https://`. Each HTTPS URL was verified to return HTTP 200 before being included.

## Files changed (54)

`ApplicationInsights-dotnet.yml`, `axelrod.yml`, `Babel.yml`, `bpython.yml`, `check-it-out.yml`, `dancer2.yml`, `datafu.yml`, `deepstream.io.yml`, `dotnet-api-docs.yml`, `dotnet-docs-desktop.yml`, `dotnet-docs.yml`, `edumips64.yml`, `emscripten.yml`, `filehelpers.yml`, `Flarum.yml`, `formo.yml`, `friendica.yml`, `grails.yml`, `GUN-extensions.yml`, `HHVM.yml`, `Hilary.yml`, `Homebrew-Core.yml`, `Homebrew.yml`, `Hoodie.yml`, `jesterj.yml`, `johnny-five.yml`, `kotlin.yml`, `leaflet.yml`, `LearnDocker.yml`, `libreoffice-crash-reports.yml`, `linkin.yml`, `moment-timezone.yml`, `momentjs.yml`, `momentjscom.yml`, `monument-cli.yml`, `monument.yml`, `mpf.yml`, `Numbas.yml`, `numbas-editor.yml`, `openra.yml`, `origodb.yml`, `osem.yml`, `pandas.yml`, `pickles.yml`, `pitivi.yml`, `react-test.yml`, `seneca.yml`, `serilog.yml`, `sharerjs.yml`, `solidity.yml`, `solr.yml`, `streamplify.yml`, `ubos.yml`, `vuejs.yml`

## Verification

- [x] All 54 HTTPS URLs verified returning HTTP 200
- [x] Only the `site:` field changed in each file — no other modifications
- [x] YAML syntax unchanged (single character substitution per file)
- [x] `upforgrabs.link` URLs untouched