### PR TITLE
Add Bilig

### DIFF
--- a/_data/projects/bilig.yml
+++ b/_data/projects/bilig.yml
@@ -1,0 +1,16 @@
+---
+name: Bilig
+desc: Headless TypeScript spreadsheet engine for formulas, WorkPaper persistence, agents, and Node services
+site: https://github.com/proompteng/bilig
+tags:
+- typescript
+- node.js
+- spreadsheet
+- excel
+- formula-engine
+- automation
+- ai-agents
+- workbook
+upforgrabs:
+  name: first-timers-only
+  link: https://github.com/proompteng/bilig/labels/first-timers-only


### PR DESCRIPTION
Adds Bilig to the project list.

Bilig is an active TypeScript headless spreadsheet engine for formulas, WorkPaper persistence, coding agents, and Node services. The project currently has a maintained first-timers-only queue with 18 open issues.

Listing target: https://github.com/proompteng/bilig/labels/first-timers-only