### PR TITLE
docs: add SECURITY.md with vulnerability reporting policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Scope
+
+Up for Grabs is a static website that helps people discover open source projects
+looking for contributors. Security issues relevant to this project include:
+
+- Cross-site scripting (XSS) in the site's JavaScript
+- Content injection or data manipulation affecting the project listings
+- Vulnerabilities in the site's dependencies
+
+Issues with the **listed projects themselves** should be reported directly to
+those projects, not here.
+
+## Reporting a Vulnerability
+
+Please do **not** open a public GitHub issue for security vulnerabilities.
+
+Report security vulnerabilities by using
+[GitHub's private vulnerability reporting](https://github.com/up-for-grabs/up-for-grabs.net/security/advisories/new).
+
+Please include:
+
+- A description of the vulnerability
+- Steps to reproduce the issue
+- Potential impact
+- Any suggested mitigations (optional)
+
+We aim to respond to reports within 7 days and will keep you informed as we
+work toward a fix.
+
+## Supported Versions
+
+Only the current production deployment of
+[up-for-grabs.net](https://up-for-grabs.net) is actively maintained.


### PR DESCRIPTION
## Problem

Issue #3015 (opened 3 years ago) requested a security policy so contributors and researchers know how to report vulnerabilities. No SECURITY.md currently exists in the repository.

Without this file, GitHub shows no security policy on the repository page, and reporters have no guidance on responsible disclosure.

## Solution

Adds `.github/SECURITY.md` with:
- **Scope** — clarifies what counts as a vulnerability for this project (XSS, content injection, dependency issues) vs. vulnerabilities in listed projects (out of scope)
- **Reporting process** — directs to GitHub's built-in private vulnerability reporting instead of public issues
- **What to include** — steps to reproduce, impact, suggested mitigations
- **Response commitment** — 7-day response target
- **Supported versions** — only current production deployment

## Related

Closes #3015