### PR TITLE
chore(dependabot): group astro and eslint updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,17 @@ updates:
     directory: '/'
     schedule:
       interval: weekly
+    groups:
+      astro:
+        patterns:
+          - "astro"
+          - "@astrojs/*"
+      eslint:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@eslint/*"
+          - "@typescript-eslint/*"
     open-pull-requests-limit: 10
   - package-ecosystem: bundler
     directory: '/'


### PR DESCRIPTION
## Summary
- add Dependabot grouping for Astro dependencies
- add Dependabot grouping for ESLint dependencies
- keep weekly npm update cadence unchanged

Fixes #5645

## Validation
- git diff --check