### PR TITLE
Add Backend Failure Lab

### DIFF
--- a/_data/projects/backend-failure-lab.yml
+++ b/_data/projects/backend-failure-lab.yml
@@ -1,0 +1,16 @@
+name: Backend Failure Lab
+desc: Learn production backend engineering through runnable failure cases with broken code, failing tests, fixes, and production notes.
+site: https://github.com/mxm-mrz/backend_failure_lab
+tags:
+  - python
+  - fastapi
+  - backend
+  - pytest
+  - sqlalchemy
+  - debugging
+  - testing
+  - education
+  - open-source
+upforgrabs:
+  name: up-for-grabs
+  link: https://github.com/mxm-mrz/backend_failure_lab/issues?q=is%3Aissue%20is%3Aopen%20label%3Aup-for-grabs


### PR DESCRIPTION
Adds Backend Failure Lab to the project list.

Backend Failure Lab is a Python/FastAPI open-source project with runnable backend failure cases: broken code, failing tests, fixes, and production notes.

The repository has beginner-friendly issues labeled `up-for-grabs`.