### PR TITLE
fix: correct README table typo and replace 3 dead site URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ To work with the new beta site, you need to have a recent version of Node.js ins
 | :------------------------ | :----------------------------------------------- |
 | `npm install`             | Installs dependencies                            |
 | `npm run dev`             | Starts local dev server at `localhost:4321`      |
-| `npm run build`           | Build your production site to `./\_site/beta/    |
+| `npm run build`           | Build your production site to `./_site/beta/`    |
 | `npm run preview`         | Preview your build locally, before deploying     |
 | `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
 | `npm run astro -- --help` | Get help using the Astro CLI                     |

--- a/_data/projects/lecturesWWW.yml
+++ b/_data/projects/lecturesWWW.yml
@@ -1,7 +1,7 @@
 ---
 name: lecturesWWW
 desc: Web Programming Lectures of the UrFu Institute department IIT. On Russian language.
-site: http://lectures.uralbash.ru/
+site: https://github.com/ustu/lectures.www
 tags:
 - education
 - web

--- a/_data/projects/nadocast-ui.yml
+++ b/_data/projects/nadocast-ui.yml
@@ -1,7 +1,7 @@
 ---
 name: nadocast-ui
 desc: An unofficial user interface for the Nadocast Project.
-site: https://nadocast-ui.robswc.me/
+site: https://github.com/robswc/nadocast-ui
 tags:
 - python
 - dash-plotly

--- a/_data/projects/owljs.yml
+++ b/_data/projects/owljs.yml
@@ -1,7 +1,7 @@
 ---
 name: owljs
 desc: Backbone-like front-end MVC library without underscore.js and jQuery dependency
-site: http://owljs.org/
+site: https://github.com/owljsorg/owljs
 tags:
 - javascript
 - web


### PR DESCRIPTION
## Summary

### README.md fix

The `npm run build` row in the command reference table had a missing closing backtick and an incorrectly escaped underscore in the output path:

```
# Before (broken)
| `npm run build` | Build your production site to `./\_site/beta/    |

# After (fixed)  
| `npm run build` | Build your production site to `./_site/beta/`    |
```

The backtick around the path was never closed, and `\_site` is redundant escaping inside a backtick span (the correct path is `_site/beta/` per `astro.config.mjs`).

### Dead site URLs (3 files)

| File | Old URL | New URL |
|------|---------|---------|
| owljs.yml | http://owljs.org/ (503) | https://github.com/owljsorg/owljs |
| nadocast-ui.yml | https://nadocast-ui.robswc.me/ (503) | https://github.com/robswc/nadocast-ui |
| lecturesWWW.yml | http://lectures.uralbash.ru/ (dead) | https://github.com/ustu/lectures.www |

## Test plan
- Replacement URLs verified HTTP 200 via curl
- README renders correctly in markdown preview
