### PR TITLE
fix(search): make popular tags reliably clickable

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -67,7 +67,11 @@
       <ul class="popular-tags">
         <% _.each(popularTags, function(entry, key){ %>
         <li>
-          <a title="Popular Tag: <%-entry.name%>" tabindex="0"
+          <a
+            title="Popular Tag: <%-entry.name%>"
+            tabindex="0"
+            data-tag="<%-entry.name%>"
+            href="#/filters?tags=<%- encodeURIComponent(entry.name) %>"
             ><%-entry.name%>
             <span class="popular-tags__frequency"
               >(<%-entry.frequency%>)</span

--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -154,22 +154,34 @@ define([
       });
 
     projectsPanel.find('ul.popular-tags li a').each((i, elem) => {
-      $(elem).on('click', function () {
-        selTags = $('.tags-filter').val() || [];
-        selectedTag = preparePopTagName($(this).text() || '');
-        if (selectedTag) {
-          tagID = allTags
-            .map((tag) => tag.name.toLowerCase())
-            .indexOf(selectedTag);
-          if (tagID !== -1) {
-            selTags.push(selectedTag);
-            location.href = updateQueryStringParameter(
-              getFilterUrl(),
-              'tags',
-              encodeURIComponent(selTags)
-            );
-          }
+      $(elem).on('click', function (event) {
+        event.preventDefault();
+
+        const selectedTag = preparePopTagName(
+          $(this).data('tag') || $(this).text() || ''
+        );
+
+        if (!selectedTag) {
+          return;
         }
+
+        const allTagNames = allTags.map((tag) => tag.name.toLowerCase());
+        const tagID = allTagNames.indexOf(selectedTag);
+
+        if (tagID === -1) {
+          return;
+        }
+
+        const selectedTags = $('.tags-filter').val() || [];
+        if (selectedTags.indexOf(selectedTag) === -1) {
+          selectedTags.push(selectedTag);
+        }
+
+        location.href = updateQueryStringParameter(
+          getFilterUrl(),
+          'tags',
+          encodeURIComponent(selectedTags)
+        );
       });
     });
   };
@@ -181,7 +193,8 @@ define([
   */
   let preparePopTagName = function (name) {
     if (name === '') return '';
-    return name.toLowerCase().split(' ')[0];
+
+    return name.toLowerCase().trim();
   };
 
   /**


### PR DESCRIPTION
## Summary
- fix popular tag chip navigation by binding each chip to its real tag value via `data-tag`
- add a fallback `href` on each popular tag chip so filtering still works without JavaScript
- update click handling to prevent default navigation, keep full tag names (including spaces), and avoid duplicate tags in the query

## Validation
- `npm run -s lint-new`
- `git diff --check`

Fixes #5369
