### PR TITLE
fix: replace 35 dead site URLs with working alternatives

### DIFF
--- a/_data/projects/Aton.yml
+++ b/_data/projects/Aton.yml
@@ -1,7 +1,7 @@
 ---
 name: Aton
 desc: Computer room administration made free
-site: http://camilosampedro.me/Aton
+site: https://github.com/camilosampedro/Aton
 tags:
 - scala
 - play-framework

--- a/_data/projects/ClippyService.yml
+++ b/_data/projects/ClippyService.yml
@@ -1,7 +1,7 @@
 ---
 name: Clippy Service
 desc: Rust Linting (with Clippy) as a Webservice
-site: http://clippy.bashy.io
+site: https://github.com/gnunicorn/clippy-service
 tags:
 - rust
 - compiler

--- a/_data/projects/EvalAI.yml
+++ b/_data/projects/EvalAI.yml
@@ -3,7 +3,7 @@ name: EvalAI
 desc: >-
   EvalAI is an open source web application that helps researchers, students and data-scientists to create,
   collaborate and participate in various AI challenges organized round the globe.
-site: https://evalai.cloudcv.org/
+site: https://github.com/Cloud-CV/EvalAI
 tags:
 - ai
 - ai-challenge

--- a/_data/projects/FDVueWebapp.yml
+++ b/_data/projects/FDVueWebapp.yml
@@ -1,7 +1,7 @@
 ---
 name: Freedomotic Vue Webapp
 desc: A Vue.js web application for Freedomotic Open IoT framework
-site: http://fd-vue-webapp.herokuapp.com/
+site: https://github.com/freedomotic/fd-vue-webapp
 tags:
 - vue.js
 - javascript

--- a/_data/projects/GreenBerry.yml
+++ b/_data/projects/GreenBerry.yml
@@ -3,7 +3,7 @@ name: GreenBerry
 desc: >-
   One-line statement language. Contribute to the development of a new language written in pure python,
   complete with ide. Propose new syntax or work as a core dev implementing support for them.
-site: https://abdur-rahmaanj.github.io/greenBerry/
+site: https://github.com/Abdur-rahmaanJ/greenberry
 tags:
 - python
 - new-language

--- a/_data/projects/OpenLiveWriter.yml
+++ b/_data/projects/OpenLiveWriter.yml
@@ -1,7 +1,7 @@
 ---
 name: Open Live Writer
 desc: Open Live Writer makes it easy to write, preview, and post to your blog.
-site: http://openlivewriter.org/
+site: https://github.com/OpenLiveWriter/OpenLiveWriter
 tags:
 - c#
 - winforms

--- a/_data/projects/TakeMeThere.yml
+++ b/_data/projects/TakeMeThere.yml
@@ -1,7 +1,7 @@
 ---
 name: Take Me There
 desc: A URL Shortening service powered by Google Apps Script
-site: https://tmt.pw
+site: https://github.com/choraria/gas-url-shortener
 tags:
 - google-apps-script
 - url-shortener

--- a/_data/projects/US-Prosecutor-Database.yml
+++ b/_data/projects/US-Prosecutor-Database.yml
@@ -3,7 +3,7 @@ name: U.S. Prosecutor Database
 desc: >-
   An open-source web app to help people hold prosecutors accountable for police brutality. Filter through
   prosecutors by name, role, state, area. Find resources like contact information &amp; relevant articles.
-site: https://us-prosecutor-database.herokuapp.com
+site: https://github.com/billimarie/prosecutor-database
 tags:
 - meteor
 - mongodb

--- a/_data/projects/WinYourBattle.yml
+++ b/_data/projects/WinYourBattle.yml
@@ -1,7 +1,7 @@
 ---
 name: WinYourBattle
 desc: An addiction tracker web app
-site: https://winyourbattle.ddns.net
+site: https://github.com/sharkpause/WinYourBattle
 tags:
 - javascript
 - laravel

--- a/_data/projects/atvjs.yml
+++ b/_data/projects/atvjs.yml
@@ -1,7 +1,7 @@
 ---
 name: atvjs
 desc: Blazing fast Apple TV application development using pure JavaScript
-site: https://emadalam.github.io/atvjs
+site: https://github.com/emadalam/atvjs
 tags:
 - javascript
 - apple-tv

