### PR TITLE
replace internals of SearchResults and search module with third-party library

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: codespell-project/actions-codespell@v2
         with:
           skip: '**/*.ai,Gemfile*,package-lock.json,**/*.css'
-          ignore_words_list: gnerate,allready,hass,noice,dota,paket,testng,radis,Lins
+          ignore_words_list: gnerate,allready,hass,noice,dota,paket,testng,radis,Lins,afterAll
 
   upload:
     runs-on: ubuntu-latest

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,5 +7,9 @@ import vue from '@astrojs/vue';
 export default defineConfig({
   base: '/beta',
   outDir: '_site/beta/',
-  integrations: [vue()],
+  integrations: [
+    vue({
+      appEntrypoint: '/src/pages/_app',
+    }),
+  ],
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@tanstack/vue-query": "^5.95.2",
         "amdefine": ">=0.1.0"
       },
       "devDependencies": {
@@ -32,6 +33,7 @@
         "eslint-plugin-astro": "^1.6.0",
         "eslint-plugin-vue": "^10.8.0",
         "jsdom": "^29.0.1",
+        "msw": "^2.12.14",
         "prettier": "^3.8.0",
         "promise-polyfill": "^8.3.0",
         "requirejs": "^2.3.8",
@@ -550,7 +552,6 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -558,7 +559,6 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -592,7 +592,6 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
       "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -751,7 +750,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -2110,6 +2108,109 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
+      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
+      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
+      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
+      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -2241,7 +2342,6 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -2253,6 +2353,24 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.41.3",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.3.tgz",
+      "integrity": "sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -2291,6 +2409,31 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
       "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2838,6 +2981,83 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tanstack/match-sorter-utils": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/match-sorter-utils/-/match-sorter-utils-8.19.4.tgz",
+      "integrity": "sha512-Wo1iKt2b9OT7d+YGhvEPD3DXvPv2etTusIMhMUoG7fbhmxcXCtIjJDEygy91Y2JFlwGyjqiBPRozme7UD8hoqg==",
+      "license": "MIT",
+      "dependencies": {
+        "remove-accents": "0.5.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.95.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.95.2.tgz",
+      "integrity": "sha512-o4T8vZHZET4Bib3jZ/tCW9/7080urD4c+0/AUaYVpIqOsr7y0reBc1oX3ttNaSW5mYyvZHctiQ/UOP2PfdmFEQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/vue-query": {
+      "version": "5.95.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/vue-query/-/vue-query-5.95.2.tgz",
+      "integrity": "sha512-GleO0GrUPdvObtff/D3iQ5kUERQM3dM6vT5pWl4zC3ap2JO84x4SQbUa1G7czKx96lETRiHnw7ZuatSRaaZqQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/match-sorter-utils": "^8.19.4",
+        "@tanstack/query-core": "5.95.2",
+        "@vue/devtools-api": "^6.6.3",
+        "vue-demi": "^0.14.10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.1.2",
+        "vue": "^2.6.0 || ^3.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tanstack/vue-query/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -2937,6 +3157,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/underscore": {
       "version": "1.13.0",
       "dev": true,
@@ -3011,175 +3238,6 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/project-service": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.2.tgz",
-      "integrity": "sha512-FuH0wipFywXRTHf+bTTjNyuNQQsQC3qh/dYzaM4I4W0jrCqjCVuUh99+xd9KamUfmCGPvbO8NDngo/vsnNVqgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.57.2",
-        "@typescript-eslint/types": "^8.57.2",
-        "debug": "^4.4.3"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.2.tgz",
-      "integrity": "sha512-snZKH+W4WbWkrBqj4gUNRIGb/jipDW3qMqVJ4C9rzdFc+wLwruxk+2a5D+uoFcKPAqyqEnSb4l2ULuZf95eSkw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.57.2",
-        "@typescript-eslint/visitor-keys": "8.57.2"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.2.tgz",
-      "integrity": "sha512-3Lm5DSM+DCowsUOJC+YqHHnKEfFh5CoGkj5Z31NQSNF4l5wdOwqGn99wmwN/LImhfY3KJnmordBq/4+VDe2eKw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.2.tgz",
-      "integrity": "sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.2.tgz",
-      "integrity": "sha512-2MKM+I6g8tJxfSmFKOnHv2t8Sk3T6rF20A1Puk0svLK+uVapDZB/4pfAeB7nE83uAZrU6OxW+HmOd5wHVdXwXA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/project-service": "8.57.2",
-        "@typescript-eslint/tsconfig-utils": "8.57.2",
-        "@typescript-eslint/types": "8.57.2",
-        "@typescript-eslint/visitor-keys": "8.57.2",
-        "debug": "^4.4.3",
-        "minimatch": "^10.2.2",
-        "semver": "^7.7.3",
-        "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.4.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.2.tgz",
-      "integrity": "sha512-zhahknjobV2FiD6Ee9iLbS7OV9zi10rG26odsQdfBO/hjSzUQbkIYgda+iNKK1zNiW2ey+Lf8MU5btN17V3dUw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.57.2",
-        "eslint-visitor-keys": "^5.0.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
@@ -3752,7 +3810,6 @@
       "version": "3.5.31",
       "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.31.tgz",
       "integrity": "sha512-k/ueL14aNIEy5Onf0OVzR8kiqF/WThgLdFhxwa4e/KF/0qe38IwIdofoSWBTvvxQOesaz6riAFAUaYjoF9fLLQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.2",
@@ -3766,7 +3823,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
       "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -3779,7 +3835,6 @@
       "version": "3.5.31",
       "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.31.tgz",
       "integrity": "sha512-BMY/ozS/xxjYqRFL+tKdRpATJYDTTgWSo0+AJvJNg4ig+Hgb0dOsHPXvloHQ5hmlivUqw1Yt2pPIqp4e0v1GUw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/compiler-core": "3.5.31",
@@ -3790,7 +3845,6 @@
       "version": "3.5.31",
       "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.31.tgz",
       "integrity": "sha512-M8wpPgR9UJ8MiRGjppvx9uWJfLV7A/T+/rL8s/y3QG3u0c2/YZgff3d6SuimKRIhcYnWg5fTfDMlz2E6seUW8Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.2",
@@ -3808,12 +3862,17 @@
       "version": "3.5.31",
       "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.31.tgz",
       "integrity": "sha512-h0xIMxrt/LHOvJKMri+vdYT92BrK3HFLtDqq9Pr/lVVfE4IyKZKvWf0vJFW10Yr6nX02OR4MkJwI0c1HDa1hog==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/compiler-dom": "3.5.31",
         "@vue/shared": "3.5.31"
       }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
     },
     "node_modules/@vue/devtools-core": {
       "version": "8.1.0",
@@ -3879,7 +3938,6 @@
       "version": "3.5.31",
       "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.31.tgz",
       "integrity": "sha512-DtKXxk9E/KuVvt8VxWu+6Luc9I9ETNcqR1T1oW1gf02nXaZ1kuAx58oVu7uX9XxJR0iJCro6fqBLw9oSBELo5g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/shared": "3.5.31"
@@ -3889,7 +3947,6 @@
       "version": "3.5.31",
       "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.31.tgz",
       "integrity": "sha512-AZPmIHXEAyhpkmN7aWlqjSfYynmkWlluDNPHMCZKFHH+lLtxP/30UJmoVhXmbDoP1Ng0jG0fyY2zCj1PnSSA6Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/reactivity": "3.5.31",
@@ -3900,7 +3957,6 @@
       "version": "3.5.31",
       "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.31.tgz",
       "integrity": "sha512-xQJsNRmGPeDCJq/u813tyonNgWBFjzfVkBwDREdEWndBnGdHLHgkwNBQxLtg4zDrzKTEcnikUy1UUNecb3lJ6g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/reactivity": "3.5.31",
@@ -3913,7 +3969,6 @@
       "version": "3.5.31",
       "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.31.tgz",
       "integrity": "sha512-GJuwRvMcdZX/CriUnyIIOGkx3rMV3H6sOu0JhdKbduaeCji6zb60iOGMY7tFoN24NfsUYoFBhshZtGxGpxO4iA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/compiler-ssr": "3.5.31",
@@ -3927,7 +3982,6 @@
       "version": "3.5.31",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.31.tgz",
       "integrity": "sha512-nBxuiuS9Lj5bPkPbWogPUnjxxWpkRniX7e5UBQDWl6Fsf4roq9wwV+cR7ezQ4zXswNvPIlsdj1slcLB7XCsRAw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@vue/test-utils": {
@@ -4555,6 +4609,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "dev": true,
@@ -4785,7 +4849,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -5656,7 +5719,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/esutils": {
@@ -5945,6 +6007,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/graphql": {
+      "version": "16.13.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
+      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
     "node_modules/h3": {
       "version": "1.15.9",
       "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.9.tgz",
@@ -6158,6 +6230,13 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/headers-polyfill": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
+      "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/hookable": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
@@ -6312,6 +6391,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -6757,7 +6843,6 @@
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -7696,6 +7781,51 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/msw": {
+      "version": "2.12.14",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.12.14.tgz",
+      "integrity": "sha512-4KXa4nVBIBjbDbd7vfQNuQ25eFxug0aropCQFoI0JdOBuJWamkT1yLVIWReFI8SiTRc+H1hKzaNk+cLk2N9rtQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/confirm": "^5.0.0",
+        "@mswjs/interceptors": "^0.41.2",
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@types/statuses": "^2.0.6",
+        "cookie": "^1.0.2",
+        "graphql": "^16.12.0",
+        "headers-polyfill": "^4.0.2",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "rettime": "^0.10.1",
+        "statuses": "^2.0.2",
+        "strict-event-emitter": "^0.5.1",
+        "tough-cookie": "^6.0.0",
+        "type-fest": "^5.2.0",
+        "until-async": "^3.0.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/muggle-string": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
@@ -7703,9 +7833,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7873,6 +8012,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/p-queue": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.1.0.tgz",
@@ -8005,6 +8151,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -8028,7 +8181,6 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -8048,7 +8200,6 @@
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
       "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8366,6 +8517,12 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remove-accents": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
+      "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
+      "license": "MIT"
+    },
     "node_modules/request-light": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.7.0.tgz",
@@ -8477,6 +8634,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/rettime": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.10.1.tgz",
+      "integrity": "sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/reusify": {
       "version": "1.1.0",
@@ -8772,7 +8936,6 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -8796,10 +8959,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/std-env": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
       "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -8939,6 +9119,19 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tiny-inflate": {
@@ -9167,6 +9360,22 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-fest": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
+      "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typesafe-path": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/typesafe-path/-/typesafe-path-0.2.2.tgz",
@@ -9176,7 +9385,7 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -9207,31 +9416,6 @@
         "@typescript-eslint/parser": "8.57.2",
         "@typescript-eslint/typescript-estree": "8.57.2",
         "@typescript-eslint/utils": "8.57.2"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/typescript-eslint/node_modules/@typescript-eslint/parser": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.1.tgz",
-      "integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/scope-manager": "8.57.1",
-        "@typescript-eslint/types": "8.57.1",
-        "@typescript-eslint/typescript-estree": "8.57.1",
-        "@typescript-eslint/visitor-keys": "8.57.1",
-        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -9619,6 +9803,16 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/until-async": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
+      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -10413,7 +10607,6 @@
       "version": "3.5.31",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.31.tgz",
       "integrity": "sha512-iV/sU9SzOlmA/0tygSmjkEN6Jbs3nPoIPFhCMLD2STrjgOU8DX7ZtzMhg4ahVwf5Rp9KoFzcXeB1ZrVbLBp5/Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@vue/compiler-dom": "3.5.31",
@@ -10795,6 +10988,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "npm": ">=11"
   },
   "dependencies": {
+    "@tanstack/vue-query": "^5.95.2",
     "amdefine": ">=0.1.0"
   },
   "devDependencies": {
@@ -50,6 +51,7 @@
     "eslint-plugin-astro": "^1.6.0",
     "eslint-plugin-vue": "^10.8.0",
     "jsdom": "^29.0.1",
+    "msw": "^2.12.14",
     "prettier": "^3.8.0",
     "promise-polyfill": "^8.3.0",
     "requirejs": "^2.3.8",

--- a/src/components/data/search.ts
+++ b/src/components/data/search.ts
@@ -2,97 +2,6 @@ import { isBefore } from 'date-fns';
 
 import { parseProject, type WebsiteProject } from './schema';
 
-// we are adding some default fields to search results,
-// so we can type them a bit better
-
-export type CollectionSearchResult = WebsiteProject;
-
-export interface InitMessage {
-  type: 'init';
-  base_uri: string;
-}
-
-export interface SearchQueryMessage {
-  type: 'search';
-  query: string;
-}
-
-export type WorkerMessage = InitMessage | SearchQueryMessage;
-
-export interface ErrorMessage {
-  type: 'search-error';
-  message?: string;
-}
-
-export interface SearchResultsMessage {
-  type: 'search-results';
-  list: Readonly<CollectionSearchResult[]>;
-}
-
-export type ResponseMessage = ErrorMessage | SearchResultsMessage;
-
-let loaded = false;
-let allProjects: ReadonlyArray<WebsiteProject>;
-
-/**
- * split init into a separate method so we can call it directly
- */
-export const Init = async (lastUpdated: Date) => {
-  if (!loaded) {
-    const dataUrl = `${import.meta.env.BASE_URL}/data.json`;
-    const response = await fetch(dataUrl);
-    if (response.ok) {
-      const rawProjects = await response.json();
-      if (Array.isArray(rawProjects)) {
-        allProjects = rawProjects.map(parseProject);
-        loaded = true;
-
-        return allProjects.filter((project) => {
-          if (
-            project.stats.lastUpdated &&
-            isBefore(project.stats.lastUpdated, lastUpdated)
-          ) {
-            return false;
-          }
-
-          return true;
-        });
-      }
-    }
-    return new Error('Failed to load project data');
-  }
-};
-
-export const SearchProjects = async (
-  text: string,
-  lastUpdated: Date
-): Promise<ResponseMessage> => {
-  if (!loaded) {
-    await Init(lastUpdated);
-  }
-
-  if (!loaded) {
-    const response: ErrorMessage = {
-      type: 'search-error',
-      message: 'failed to load results',
-    };
-    return response;
-  }
-
-  const list = allProjects
-    .filter((project) => filterProject(project, text, lastUpdated))
-    .sort((left, right) => {
-      return left.name.localeCompare(right.name);
-    });
-
-  const response: SearchResultsMessage = {
-    type: 'search-results',
-    list,
-  };
-
-  return response;
-};
-
 export function filterProject(
   project: WebsiteProject,
   searchText: string,
@@ -117,3 +26,40 @@ export function filterProject(
 
   return false;
 }
+
+let allProjects: WebsiteProject[] | null = null;
+
+function getDataUrl(): string {
+  const baseDir = import.meta.env.BASE_URL;
+
+  if (baseDir === '' || baseDir === '/') {
+    return '/data.json';
+  }
+
+  return `${import.meta.env.BASE_URL}/data.json`;
+}
+
+const fetchAllProjects = async (): Promise<WebsiteProject[]> => {
+  const url = getDataUrl();
+  const response = await fetch(url);
+  if (response.ok) {
+    const rawProjects = await response.json();
+    return rawProjects.map(parseProject);
+  }
+  return Promise.reject(Error('Failed to load project data'));
+};
+
+export const fetchProjects = async (
+  text: string,
+  lastUpdated: Date
+): Promise<WebsiteProject[]> => {
+  if (allProjects == null) {
+    allProjects = await fetchAllProjects();
+  }
+
+  return allProjects
+    .filter((project) => filterProject(project, text, lastUpdated))
+    .sort((left, right) => {
+      return left.name.localeCompare(right.name);
+    });
+};

--- a/src/components/search/SearchResults.test.ts
+++ b/src/components/search/SearchResults.test.ts
@@ -1,9 +1,14 @@
-import { expect, test } from 'vitest';
-import SearchResults from './SearchResults.vue';
-
+import { expect, test, vi, afterEach, beforeAll, afterAll } from 'vitest';
 import { mount, flushPromises } from '@vue/test-utils';
-import { WebsiteProject } from '../data/schema';
-import { ResponseMessage } from '../data/search';
+
+import { setupServer } from 'msw/node';
+import { http, HttpResponse } from 'msw';
+
+import { VueQueryPlugin } from '@tanstack/vue-query';
+
+import { type WebsiteProject } from '../data/schema';
+
+import SearchResults from './SearchResults.vue';
 
 const projectWithoutStats: WebsiteProject = {
   id: 'abcdef',
@@ -17,73 +22,6 @@ const projectWithoutStats: WebsiteProject = {
   },
   stats: {},
 };
-
-test('SearchResults displays count of initial projects when first rendered', async () => {
-  const wrapper = mount(SearchResults, {
-    props: {
-      initialProjects: [projectWithoutStats],
-      fetchProjects: (date: Date) => Promise.resolve([]),
-      filterProjects: (text: string, date: Date) =>
-        Promise.resolve<ResponseMessage>({ type: 'search-results', list: [] }),
-    },
-  });
-
-  const textInput = wrapper.find('#search');
-  expect(textInput.text()).toBe('');
-
-  const resultsCount = wrapper.find('.results-count');
-  expect(resultsCount.text()).toBe('1 projects found');
-});
-
-const projectWithStats: WebsiteProject = {
-  id: 'abcdef',
-  name: 'a title',
-  desc: 'a description',
-  site: 'https://github.com/some-owner/something',
-  tags: [],
-  upforgrabs: {
-    name: 'good-first-issue',
-    link: 'https://github.com/some-owner/something/labels/good-first-issue',
-  },
-  stats: {
-    lastUpdated: new Date(),
-    issueCount: 1,
-    forkCount: 1,
-  },
-};
-
-test('SearchResults fetches and displays initial count of projects', async () => {
-  const wrapper = mount(SearchResults, {
-    props: {
-      initialProjects: [],
-      fetchProjects: (date: Date) => Promise.resolve([projectWithStats]),
-      filterProjects: (text: string, date: Date) =>
-        Promise.resolve<ResponseMessage>({ type: 'search-results', list: [] }),
-    },
-  });
-
-  await flushPromises(); // wait for fetchProjects promise to resolve
-
-  const resultsCount = wrapper.find('.results-count');
-  expect(resultsCount.text()).toBe('1 projects found');
-});
-
-test('SearchResults updates UI when filter does not return results', async () => {
-  const wrapper = mount(SearchResults, {
-    props: {
-      initialProjects: [projectWithoutStats],
-      fetchProjects: (date: Date) => Promise.resolve([]),
-      filterProjects: (text: string, date: Date) =>
-        Promise.resolve<ResponseMessage>({ type: 'search-results', list: [] }),
-    },
-  });
-
-  const textInput = wrapper.find('#search');
-  await textInput.setValue('foo');
-
-  const resultsCount = wrapper.find('.results-count');
-  expect(resultsCount.text()).toBe('0 projects found');
-});
 
 const searchResults: Array<WebsiteProject> = [
   {
@@ -112,27 +50,73 @@ const searchResults: Array<WebsiteProject> = [
   },
 ];
 
+// Start server before all tests
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+
+// Close server after all tests
+afterAll(() => server.close());
+
+// Reset handlers after each test for test isolation
+afterEach(() => server.resetHandlers());
+
+const restHandlers = [
+  http.get('/data.json', () => {
+    return HttpResponse.json(searchResults);
+  }),
+];
+
+const server = setupServer(...restHandlers);
+
+test('SearchResults displays count of initial projects when first rendered', async () => {
+  const wrapper = mount(SearchResults, {
+    props: {
+      initialProjects: [projectWithoutStats],
+    },
+    global: {
+      plugins: [VueQueryPlugin],
+    },
+  });
+
+  await flushPromises();
+
+  const textInput = wrapper.find('#search');
+  expect(textInput.text()).toBe('');
+
+  const resultsCount = wrapper.find('.results-count');
+  expect(resultsCount.text()).toBe('2 projects found');
+});
+
+test('SearchResults fetches and displays initial count of projects', async () => {
+  const wrapper = mount(SearchResults, {
+    props: {
+      initialProjects: [],
+    },
+    global: {
+      plugins: [VueQueryPlugin],
+    },
+  });
+
+  await flushPromises();
+
+  const resultsCount = wrapper.find('.results-count');
+  expect(resultsCount.text()).toBe('2 projects found');
+});
+
 test('SearchResults updates count when filter returns additional results', async () => {
   const wrapper = mount(SearchResults, {
     props: {
       initialProjects: [projectWithoutStats],
-      fetchProjects: (date: Date) => Promise.resolve([]),
-      filterProjects: (text: string, date: Date) => {
-        // assert the client send the text through
-        expect(text).toBe('foo');
-
-        // return more results than expected
-        return Promise.resolve<ResponseMessage>({
-          type: 'search-results',
-          list: searchResults,
-        });
-      },
+    },
+    global: {
+      plugins: [VueQueryPlugin],
     },
   });
 
   const textInput = wrapper.find('#search');
   await textInput.setValue('foo');
 
+  await flushPromises();
+
   const resultsCount = wrapper.find('.results-count');
-  expect(resultsCount.text()).toBe('2 projects found');
+  expect(resultsCount.text()).toBe('0 projects found');
 });

--- a/src/components/search/SearchResults.vue
+++ b/src/components/search/SearchResults.vue
@@ -1,81 +1,68 @@
 <script setup lang="ts">
-import { ref, onMounted, computed } from 'vue';
+import { onMounted, ref, watch } from 'vue';
+
+import { useQuery } from '@tanstack/vue-query';
 
 import { subDays } from 'date-fns';
 
 import { InitialDaysActive } from '../data/config';
-import { type ResponseMessage } from '../data/search';
+import { fetchProjects } from '../data/search';
 import { type WebsiteProject } from '../data/schema';
 
 import ProjectEntry from './ProjectEntry.vue';
 
 const props = defineProps<{
-  initialProjects: ReadonlyArray<WebsiteProject>;
-  fetchProjects: (datetime: Date) => Promise<Array<WebsiteProject>>;
-  filterProjects: (text: string, datetime: Date) => Promise<ResponseMessage>;
+  initialProjects: Array<WebsiteProject>;
 }>();
 
-const currentProjects = ref(props.initialProjects);
+const isMounted = ref(false);
 
-const searchText = ref('');
-const lastUpdated = ref(InitialDaysActive);
-
-const lastUpdatedDate = computed(() => {
-  if (lastUpdated.value < 0) {
-    return new Date(2000, 0, 1);
-  }
-
-  return subDays(new Date(), lastUpdated.value);
+const searchText = defineModel('searchText', { default: '' });
+const lastUpdatedDays = defineModel('lastUpdatedDays', {
+  default: InitialDaysActive,
 });
 
-onMounted(() => {
-  props.fetchProjects(lastUpdatedDate.value).then((result) => {
-    if (result instanceof Error) {
-      console.error('error observed during init', result);
-    } else if (result) {
-      currentProjects.value = result;
+function parseLastUpdated(key: string | number): Date | Error {
+  if (typeof key === 'number') {
+    return subDays(new Date(), key);
+  }
+
+  if (typeof key === 'string') {
+    const intValue = parseInt(key, 10);
+
+    if (isNaN(intValue)) {
+      return new Date(2000, 0, 1);
     }
-  });
+
+    return subDays(new Date(), intValue);
+  }
+
+  return new Error(`lastUpdated query token could not be parsed: ${key}`);
+}
+
+const { data, error, isPending, isError, refetch } = useQuery({
+  queryKey: ['projects', searchText, lastUpdatedDays],
+  queryFn: ({ queryKey }) => {
+    const text = queryKey[1];
+    if (typeof text !== 'string') {
+      return Promise.reject(new Error('search text placeholder broken'));
+    }
+
+    const lastUpdated = parseLastUpdated(queryKey[2]);
+    if (lastUpdated instanceof Error) {
+      return Promise.reject(lastUpdated);
+    }
+
+    return fetchProjects(text, lastUpdated);
+  },
+  placeholderData: props.initialProjects,
+  enabled: isMounted,
 });
 
-async function search() {
-  const response = await props.filterProjects(
-    searchText.value,
-    lastUpdatedDate.value
-  );
+onMounted(() => (isMounted.value = true));
 
-  if (response.type == 'search-results') {
-    currentProjects.value = response.list;
-  } else {
-    console.error('error observed during search', response.message);
-  }
-}
-
-async function onTextChanged(ev: Event) {
-  const element = ev.target as HTMLInputElement;
-  if (!element) {
-    return;
-  }
-
-  const text = element.value;
-  searchText.value = text;
-  await search();
-}
-
-async function onPeriodChanged(ev: Event) {
-  const element = ev.target as HTMLSelectElement;
-  if (!element) {
-    return;
-  }
-
-  const text = element.value;
-  const parsedValue = parseInt(text, 10);
-  if (Number.isNaN(parsedValue)) {
-    return;
-  }
-  lastUpdated.value = parsedValue;
-  await search();
-}
+watch(searchText, () => refetch());
+watch(lastUpdatedDays, () => refetch());
 </script>
 
 <style>
@@ -134,7 +121,7 @@ menu {
         type="text"
         id="search"
         aria-labelledby="search-by-text"
-        v-on:input="onTextChanged"
+        v-model="searchText"
         placeholder="Enter text to filter projects..."
       />
       <div>
@@ -142,7 +129,7 @@ menu {
           >Choose projects active within the previous</label
         >
 
-        <select v-on:change="onPeriodChanged" aria-labelledby="activity-filter">
+        <select v-model="lastUpdatedDays" aria-labelledby="activity-filter">
           <option value="7">1 week</option>
           <option selected value="30">1 month</option>
           <!-- TODO: how to keep selected in sync with items? onMount? -->
@@ -154,12 +141,15 @@ menu {
       </div>
     </form>
   </menu>
-  <div class="results-count" aria-live="polite">
-    {{ currentProjects.length }} projects found
+  <span v-if="isPending">Loading...</span>
+  <span v-else-if="isError">Error: {{ error?.message }}</span>
+  <!-- We can assume by this point that `isSuccess === true` -->
+  <div v-else-if="data" class="results-count" aria-live="polite">
+    {{ data.length }} projects found
   </div>
-  <div class="projects">
+  <div v-if="data" class="projects">
     <ProjectEntry
-      v-for="project in currentProjects"
+      v-for="project in data"
       :key="project.id"
       :project="project"
     />

--- a/src/pages/_app.ts
+++ b/src/pages/_app.ts
@@ -1,0 +1,6 @@
+import type { App } from 'vue';
+import { VueQueryPlugin } from '@tanstack/vue-query';
+
+export default (app: App) => {
+  app.use(VueQueryPlugin);
+};

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,7 +4,6 @@ import Progress from '../components/Progress.astro';
 import Layout from '../layouts/Layout.astro';
 
 import { InitialProjects } from '../components/data/projects';
-import { Init, SearchProjects } from '../components/data/search';
 ---
 
 <Layout>
@@ -13,12 +12,7 @@ import { Init, SearchProjects } from '../components/data/search';
     <article id="projects" class="block">
       <section class="block">
         <h1>Projects</h1>
-        <SearchResults
-          client:visible
-          initialProjects={InitialProjects}
-          fetchProjects={Init}
-          filterProjects={SearchProjects}
-        />
+        <SearchResults client:visible initialProjects={InitialProjects} />
       </section>
     </article>
   </div>


### PR DESCRIPTION
https://github.com/up-for-grabs/up-for-grabs.net/pull/5683 introduced a regression that impacted the text change, so rather than undo that I wanted to streamline the internals and make this more reactive:

 - `@tanstack/vue-query` to handle state and caching, with `watcher` to handle changes
 - model binders to align with Vue conventions and reduce boilerplate
 - `msw` to handle tests stubbing fetch calls