### PR TITLE
fix: replace 4 remaining dead site URLs with working alternatives

### DIFF
--- a/_data/projects/CiviWiki.yml
+++ b/_data/projects/CiviWiki.yml
@@ -1,7 +1,7 @@
 ---
 name: CiviWiki
 desc: Building a Better Democracy for the Internet Age
-site: https://civi.wiki
+site: https://github.com/CiviWiki/OpenCiviWiki
 tags:
 - python
 - django

--- a/_data/projects/almond.yml
+++ b/_data/projects/almond.yml
@@ -1,7 +1,7 @@
 ---
 name: Almond
 desc: The Open Source, Privacy Preserving Virtual Assistant
-site: https://almond.stanford.edu
+site: https://github.com/stanford-oval/genie-toolkit
 tags:
 - virtual-assistant
 - voice

--- a/_data/projects/loklak.yml
+++ b/_data/projects/loklak.yml
@@ -1,7 +1,7 @@
 ---
 name: loklak
 desc: Distributed search and analytics framework to collect, store, search, and analyze social media
-site: http://loklak.org/
+site: https://github.com/loklak/loklak_server
 tags:
 - loklak
 - twitter

--- a/_data/projects/schul-cloud.yml
+++ b/_data/projects/schul-cloud.yml
@@ -1,7 +1,7 @@
 ---
 name: Schul-Cloud
 desc: open-source software for schools in Germany
-site: https://schul-cloud.github.io
+site: https://github.com/hpi-schul-cloud
 tags:
 - oss
 - javascript


### PR DESCRIPTION
## Problem

4 project listings had unreachable `site:` URLs that could not be fixed in the previous batch due to no known alternative at the time.

| File | Dead URL | Reason |
|------|----------|--------|
| `almond.yml` | `https://almond.stanford.edu` | HTTP 000 — connection refused |
| `CiviWiki.yml` | `https://civi.wiki` | HTTP 000 — connection refused |
| `schul-cloud.yml` | `https://schul-cloud.github.io` | HTTP 404 — GitHub Pages removed |
| `loklak.yml` | `http://loklak.org/` | HTTP 000 — domain dead |

## Solution

Replaced each with the project's active GitHub repository or org, all verified HTTP 200.

| File | New URL |
|------|---------|
| `almond.yml` | `https://github.com/stanford-oval/genie-toolkit` |
| `CiviWiki.yml` | `https://github.com/CiviWiki/OpenCiviWiki` |
| `schul-cloud.yml` | `https://github.com/hpi-schul-cloud` |
| `loklak.yml` | `https://github.com/loklak/loklak_server` |

## Verification

- [x] All replacement URLs verified returning HTTP 200
- [x] Only the `site:` field changed — no other modifications
- [x] `upforgrabs.link` URLs untouched