### PR TITLE
docs: update stale version requirements and replace Yarn with npm

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,16 +18,16 @@ git clone https://github.com/up-for-grabs/up-for-grabs.net.git
 If you have a fork of the repository on GitHub, replace the first `up-for-grabs`
 with your GitHub account.
 
-We require Ruby 3, Bundler 2.2 and Node 16+ to test the site. You can check
+We require Ruby 4, Bundler 2.x and Node 24+ to test the site. You can check
 these are present by running these commands in a terminal:
 
 ```
 $ ruby -v
-ruby 3.0.3p157 (2021-11-24 revision 3fb7d2cadc) [x86_64-darwin18]
+ruby 4.0.0 [x86_64-darwin]
 $ bundle -v
-Bundler version 2.2.33
+Bundler version 2.x.x
 $ node -v
-v22.2.0
+v24.x.x
 ```
 
 ## Testing the site
@@ -63,9 +63,9 @@ The site should be accessible in your browser at `localhost:4000`.
 contributors who don't want to install the tooling locally. Check the setup
 instructions for your OS for more information:
 
-- [Docker for Windows](https://docs.docker.com/docker-for-windows/install/)
-- [Docker for macOS](https://docs.docker.com/docker-for-mac/install/)
-- [Other platforms, including Linux distros](https://docs.docker.com/v17.12/install/)
+- [Docker for Windows](https://docs.docker.com/desktop/install/windows-install/)
+- [Docker for macOS](https://docs.docker.com/desktop/install/mac-install/)
+- [Other platforms, including Linux distros](https://docs.docker.com/engine/install/)
 
 Once you have that installed, use the `docker-compose` command to build and
 view the site:

--- a/docs/client-side-scripting.md
+++ b/docs/client-side-scripting.md
@@ -109,7 +109,7 @@ Up-For-Grabs now supports using `jest` to run tests inside a NodeJS context.
 It uses `babel-jest` which automagically transforms AMD modules into CommonJS
 modules.
 
-You can run these tests at any time using `yarn test` to ensure the
+You can run these tests at any time using `npm test` to ensure the
 functionality covered by tests is not affected by your local changes.
 
 ### Testing modules inside `jest`

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -6,27 +6,27 @@ and what you should know if you wish to contribute.
 ## JS Development
 
 If you are working with JS files, you should ensure you have a recent version of
-[NodeJS](https://nodejs.org) and [Yarn](https://yarnpkg.com/) installed. There
+[NodeJS](https://nodejs.org) (v24+) and npm (v11+) installed. There
 are helpful tools installed that require these to be available.
 
 With those tools installed, you can then install the packages required:
 
 ```shellsession
-$ yarn
+$ npm install
 ```
 
 We use `prettier` to enforce a consistent format to the code, and at any time
 you can run this command to ensure your changes are formatted correctly:
 
 ```shellsession
-$ yarn prettify
+$ npm run prettier
 ```
 
-You should also ensure the code satisfies the rules defined in the `eslintrc.json`
+You should also ensure the code satisfies the rules defined in the `eslint.config.mjs`
 config file:
 
 ```shellsession
-$ yarn lint
+$ npm run lint
 ```
 
 These rules will be checked as part of every pull request into the project, but


### PR DESCRIPTION
## Problem

The contributor documentation had significantly outdated information that would cause setup failures for new contributors:

1. **Wrong version requirements** — `CONTRIBUTING.md` states Ruby 3 / Node 16+, but the repo's `Gemfile` requires `ruby '~> 4.0'`, `.ruby-version` is `4.0.0`, and `package.json` engines specify `node >=24, npm >=11`
2. **Wrong toolchain** — `docs/setup.md` uses Yarn throughout, but the project has no `yarn.lock`, `package.json` specifies `npm >=11`, and all CI scripts use npm
3. **Non-existent script** — `yarn prettify` does not exist; the correct command is `npm run prettier`
4. **Wrong config file** — references `eslintrc.json` but the project migrated to ESLint flat config (`eslint.config.mjs`)
5. **Outdated Docker links** — all three Docker install links redirected to new URLs

## Changes

**`.github/CONTRIBUTING.md`**
- Ruby 3 → Ruby 4, Node 16+ → Node 24+, Bundler 2.2 → 2.x
- Update example version output to match current toolchain
- Fix Docker install links for Windows, macOS, and Linux

**`docs/setup.md`**
- Replace `yarn` → `npm install`
- Replace `yarn prettify` → `npm run prettier`
- Replace `yarn lint` → `npm run lint`
- Fix `eslintrc.json` → `eslint.config.mjs`

**`docs/client-side-scripting.md`**
- Replace `yarn test` → `npm test`

## Verification

- [x] Verified actual requirements against `Gemfile`, `.ruby-version`, `package.json`
- [x] Confirmed `npm run prettier`, `npm run lint`, `npm test` exist in `package.json`
- [x] Confirmed `eslint.config.mjs` exists in repo root
- [x] All new Docker links verified returning HTTP 200