### PR TITLE
chore(dependabot): group astro and eslint dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,17 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    groups:
+      astro:
+        patterns:
+          - 'astro'
+          - '@astrojs/*'
+      eslint:
+        patterns:
+          - 'eslint'
+          - 'eslint-*'
+          - '@eslint/*'
+          - '@typescript-eslint/*'
   - package-ecosystem: bundler
     directory: '/'
     schedule:


### PR DESCRIPTION
## Summary
- add a Dependabot `astro` group for `astro` and `@astrojs/*` packages
- add a Dependabot `eslint` group for core eslint, plugin, and TypeScript ESLint packages
- keep existing npm update schedule and PR limit unchanged

Closes #5645

## Validation
- `git diff --check`
- `ruby -e "require 'yaml'; YAML.load_file('.github/dependabot.yml')"`