--- a/_data/projects/battleships.yml
+++ b/_data/projects/battleships.yml
@@ -1,7 +1,7 @@
 ---
 name: Battleships
 desc: Strategy type guessing game
-site: http://ec2-3-142-134-11.us-east-2.compute.amazonaws.com:3000/
+site: https://github.com/np25071984/battleships
 tags:
 - typescript
 - board-game

--- a/_data/projects/defe.yml
+++ b/_data/projects/defe.yml
@@ -1,7 +1,7 @@
 ---
 name: defe
 desc: A Tech feed Aggregator for Developers & Tech Enthusiasts
-site: https://defe-app.herokuapp.com/
+site: https://github.com/Bhupesh-V/defe
 tags:
 - python
 - javascript

--- a/_data/projects/esfiddle.yml
+++ b/_data/projects/esfiddle.yml
@@ -3,7 +3,7 @@ name: esfiddle
 desc: >-
   Try out the newest ES6+ features in your browser. We are creating a brand new React Frontend and Typescipt
   API - we'd love to have your help!
-site: https://esfiddle.net/
+site: https://github.com/esfiddle/esfiddle
 tags:
 - oss
 - web

--- a/_data/projects/flame-coach-web.yml
+++ b/_data/projects/flame-coach-web.yml
@@ -1,7 +1,7 @@
 ---
 name: Flame Coach
 desc: A simple way nutrition coaches track their client's progress!
-site: https://app.flamenutrition.co.uk/login
+site: https://github.com/FlameNutrition/flame-coach-web
 tags:
 - kotlin
 - java

--- a/_data/projects/hilbish.yml
+++ b/_data/projects/hilbish.yml
@@ -1,7 +1,7 @@
 ---
 name: Hilbish
 desc: An extensible Lua-configured Unix shell
-site: https://rosettea.github.io/Hilbish
+site: https://github.com/Rosettea/Hilbish
 tags:
 - shell
 - lua

--- a/_data/projects/horusec.yml
+++ b/_data/projects/horusec.yml
@@ -3,7 +3,7 @@ name: Horusec
 desc: >-
   Horusec is an open source tool that improves identification of vulnerabilities in your project with
   just one command.
-site: https://horusec.io
+site: https://github.com/ZupIT/horusec
 tags:
 - java
 - javascript

--- a/_data/projects/human-connection.yml
+++ b/_data/projects/human-connection.yml
@@ -1,7 +1,7 @@
 ---
 name: Human Connection
 desc: The free and open source social network for active citizenship.
-site: https://human-connection.org/en/in-nerds-we-trust/
+site: https://github.com/Human-Connection/Human-Connection
 tags:
 - javascript
 - vuejs

--- a/_data/projects/ieee-com-soc-new-project.yml
+++ b/_data/projects/ieee-com-soc-new-project.yml
@@ -3,7 +3,7 @@ name: Annual-Yearbook
 desc: >-
   A yearbook which records the precious memories of University students to add their messages in their
   yearbook.
-site: https://memories.ieeecsvitc.com
+site: https://github.com/ComputerSocietyVITC/Annual-Yearbook
 tags:
 - typescript
 - javascript

--- a/_data/projects/ipfs-pastebin.yml
+++ b/_data/projects/ipfs-pastebin.yml
@@ -1,7 +1,7 @@
 ---
 name: ipfs-pastebin
 desc: A text/code sharing pastebin based on IPFS
-site: https://ipfs-pastebin.herokuapp.com
+site: https://github.com/hrishibawane/ipfs-pastebin
 tags:
 - pastebin
 - ipfs

--- a/_data/projects/lecturesWWW.yml
+++ b/_data/projects/lecturesWWW.yml
@@ -1,7 +1,7 @@
 ---
 name: lecturesWWW
 desc: Web Programming Lectures of the UrFu Institute department IIT. On Russian language.
-site: http://lectures.uralbash.ru/
+site: https://github.com/ustu/lectures.www
 tags:
 - education
 - web

--- a/_data/projects/mocked-api.yml
+++ b/_data/projects/mocked-api.yml
@@ -1,7 +1,7 @@
 ---
 name: Mocked-API
 desc: A set of FREE Api's that allow you to fill your application with mocked data
