### PR TITLE
fix: correct three bugs and a typo in JS/Vue/TS source files

### DIFF
--- a/javascripts/fetchIssueCount.js
+++ b/javascripts/fetchIssueCount.js
@@ -158,7 +158,7 @@ define(['whatwg-fetch', 'promise-polyfill'], () => {
 
     if (cached && cached.etag) {
       settings.headers = {
-        ...settings,
+        ...settings.headers,
         'If-None-Match': cached.etag,
       };
     }

--- a/javascripts/projectsService.js
+++ b/javascripts/projectsService.js
@@ -184,7 +184,7 @@ define(['underscore', 'tag-builder', 'project-ordering'], (
     const labelNames = _.collect(labels, (label) => label.name);
 
     // find all projects with the given labels via OR
-    results = _.map(labelNames, (name) =>
+    const results = _.map(labelNames, (name) =>
       _.filter(
         projects,
         (project) =>

--- a/src/components/data/search.ts
+++ b/src/components/data/search.ts
@@ -59,7 +59,7 @@ export const Init = async (lastUpdated: Date) => {
         });
       }
     }
-    return new Error('oops');
+    return new Error('Failed to load project data');
   }
 };
 

--- a/src/components/search/SearchResults.vue
+++ b/src/components/search/SearchResults.vue
@@ -137,7 +137,7 @@ menu {
       />
       <div>
         <label id="activity-filter"
-          >Choose active projects active within the previous</label
+          >Choose projects active within the previous</label
         >
 
         <select v-on:change="onPeriodChanged" aria-labelledby="activity-filter">


### PR DESCRIPTION
## Changes

### 1. `javascripts/projectsService.js` — implicit global variable

```js
// Before (accidental global)
results = _.map(labelNames, ...)

// After
const results = _.map(labelNames, ...)
```

`results` was assigned without `const`/`let`/`var`, silently creating a global variable in non-strict mode. This could cause subtle bugs if the function is called multiple times concurrently or if other code reads the global.

### 2. `javascripts/fetchIssueCount.js` — wrong object spread in header merge

```js
// Before (spreads entire settings object into headers)
settings.headers = {
  ...settings,
  'If-None-Match': cached.etag,
};

// After (spreads only the existing headers)
settings.headers = {
  ...settings.headers,
  'If-None-Match': cached.etag,
};
```

Spreading `settings` instead of `settings.headers` would populate the headers object with non-header fields (`method`, `url`, etc.), potentially causing unexpected API request behaviour.

### 3. `src/components/search/SearchResults.vue` — duplicate word in UI label

```
Before: "Choose active projects active within the previous"
After:  "Choose projects active within the previous"
```

### 4. `src/components/data/search.ts` — uninformative error message

```ts
// Before
return new Error('oops');

// After
return new Error('Failed to load project data');
```

## Verification

- [x] Changes are minimal and surgical — one line each
- [x] No behaviour change for the `const` and label fixes
- [x] Header spread fix restores intended behaviour