### PR TITLE
Add httpress project

### DIFF
--- a/_data/projects/httpress.yaml
+++ b/_data/projects/httpress.yaml
@@ -1,0 +1,14 @@
+name: httpress
+desc: A http benchmarking library and cli tool built in rust
+site: https://github.com/GabrielTecuceanu/httpress
+tags:
+  - http
+  - benchmarking
+  - rust
+  - cli
+  - library
+  - tokio
+  - clap
+upforgrabs:
+  name: good first issue
+  link: https://github.com/GabrielTecuceanu/httpress/labels/good%20first%20issue


### PR DESCRIPTION
## Summary

- Adds [httpress](https://github.com/GabrielTecuceanu/httpress) to the project list
- A rust http benchmarking library with a flexible builder api
- Label: `good first issue`

## Test plan

- [x] Verify YAML is valid and follows the project template
- [x] Verify the label link resolves to the correct GitHub labels page