-site: https://mocked-api.dev/
+site: https://github.com/ageddesi/Mocked-API
 tags:
 - typescipt
 - api

--- a/_data/projects/mockingcase.yml
+++ b/_data/projects/mockingcase.yml
@@ -1,7 +1,7 @@
 ---
 name: mockingcase
 desc: npm package that convert a string to mOcKiNgCaSe
-site: https://www.npmjs.com/package/@strdr4605/mockingcase
+site: https://github.com/strdr4605/mockingcase
 tags:
 - npm
 - javascript

--- a/_data/projects/mutabilitydetector.yml
+++ b/_data/projects/mutabilitydetector.yml
@@ -1,7 +1,7 @@
 ---
 name: Mutability Detector
 desc: Lightweight analysis tool for detecting mutability in Java classes
-site: http://mutabilitydetector.org
+site: https://github.com/MutabilityDetector/MutabilityDetector
 tags:
 - java
 - immutability

--- a/_data/projects/mycovidconnect-android.yml
+++ b/_data/projects/mycovidconnect-android.yml
@@ -3,7 +3,7 @@ name: My Covid Connect Android App Version
 desc: >-
   Project XCoV19 aims to build a software that guides patients to the nearest hospital, streamlines patient
   flow, and models the spread of the virus in order to better anticipate hospital needs.
-site: https://www.covidsos.net
+site: https://github.com/Xcov19/android-mycovidconnect
 tags:
 - covid
 - xcov19

--- a/_data/projects/mycovidconnect.yml
+++ b/_data/projects/mycovidconnect.yml
@@ -1,7 +1,7 @@
 ---
 name: mycovidconnect
 desc: Skip the Queue. Check-in to hospital faster! Automated 911 for Non-ER Patients.
-site: https://www.mycovidconnect.com
+site: https://github.com/Xcov19/mycovidconnect
 tags:
 - xcov19
 - pre-triage

--- a/_data/projects/nadocast-ui.yml
+++ b/_data/projects/nadocast-ui.yml
@@ -1,7 +1,7 @@
 ---
 name: nadocast-ui
 desc: An unofficial user interface for the Nadocast Project.
-site: https://nadocast-ui.robswc.me/
+site: https://github.com/robswc/nadocast-ui
 tags:
 - python
 - dash-plotly

--- a/_data/projects/o11y-wiki.yml
+++ b/_data/projects/o11y-wiki.yml
@@ -1,7 +1,7 @@
 ---
 name: o11y.wiki
 desc: A glossary of all terms related to Observability, starting from A to Z!
-site: https://o11y.wiki
+site: https://github.com/prathamesh-sonpatki/o11y-wiki
 tags:
 - observability
 - documentation

--- a/_data/projects/owljs.yml
+++ b/_data/projects/owljs.yml
@@ -1,7 +1,7 @@
 ---
 name: owljs
 desc: Backbone-like front-end MVC library without underscore.js and jQuery dependency
-site: http://owljs.org/
+site: https://github.com/owljsorg/owljs
 tags:
 - javascript
 - web

--- a/_data/projects/pubgate-philip.yml
+++ b/_data/projects/pubgate-philip.yml
@@ -1,7 +1,7 @@
 ---
 name: PubGate FE App
 desc: Minimalist blogging Fediverse client made with Svelte
-site: https://pubgate.autogestion.org/
+site: https://github.com/autogestion/pubgate-philip
 tags:
 - svelte
 - activitypub

--- a/_data/projects/punchy.yml
+++ b/_data/projects/punchy.yml
@@ -1,7 +1,7 @@
 ---
 name: Punchy
 desc: A 2.5D side-scroller beatemup, made in Bevy
-site: https://fishfolks.github.io/punchy/player/latest/
+site: https://github.com/fishfolk/punchy
 tags:
 - bevy
 - game

--- a/_data/projects/qeda.yml
+++ b/_data/projects/qeda.yml
@@ -3,7 +3,7 @@ name: Quantum Electronics Design Automation!
 desc: >-
   QEDA allows you to design and build real, affordable, room-temperature stable, and scalable quantum
   hardware at home!
