### PR TITLE
Add tapflow

### DIFF
--- a/_data/projects/tapflow.yml
+++ b/_data/projects/tapflow.yml
@@ -1,0 +1,16 @@
+---
+name: tapflow
+desc: Self-hosted iOS & Android simulator streaming so the whole team can test mobile apps directly from a browser, using the Mac you already own with no external cloud.
+site: https://www.tapflow.dev
+tags:
+- typescript
+- testing
+- mobile-testing
+- ios
+- android
+- simulator
+- self-hosted
+- developer-tools
+upforgrabs:
+  name: good first issue
+  link: https://github.com/jo-duchan/tapflow/labels/good%20first%20issue


### PR DESCRIPTION
Adds **tapflow** — an open-source, self-hosted tool that streams iOS & Android simulators to the browser so the whole team (PM, design, QA, engineers) can test mobile apps without Xcode or device setup, using a Mac the team already owns.

**Eligibility**
- `good first issue` label with multiple open, beginner-friendly issues
- Actively maintained (commits this week)
- README.md with setup instructions and CONTRIBUTING.md
- MIT licensed

Label link: https://github.com/jo-duchan/tapflow/labels/good%20first%20issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)