### PR TITLE
Add Bilig

### DIFF
--- a/_data/projects/bilig.yml
+++ b/_data/projects/bilig.yml
@@ -1,7 +1,7 @@
 ---
 name: Bilig
 desc: >-
-  Headless spreadsheet engine for Node.js services, workbook automation, coding agents, and formula-heavy imports.
+  Headless TypeScript spreadsheet engine for Node.js services, coding agents, and workbook automation.
 site: https://github.com/proompteng/bilig
 tags:
   - typescript
@@ -12,7 +12,8 @@ tags:
   - headless-spreadsheet
   - workbook-automation
   - ai-agents
+  - mcp
   - open-source
 upforgrabs:
-  name: first-timers-only
-  link: https://github.com/proompteng/bilig/labels/first-timers-only
+  name: good first issue
+  link: https://github.com/proompteng/bilig/labels/good%20first%20issue

--- a/_data/projects/bilig.yml
+++ b/_data/projects/bilig.yml
@@ -1,0 +1,17 @@
+---
+name: Bilig
+desc: >-
+  Headless spreadsheet engine for Node.js services, workbook automation, and coding-agent tool calls.
+site: https://github.com/proompteng/bilig
+tags:
+  - typescript
+  - nodejs
+  - spreadsheet
+  - formulas
+  - agents
+  - workbook
+  - automation
+  - open-source
+upforgrabs:
+  name: good first issue
+  link: https://github.com/proompteng/bilig/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22

--- a/_data/projects/bilig.yml
+++ b/_data/projects/bilig.yml
@@ -5,7 +5,7 @@ desc: >-
 site: https://github.com/proompteng/bilig
 tags:
   - typescript
-  - nodejs
+  - node.js
   - spreadsheet
   - formulas
   - agents

--- a/_data/projects/bilig.yml
+++ b/_data/projects/bilig.yml
@@ -1,17 +1,18 @@
 ---
 name: Bilig
 desc: >-
-  Headless spreadsheet engine for Node.js services, workbook automation, and coding-agent tool calls.
+  Headless spreadsheet engine for Node.js services, workbook automation, coding agents, and formula-heavy imports.
 site: https://github.com/proompteng/bilig
 tags:
   - typescript
   - node.js
   - spreadsheet
-  - formulas
-  - agents
-  - workbook
-  - automation
+  - excel
+  - formula-engine
+  - headless-spreadsheet
+  - workbook-automation
+  - ai-agents
   - open-source
 upforgrabs:
-  name: good first issue
-  link: https://github.com/proompteng/bilig/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22
+  name: first-timers-only
+  link: https://github.com/proompteng/bilig/labels/first-timers-only


### PR DESCRIPTION
Adds Bilig to Up For Grabs.

Bilig has a maintained queue of scoped starter issues labeled `first-timers-only`, `good first issue`, and `help wanted`. The issue bodies include expected files, validation commands, and maintainer notes so a new contributor can make a narrow first PR.

Project: https://github.com/proompteng/bilig
Starter queue: https://github.com/proompteng/bilig/labels/first-timers-only