-site: https://www.spookymanufacturing.com/QEDA/
+site: https://github.com/Spooky-Manufacturing/QEDA
 tags:
 - quantum
 - electronics

--- a/_data/projects/quotes.yml
+++ b/_data/projects/quotes.yml
@@ -1,7 +1,7 @@
 ---
 name: Quotes
 desc: Open-source Quotes app for viewing/saving/commenting on quotes. Contains a frontend and an API.
-site: https://quotes.programmersdiary.com/
+site: https://github.com/EvalVis/QuotesFE
 tags:
 - quotes
 - open-source

--- a/_data/projects/react-auth-kit.yml
+++ b/_data/projects/react-auth-kit.yml
@@ -1,7 +1,7 @@
 ---
 name: React Auth Kit
 desc: Easily handle authentication in React Js Apps
-site: https://authkit.arkadip.co
+site: https://github.com/react-auth-kit/react-auth-kit
 tags:
 - reactjs
 - auth

--- a/_data/projects/xcovfe.yml
+++ b/_data/projects/xcovfe.yml
@@ -1,7 +1,7 @@
 ---
 name: xcovfe
 desc: CovidX frontend project
-site: https://www.covidsos.net
+site: https://github.com/Xcov19/xcovfe
 tags:
 - covidx
 - xcov19

--- a/_data/projects/zelthy3.yml
+++ b/_data/projects/zelthy3.yml
@@ -4,7 +4,7 @@ desc: >-
   Python web framework for building enterprise-ready apps. Higher level framework (built on top of Django),
   strives to handle all components of application logics that are needed for enterprise readiness at the
   framework level.
-site: https://www.zelthy.com/framework
+site: https://www.zelthy.com
 tags:
 - python
 - django


### PR DESCRIPTION
## Problem

35 project listings had unreachable `site:` URLs. Root causes:

- **Heroku free-tier shutdown** (Dec 2022): `defe`, `FDVueWebapp`, `ipfs-pastebin`, `US-Prosecutor-Database`
- **Dead GitHub Pages**: `atvjs`, `GreenBerry`, `hilbish`, `human-connection`, `punchy`
- **Defunct/expired domains** (HTTP 000/404/503): `ClippyService`, `Aton`, `battleships` (EC2 IP), `mutabilitydetector`, `OpenLiveWriter`, `owljs`, `lecturesWWW`, `o11y-wiki`, `horusec`, `mocked-api`, `nadocast-ui`, `pubgate-philip`, `qeda`, `quotes`, `react-auth-kit`, `TakeMeThere`, `WinYourBattle`, `xcovfe`, `mycovidconnect`, `mycovidconnect-android`, `ieee-com-soc-new-project`, `esfiddle`, `flame-coach-web`, `EvalAI`, `mockingcase`
- **Broken subpath**: `zelthy3` (`/framework` returns 404, root domain works)

## Solution

Replaced each dead URL with the project's GitHub repository or a verified working URL. All replacements confirmed HTTP 200.

## Files changed (35)

`Aton.yml`, `ClippyService.yml`, `EvalAI.yml`, `FDVueWebapp.yml`, `GreenBerry.yml`, `OpenLiveWriter.yml`, `TakeMeThere.yml`, `US-Prosecutor-Database.yml`, `WinYourBattle.yml`, `atvjs.yml`, `battleships.yml`, `defe.yml`, `esfiddle.yml`, `flame-coach-web.yml`, `hilbish.yml`, `horusec.yml`, `human-connection.yml`, `ieee-com-soc-new-project.yml`, `ipfs-pastebin.yml`, `lecturesWWW.yml`, `mocked-api.yml`, `mockingcase.yml`, `mutabilitydetector.yml`, `mycovidconnect-android.yml`, `mycovidconnect.yml`, `nadocast-ui.yml`, `o11y-wiki.yml`, `owljs.yml`, `pubgate-philip.yml`, `punchy.yml`, `qeda.yml`, `quotes.yml`, `react-auth-kit.yml`, `xcovfe.yml`, `zelthy3.yml`

## Verification

- [x] All replacement URLs verified returning HTTP 200
- [x] Only the `site:` field changed in each file
- [x] YAML syntax unchanged
- [x] `upforgrabs.link` URLs untouched