### PR TITLE
Add ZamSync

### DIFF
--- a/_data/projects/zamsync.yml
+++ b/_data/projects/zamsync.yml
@@ -1,0 +1,14 @@
+name: ZamSync
+desc: Offline-first sync engine in Rust for clinics in low-connectivity environments (2G, power outages). Built on an encrypted write-ahead log, version vectors, hybrid logical clocks, and mTLS. Under 10 MB RAM on Raspberry Pi 3.
+site: https://github.com/Etoile-Bleu/ZamSync
+tags:
+  - rust
+  - distributed-systems
+  - offline-first
+  - healthcare
+  - embedded
+  - networking
+  - raspberry-pi
+upforgrabs:
+  name: good first issue
+  link: https://github.com/Etoile-Bleu/ZamSync/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22


### PR DESCRIPTION
## Add ZamSync

ZamSync is an offline-first sync engine written in Rust, built for district clinics in rural Bhutan that operate over 2G cellular with frequent power outages.

**Key properties:**
- Encrypted append-only WAL with crash recovery
- Version Vector deduplication (no duplicate events ever)
- Hybrid Logical Clocks for deterministic ordering across disconnected nodes
- Mutual TLS (mTLS) with a hub-signed PKI
- Under 10 MB RAM -- runs on a Raspberry Pi 3
- Static binary, zero runtime dependencies

**Beginner-friendly issues** are labeled `good first issue` and cover areas like CLI ergonomics, documentation, additional platform tests, and observability improvements -- no deep distributed-systems knowledge required to get started.

- Site: https://github.com/Etoile-Bleu/ZamSync
- Issues: https://github.com/Etoile-Bleu/ZamSync/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22