### PR TITLE
Render most popular tags

### DIFF
--- a/src/components/data/schema.ts
+++ b/src/components/data/schema.ts
@@ -44,6 +44,11 @@ export type WebsiteProject = z.infer<typeof WebsiteProjectSchema> & {
   id: string;
 };
 
+export interface PopularTag {
+  name: string;
+  frequency: number;
+}
+
 export function parseProject(input: Project): WebsiteProject {
   let parsedDate: Date | undefined;
 

--- a/src/components/data/search.ts
+++ b/src/components/data/search.ts
@@ -69,13 +69,18 @@ export function calculatePopularTags(
     .slice(0, count);
 }
 
-function filterByTags(project: WebsiteProject, selectedTags: string[]): boolean {
+function filterByTags(
+  project: WebsiteProject,
+  selectedTags: string[]
+): boolean {
   if (selectedTags.length === 0) {
     return true;
   }
   // All selected tags must be in project tags
   const projectTagsLower = project.tags.map((t) => t.toLowerCase());
-  return selectedTags.every((tag) => projectTagsLower.includes(tag.toLowerCase()));
+  return selectedTags.every((tag) =>
+    projectTagsLower.includes(tag.toLowerCase())
+  );
 }
 
 export const fetchProjects = async (

--- a/src/components/data/search.ts
+++ b/src/components/data/search.ts
@@ -1,6 +1,6 @@
 import { isBefore } from 'date-fns';
 
-import { parseProject, type WebsiteProject } from './schema';
+import { parseProject, type WebsiteProject, type PopularTag } from './schema';
 
 export function filterProject(
   project: WebsiteProject,
@@ -49,9 +49,39 @@ const fetchAllProjects = async (): Promise<WebsiteProject[]> => {
   return Promise.reject(Error('Failed to load project data'));
 };
 
+export function calculatePopularTags(
+  projects: WebsiteProject[],
+  count: number = 6
+): PopularTag[] {
+  // Count tag frequencies
+  const tagMap: Record<string, number> = {};
+  projects.forEach((project) => {
+    project.tags.forEach((tag) => {
+      const lowerTag = tag.toLowerCase();
+      tagMap[lowerTag] = (tagMap[lowerTag] || 0) + 1;
+    });
+  });
+
+  // Convert to array and sort by frequency DESC, then name ASC
+  return Object.entries(tagMap)
+    .map(([name, frequency]) => ({ name, frequency }))
+    .sort((a, b) => b.frequency - a.frequency || a.name.localeCompare(b.name))
+    .slice(0, count);
+}
+
+function filterByTags(project: WebsiteProject, selectedTags: string[]): boolean {
+  if (selectedTags.length === 0) {
+    return true;
+  }
+  // All selected tags must be in project tags
+  const projectTagsLower = project.tags.map((t) => t.toLowerCase());
+  return selectedTags.every((tag) => projectTagsLower.includes(tag.toLowerCase()));
+}
+
 export const fetchProjects = async (
   text: string,
-  lastUpdated: Date
+  lastUpdated: Date,
+  tags?: string[]
 ): Promise<WebsiteProject[]> => {
   if (allProjects == null) {
     allProjects = await fetchAllProjects();
@@ -59,6 +89,7 @@ export const fetchProjects = async (
 
   return allProjects
     .filter((project) => filterProject(project, text, lastUpdated))
+    .filter((project) => filterByTags(project, tags || []))
     .sort((left, right) => {
       return left.name.localeCompare(right.name);
     });

--- a/src/components/search/PopularTags.vue
+++ b/src/components/search/PopularTags.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import type { PopularTag } from '../data/schema';
+
+defineProps<{
+  tags: PopularTag[];
+  selectedTags: string[];
+}>();
+
+defineEmits<{
+  toggleTag: [tagName: string];
+}>();
+</script>
+
+<template>
+  <div v-if="tags.length > 0">
+    <label class="filter-label">Filter by tags:</label>
+    <div class="radio-btn-row">
+      <button
+        v-for="tag in tags"
+        :key="tag.name"
+        :class="['radio-btn', { 'radio-btn-selected': selectedTags.includes(tag.name) }]"
+        type="button"
+        @click="$emit('toggleTag', tag.name)"
+      >
+        {{ tag.name }}
+      </button>
+    </div>
+  </div>
+</template>

--- a/src/components/search/PopularTags.vue
+++ b/src/components/search/PopularTags.vue
@@ -13,7 +13,7 @@ defineEmits<{
 
 <template>
   <div v-if="tags.length > 0">
-    <label class="filter-label">Filter by tags:</label>
+    <label class="filter-label">Filter by popular tags:</label>
     <div class="radio-btn-row">
       <button
         v-for="tag in tags"

--- a/src/components/search/PopularTags.vue
+++ b/src/components/search/PopularTags.vue
@@ -18,7 +18,10 @@ defineEmits<{
       <button
         v-for="tag in tags"
         :key="tag.name"
-        :class="['radio-btn', { 'radio-btn-selected': selectedTags.includes(tag.name) }]"
+        :class="[
+          'radio-btn',
+          { 'radio-btn-selected': selectedTags.includes(tag.name) },
+        ]"
         type="button"
         @click="$emit('toggleTag', tag.name)"
       >

--- a/src/components/search/SearchResults.vue
+++ b/src/components/search/SearchResults.vue
@@ -126,10 +126,14 @@ watch(lastUpdatedDays, () => {
   refetch();
 });
 
-watch(selectedTags, () => {
-  updateQueryString();
-  refetch();
-}, { deep: true });
+watch(
+  selectedTags,
+  () => {
+    updateQueryString();
+    refetch();
+  },
+  { deep: true }
+);
 
 const initialPopularTags = computed(() =>
   calculatePopularTags(props.initialProjects, 6)

--- a/src/components/search/SearchResults.vue
+++ b/src/components/search/SearchResults.vue
@@ -73,7 +73,7 @@ function parseLastUpdated(key: string | number): Date | Error {
 }
 
 const { data, error, isPending, isError, refetch } = useQuery({
-  queryKey: ['projects', searchText.value, lastUpdatedDays.value, selectedTags.value],
+  queryKey: ['projects', searchText, lastUpdatedDays, selectedTags],
   queryFn: ({ queryKey }) => {
     const text = queryKey[1] as string;
     const days = queryKey[2] as number;
@@ -131,19 +131,15 @@ watch(selectedTags, () => {
   refetch();
 }, { deep: true });
 
-const popularTags = computed(() => {
-  if (!data.value) {
-    return [];
-  }
-  return calculatePopularTags(data.value, 6);
-});
+const initialPopularTags = computed(() =>
+  calculatePopularTags(props.initialProjects, 6)
+);
 
 function handleToggleTag(tagName: string) {
-  const index = selectedTags.value.indexOf(tagName);
-  if (index > -1) {
-    selectedTags.value.splice(index, 1);
+  if (selectedTags.value[0] === tagName) {
+    selectedTags.value = [];
   } else {
-    selectedTags.value.push(tagName);
+    selectedTags.value = [tagName];
   }
 }
 </script>
@@ -238,7 +234,7 @@ menu {
       </div>
     </form>
     <PopularTags
-      :tags="popularTags"
+      :tags="initialPopularTags"
       :selectedTags="selectedTags"
       @toggle-tag="handleToggleTag"
     />

--- a/src/components/search/SearchResults.vue
+++ b/src/components/search/SearchResults.vue
@@ -1,18 +1,20 @@
 <script setup lang="ts">
-import { onMounted, ref, watch } from 'vue';
+import { onMounted, ref, watch, computed } from 'vue';
 
 import { useQuery } from '@tanstack/vue-query';
 
 import { subDays } from 'date-fns';
 
 import { InitialDaysActive } from '../data/config';
-import { fetchProjects } from '../data/search';
+import { fetchProjects, calculatePopularTags } from '../data/search';
 import { type WebsiteProject } from '../data/schema';
 
 import ProjectEntry from './ProjectEntry.vue';
+import PopularTags from './PopularTags.vue';
 
 const QUERY_PARAM = 'q';
 const LAST_UPDATED_PARAM = 'lastUpdated';
+const TAGS_PARAM = 'tags';
 
 const props = defineProps<{
   initialProjects: Array<WebsiteProject>;
@@ -24,6 +26,7 @@ const searchText = defineModel('searchText', { default: '' });
 const lastUpdatedDays = defineModel('lastUpdatedDays', {
   default: InitialDaysActive,
 });
+const selectedTags = ref<string[]>([]);
 
 function updateQueryString() {
   const params = new URLSearchParams(window.location.search);
@@ -36,6 +39,12 @@ function updateQueryString() {
   }
 
   params.set(LAST_UPDATED_PARAM, String(lastUpdatedDays.value));
+
+  if (selectedTags.value.length > 0) {
+    params.set(TAGS_PARAM, selectedTags.value.join(','));
+  } else {
+    params.delete(TAGS_PARAM);
+  }
 
   const queryString = params.toString();
   const nextUrl = queryString
@@ -64,19 +73,18 @@ function parseLastUpdated(key: string | number): Date | Error {
 }
 
 const { data, error, isPending, isError, refetch } = useQuery({
-  queryKey: ['projects', searchText, lastUpdatedDays],
+  queryKey: ['projects', searchText.value, lastUpdatedDays.value, selectedTags.value],
   queryFn: ({ queryKey }) => {
-    const text = queryKey[1];
-    if (typeof text !== 'string') {
-      return Promise.reject(new Error('search text placeholder broken'));
-    }
+    const text = queryKey[1] as string;
+    const days = queryKey[2] as number;
+    const tags = queryKey[3] as string[];
 
-    const lastUpdated = parseLastUpdated(queryKey[2]);
+    const lastUpdated = parseLastUpdated(days);
     if (lastUpdated instanceof Error) {
       return Promise.reject(lastUpdated);
     }
 
-    return fetchProjects(text, lastUpdated);
+    return fetchProjects(text, lastUpdated, tags.length > 0 ? tags : undefined);
   },
   placeholderData: props.initialProjects,
   enabled: isMounted,
@@ -99,6 +107,12 @@ onMounted(() => {
       lastUpdatedDays.value = parsedValue;
     }
   }
+
+  const tagsParam = params.get(TAGS_PARAM);
+  if (tagsParam) {
+    selectedTags.value = tagsParam.split(',').filter((t) => t.length > 0);
+  }
+
   updateQueryString();
 });
 
@@ -111,6 +125,27 @@ watch(lastUpdatedDays, () => {
   updateQueryString();
   refetch();
 });
+
+watch(selectedTags, () => {
+  updateQueryString();
+  refetch();
+}, { deep: true });
+
+const popularTags = computed(() => {
+  if (!data.value) {
+    return [];
+  }
+  return calculatePopularTags(data.value, 6);
+});
+
+function handleToggleTag(tagName: string) {
+  const index = selectedTags.value.indexOf(tagName);
+  if (index > -1) {
+    selectedTags.value.splice(index, 1);
+  } else {
+    selectedTags.value.push(tagName);
+  }
+}
 </script>
 
 <style>
@@ -202,6 +237,11 @@ menu {
         </select>
       </div>
     </form>
+    <PopularTags
+      :tags="popularTags"
+      :selectedTags="selectedTags"
+      @toggle-tag="handleToggleTag"
+    />
   </menu>
   <span v-if="isPending">Loading...</span>
   <span v-else-if="isError">Error: {{ error?.message }}</span>


### PR DESCRIPTION
## Summary
- Added calculatePopularTags to compute tag frequencies from projects
- Extended fetchProjects to filter by selected tags using AND logic
- Added PopularTag to schema
- Created PopularTags.vue component for tag display
- Updated SearchResults.vue to integrate popular tags

Fixes #5511 

## Validation
- npm test
- npm run prettier-fix
- git diff --check