### PR TITLE
Add KDM-CLI project

### DIFF
--- a/_data/projects/KDM-CLI.yml
+++ b/_data/projects/KDM-CLI.yml
@@ -11,7 +11,3 @@ tags:
 upforgrabs:
   name: good first issue
   link: https://github.com/KDM-cli/kdm-cli/labels/good%20first%20issue
-stats:
-  issue-count: 14
-  last-updated: '2026-05-28T09:39:51Z'
-  fork-count: 8

--- a/_data/projects/KDM-CLI.yml
+++ b/_data/projects/KDM-CLI.yml
@@ -1,0 +1,17 @@
+---
+name: kdm-cli
+desc: Kubernetes and Docker monitoring CLI for real-time workload, health, and log visibility
+site: https://github.com/KDM-cli/kdm-cli
+tags:
+  - kubernetes
+  - docker
+  - monitoring
+  - cli
+  - devops
+upforgrabs:
+  name: good first issue
+  link: https://github.com/KDM-cli/kdm-cli/labels/good%20first%20issue
+stats:
+  issue-count: 14
+  last-updated: '2026-05-28T09:39:51Z'
+  fork-count: 8


### PR DESCRIPTION
KDM (Kubernetes Docker Monitor) is a lightweight CLI tool that automatically detects and monitors running Docker containers and Kubernetes pods. It provides real-time health status, live dashboards, log fetching, and alert notifications — all from your terminal.

Unlike tools that focus on a single runtime ([k9s](https://k9scli.io/) for Kubernetes or [lazydocker](https://github.com/jesseduffield/lazydocker) for Docker), KDM gives you a unified view of both worlds.