### PR TITLE
Add career-copilot project

### DIFF
--- a/_data/projects/career-copilot.yml
+++ b/_data/projects/career-copilot.yml
@@ -1,0 +1,14 @@
+name: career-copilot
+desc: AI-powered job search pipeline built on GitHub Copilot CLI. Evaluate offers, generate tailored CVs, scan portals, track applications — all from your terminal.
+site: https://github.com/RajjjAryan/career-copilot
+tags:
+  - javascript
+  - nodejs
+  - golang
+  - ai
+  - cli
+  - career
+  - automation
+upforgrabs:
+  name: up-for-grabs
+  link: https://github.com/RajjjAryan/career-copilot/labels/up-for-grabs


### PR DESCRIPTION
Adding **career-copilot** — an AI-powered job search pipeline built on GitHub Copilot CLI.

**Repository:** https://github.com/RajjjAryan/career-copilot
**Label:** `up-for-grabs` ([link](https://github.com/RajjjAryan/career-copilot/labels/up-for-grabs))
**Open issues with label:** 11+
**License:** MIT
**Contributors:** 5+
**Language:** JavaScript/Node.js + Go

The project helps job seekers evaluate offers with structured scoring, generate ATS-optimized CVs, scan 45+ company portals, and track applications — all from the terminal.