### PR TITLE
Add Open Source Starter Lab

### DIFF
--- a/_data/projects/open-source-starter-lab.yml
+++ b/_data/projects/open-source-starter-lab.yml
@@ -1,0 +1,14 @@
+name: Open Source Starter Lab
+desc: Beginner-friendly open-source lab for practicing Git, GitHub, issues, pull requests, CI, and maintainer workflows.
+site: https://github.com/P-r-e-m-i-u-m/open-source-starter-lab
+tags:
+  - git
+  - github
+  - typescript
+  - cli
+  - documentation
+  - beginners
+  - open-source
+upforgrabs:
+  name: good first issue
+  link: https://github.com/P-r-e-m-i-u-m/open-source-starter-lab/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22

--- a/_data/projects/open-source-starter-lab.yml
+++ b/_data/projects/open-source-starter-lab.yml
@@ -7,7 +7,7 @@ tags:
   - typescript
   - cli
   - documentation
-  - beginners
+  - beginner
   - open-source
 upforgrabs:
   name: good first issue


### PR DESCRIPTION
## Summary

Adds Open Source Starter Lab to the project list.

Open Source Starter Lab is a beginner-friendly Git/GitHub practice lab with curated `good first issue` tasks, contributor docs, CI, and maintainer guidance.

Project: https://github.com/P-r-e-m-i-u-m/open-source-starter-lab

Good first issues: https://github.com/P-r-e-m-i-u-m/open-source-starter-lab/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22

## Validation

I checked the listing format manually. I could not run the Ruby validation locally because Ruby/Bundler are not installed in this Windows environment.
