### PR TITLE
Add React Debugger to the list

### DIFF
--- a/_data/projects/react-debugger-extension.yml
+++ b/_data/projects/react-debugger-extension.yml
@@ -1,0 +1,17 @@
+---
+name: React Debugger
+desc: Chrome DevTools extension that unifies React render timeline, performance, memory-leak detection, useEffect audit, CLS monitoring, Redux state inspection, and AI analysis into one panel.
+site: https://github.com/hoainho/react-debugger-extension
+tags:
+  - react
+  - typescript
+  - javascript
+  - chrome-extension
+  - devtools
+  - debugging
+  - performance
+  - redux
+  - core-web-vitals
+upforgrabs:
+  name: good first issue
+  link: https://github.com/hoainho/react-debugger-extension/labels/good%20first%20issue

--- a/_data/projects/react-debugger-extension.yml
+++ b/_data/projects/react-debugger-extension.yml
@@ -3,7 +3,7 @@ name: React Debugger
 desc: Chrome DevTools extension that unifies React render timeline, performance, memory-leak detection, useEffect audit, CLS monitoring, Redux state inspection, and AI analysis into one panel.
 site: https://github.com/hoainho/react-debugger-extension
 tags:
-  - react
+  - reactjs
   - typescript
   - javascript
   - chrome-extension


### PR DESCRIPTION
## What's added

Adding [React Debugger](https://github.com/hoainho/react-debugger-extension) — a Chrome DevTools extension for React debugging — to the project list.

```yaml
---
name: React Debugger
desc: Chrome DevTools extension that unifies React render timeline, performance, memory-leak detection, useEffect audit, CLS monitoring, Redux state inspection, and AI analysis into one panel.
site: https://github.com/hoainho/react-debugger-extension
tags:
  - react
  - typescript
  - javascript
  - chrome-extension
  - devtools
  - debugging
  - performance
  - redux
  - core-web-vitals
upforgrabs:
  name: good first issue
  link: https://github.com/hoainho/react-debugger-extension/labels/good%20first%20issue
```

## Why this project fits the criteria

- ✅ **Available maintainers** — I'm the maintainer (@hoainho), actively reviewing PRs and responding to issues within 24h
- ✅ **Curated tasks for new contributors** — currently **10 open `good first issue`** labeled tasks covering a11y, perf, UX, tests, and DX (see [filtered list](https://github.com/hoainho/react-debugger-extension/labels/good%20first%20issue))
- ✅ **Active recent contributions** — 4 PRs merged from new contributors in the last 7 days (#36 a11y, #38 docs, #40 editor config, #47 CHANGELOG)
- ✅ **First-timer-friendly workflow** — soft 7-day claim policy, structured PR template, [CONTRIBUTING.md](https://github.com/hoainho/react-debugger-extension/blob/main/.github/CONTRIBUTING.md) with explicit 5-minute first-PR path

## Checklist (matches docs/list-a-project.md)

- [x] All `tags` lowercase, no spaces, only `a-z 0-9 + # . -`
- [x] `upforgrabs.link` points to a real label with open issues (10 currently)
- [x] `stats` field omitted (auto-populated by your tooling)
- [x] Filename matches project: `react-debugger-extension.yml`
- [x] Single project per PR

## Context

- 🟢 MIT-licensed, TypeScript, actively maintained (last commit today)
- 🟢 [npm package](https://www.npmjs.com/package/@nhonh/react-debugger) — published, 18 weekly downloads and growing
- 🟢 v2.0.3 released today (June 2, 2026) with major perf overhaul
- 🟢 Star Check workflow ensures contributors are engaged before merge
- 🟢 [Pinned good-first-issues](https://github.com/hoainho/react-debugger-extension/issues) on the repo to greet new visitors

Thanks for maintaining this list — Up for Grabs is genuinely how I find OSS to contribute to, and we've already seen referral traffic from goodfirstissues.com. 🙏