### PR TITLE
fix(astro): randomize initial project order per publish

### DIFF
--- a/src/components/Progress.astro
+++ b/src/components/Progress.astro
@@ -23,6 +23,6 @@
       Add support for responsive styling to support desktop/mobile screen sizes
     </li>
     <li>Search for projects based on tag</li>
-    <li>Project render order is based on client-side storage</li>
+    <li class="done">Project render order is randomized per publish</li>
   </ul>
 </section>

--- a/src/components/data/projects.ts
+++ b/src/components/data/projects.ts
@@ -13,6 +13,13 @@ const projects = await getCollection('projects', ({ data }) => {
   return false;
 });
 
+const BuildSeed = createHash('sha256')
+  .update(`${Date.now()}-${process.pid}`)
+  .digest('hex');
+
+const createBuildOrderWeight = (id: string) =>
+  createHash('sha256').update(`${BuildSeed}:${id}`).digest('hex');
+
 export const RawProjects: Array<Project> = projects
   .map((project) => {
     const hash = createHash('sha256');
@@ -23,7 +30,16 @@ export const RawProjects: Array<Project> = projects
       ...project.data,
     };
   })
-  .sort((left, right) => left.name.localeCompare(right.name));
+  .sort((left, right) => {
+    const leftWeight = createBuildOrderWeight(left.id);
+    const rightWeight = createBuildOrderWeight(right.id);
+
+    if (leftWeight === rightWeight) {
+      return left.name.localeCompare(right.name);
+    }
+
+    return leftWeight.localeCompare(rightWeight);
+  });
 
 const lastUpdated = subDays(new Date(), InitialDaysActive);
 


### PR DESCRIPTION
## Summary
- randomize initial project order at build time using a per-build seed
- remove reliance on client-side persisted ordering
- mark progress item as done now that ordering is publish-time randomized

## Validation
- `git diff --check`
- `npm run -s lint-new` *(not runnable in this ephemeral env: eslint is not installed)*

Fixes #5515
