### PR TITLE
bugfix: align names filter with other inputs

### DIFF
--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -1013,8 +1013,6 @@ ul.tags li {
   }
 
   select {
-    box-sizing: border-box;
-    width: 100%;
     max-width: 100%;
   }
 
@@ -1083,6 +1081,16 @@ ul.tags li {
 
 .filters-panel {
   margin-bottom: 20px;
+}
+
+.filters-panel .chosen-container {
+  width: 100% !important;
+  max-width: 100%;
+}
+
+.filters-panel .chosen-container .chosen-choices {
+  box-sizing: border-box;
+  width: 100%;
 }
 
 .projects .stats {


### PR DESCRIPTION
After merging #5641 I see at wide screen that the name lookup is slightly shorter than the other two:

<img width="2268" height="362" alt="Screenshot 2026-03-21 at 12 08 19 PM" src="https://github.com/user-attachments/assets/c12bbddb-25f4-4b42-9b1c-f91d62b926d1" />

The second two both have a `style="width: 95%"` attribute set in the DOM, so this PR is trying to make these consistent...