### PR TITLE
Sort projects by recently updated instead of alphabetically

### DIFF
--- a/src/components/data/projects.ts
+++ b/src/components/data/projects.ts
@@ -23,7 +23,14 @@ export const RawProjects: Array<Project> = projects
       ...project.data,
     };
   })
-  .sort((left, right) => left.name.localeCompare(right.name));
+  .sort((left, right) => {
+    const leftDate = left.stats?.['last-updated'];
+    const rightDate = right.stats?.['last-updated'];
+    if (!leftDate && !rightDate) return left.name.localeCompare(right.name);
+    if (!leftDate) return 1;
+    if (!rightDate) return -1;
+    return new Date(rightDate).getTime() - new Date(leftDate).getTime();
+  });
 
 const lastUpdated = subDays(new Date(), InitialDaysActive);
 

--- a/src/components/data/search.ts
+++ b/src/components/data/search.ts
@@ -101,7 +101,12 @@ export const SearchProjects = async (
       return false;
     })
     .sort((left, right) => {
-      return left.name.localeCompare(right.name);
+      const leftDate = left.stats.lastUpdated;
+      const rightDate = right.stats.lastUpdated;
+      if (!leftDate && !rightDate) return left.name.localeCompare(right.name);
+      if (!leftDate) return 1;
+      if (!rightDate) return -1;
+      return rightDate.getTime() - leftDate.getTime();
     });
 
   const response: SearchResultsMessage = {


### PR DESCRIPTION
## Summary

Changes the default sort order for projects from alphabetical by name to **most recently updated first** (descending by `last-updated` date).

## Changes

- **`src/components/data/projects.ts`** — Build-time sort now orders `RawProjects` by `stats['last-updated']` descending.
- **`src/components/data/search.ts`** — Search results sort also orders by `stats.lastUpdated` descending, so filtering/searching preserves the "recently updated" order.

Projects without a `last-updated` date fall back to alphabetical ordering so nothing is lost.

## Motivation

The alphabetical sort made it hard to discover newly added or recently active projects. Sorting by most recently updated surfaces the most active projects at the top, which is more useful for contributors looking for something to work on.