### PR TITLE
fix(search): wrap long project descriptions and tags for Safari

### DIFF
--- a/src/components/search/ProjectEntry.vue
+++ b/src/components/search/ProjectEntry.vue
@@ -23,14 +23,18 @@ const linkTitle = `View open issues for ${project.name}`;
 
 .project .header {
   display: flex;
-  flex-flow: row nowrap;
+  flex-flow: row wrap;
+  align-items: flex-start;
+  gap: 0.5em;
   margin-bottom: 1em;
 }
 
 .project .title {
   font-weight: bold;
   flex-grow: 1;
+  min-width: 0;
   font-size: 1.5em;
+  overflow-wrap: anywhere;
 }
 
 .project .title a {
@@ -39,6 +43,11 @@ const linkTitle = `View open issues for ${project.name}`;
 
 .project .label {
   margin-left: 8px;
+}
+
+
+.project .description {
+  overflow-wrap: anywhere;
 }
 
 .project .tags {
@@ -56,6 +65,8 @@ const linkTitle = `View open issues for ${project.name}`;
   border-radius: 5px;
   background: #bfd1d9;
   padding: 0.3em;
+  max-width: 100%;
+  overflow-wrap: anywhere;
 }
 
 .label {


### PR DESCRIPTION
## Summary\n- allow the project-card header to wrap when content is wide\n- prevent long descriptions and long tag text from overflowing by enabling safe text wrapping\n- keep tag pills constrained to the card width\n\nFixes #5617\n\n## Validation\n- \\n- attempted \ (fails in ephemeral environment: \)