### PR TITLE
fix: replace Alpine.js x-if with Vue v-if in ProjectEntry

### DIFF
--- a/src/components/search/ProjectEntry.vue
+++ b/src/components/search/ProjectEntry.vue
@@ -96,9 +96,9 @@ const linkTitle = `View open issues for ${project.name}`;
       </div>
     </div>
 
-    <div class="description" x-if="project.desc">{{ project.desc }}</div>
+    <div class="description" v-if="project.desc">{{ project.desc }}</div>
 
-    <ul class="tags" x-if="project.tags" aria-label="project tags">
+    <ul class="tags" v-if="project.tags" aria-label="project tags">
       <li v-for="tag in project.tags" v-bind:key="tag">{{ tag }}</li>
     </ul>
   </div>


### PR DESCRIPTION
## Summary

Two template conditionals in `ProjectEntry.vue` used `x-if` (an Alpine.js directive) instead of `v-if` (the Vue 3 directive):

```html
<!-- Before -->
<div class="description" x-if="project.desc">...</div>
<ul class="tags" x-if="project.tags" ...>...</ul>

<!-- After -->
<div class="description" v-if="project.desc">...</div>
<ul class="tags" v-if="project.tags" ...>...</ul>
```

Vue does not process `x-if`, so both conditionals were silently ignored — the elements always rendered regardless of whether `project.desc` or `project.tags` were present. The fix uses the correct `v-if` directive so Vue evaluates the conditions properly.

## Test plan
- Verify project cards still render description and tags correctly
- `npm run lint-new` passes