### PR TITLE
Add CloudCertPrep project information

### DIFF
--- a/_data/projects/cloudcertprep.yml
+++ b/_data/projects/cloudcertprep.yml
@@ -1,0 +1,14 @@
+name: CloudCertPrep
+desc: Free, open-source AWS certification practice exams (CLF-C02 and AIF-C01) with explained answers, timed mock exams, and domain practice. No signup, no ads, MIT licensed.
+site: https://www.cloudcertprep.io
+tags:
+  - aws
+  - aws-certification
+  - certification
+  - education
+  - typescript
+  - astro
+  - react
+upforgrabs:
+  name: good first issue
+  link: https://github.com/nastaso/cloudcertprep/labels/good%20first%20issue

--- a/_data/projects/cloudcertprep.yml
+++ b/_data/projects/cloudcertprep.yml
@@ -8,7 +8,7 @@ tags:
   - education
   - typescript
   - astro
-  - react
+  - reactjs
 upforgrabs:
   name: good first issue
   link: https://github.com/nastaso/cloudcertprep/labels/good%20first%20issue


### PR DESCRIPTION
Adds CloudCertPrep, a free and open-source (MIT) AWS certification practice exam platform.

- Active project: v2.0.0 released this week, two contributor PRs already merged.
- Curated beginner tasks: 22 issues labelled "good first issue", including
  single-question "even one is welcome" tasks ideal for newcomers.
- Maintainer actively reviews and merges contributor PRs.