### PR TITLE
fix: replace 3 dead site URLs with working alternatives

### DIFF
--- a/_data/projects/TripAi.yml
+++ b/_data/projects/TripAi.yml
@@ -5,7 +5,7 @@ desc: >-
   customised trip itineraries. By leveraging Meta’s Llama 3.8B Instruct model and integrating real-time
   data from Amadeus APIs, TripAi delivers intelligent and practical trip suggestions – including flights,
   hotels, and personalised activities.
-site: https://tripai25.onrender.com/
+site: https://github.com/vcint/TripAi
 tags:
 - node.js
 - express

--- a/_data/projects/ieee-com-soc-new-project.yml
+++ b/_data/projects/ieee-com-soc-new-project.yml
@@ -3,7 +3,7 @@ name: Annual-Yearbook
 desc: >-
   A yearbook which records the precious memories of University students to add their messages in their
   yearbook.
-site: https://memories.ieeecsvitc.com
+site: https://github.com/ComputerSocietyVITC/Annual-Yearbook
 tags:
 - typescript
 - javascript

--- a/_data/projects/qeda.yml
+++ b/_data/projects/qeda.yml
@@ -3,7 +3,7 @@ name: Quantum Electronics Design Automation!
 desc: >-
   QEDA allows you to design and build real, affordable, room-temperature stable, and scalable quantum
   hardware at home!
-site: https://www.spookymanufacturing.com/QEDA/
+site: https://github.com/Spooky-Manufacturing/QEDA
 tags:
 - quantum
 - electronics


### PR DESCRIPTION
## Summary

Replaces 3 project `site:` URLs that are no longer accessible with their GitHub repository pages.

| File | Old URL | New URL |
|------|---------|---------|
| TripAi.yml | https://tripai25.onrender.com/ (dead Render deployment) | https://github.com/vcint/TripAi |
| ieee-com-soc-new-project.yml | https://memories.ieeecsvitc.com (dead domain) | https://github.com/ComputerSocietyVITC/Annual-Yearbook |
| qeda.yml | https://www.spookymanufacturing.com/QEDA/ (dead domain) | https://github.com/Spooky-Manufacturing/QEDA |

Replacement URLs derived from the existing `upforgrabs.link` field in each file.

## Test plan
- All replacement URLs verified HTTP 200 via curl