### PR TITLE
fix(search): include tag values in text search results

### DIFF
--- a/src/components/data/search.ts
+++ b/src/components/data/search.ts
@@ -115,5 +115,9 @@ export function filterProject(
     return true;
   }
 
+  if (project.tags.some((tag) => tag.toLowerCase().indexOf(searchText) > -1)) {
+    return true;
+  }
+
   return false;
 }


### PR DESCRIPTION
## Summary
- include project tag values in SearchProjects filtering
- keep existing name/description checks unchanged
- allow tag text queries (e.g. language/platform tags) to return matching projects

Fixes #5514

## Validation
- npm run -s lint-new
- git diff --check