### PR TITLE
data(feat): add Payload Components to project list

### DIFF
--- a/_data/projects/payload-components.yml
+++ b/_data/projects/payload-components.yml
@@ -1,0 +1,14 @@
+name: Payload Components
+desc: MIT registry and CLI for installing wired Payload CMS blocks into Payload v3 and Next.js projects.
+site: https://github.com/Ducksss/payload-components
+tags:
+  - typescript
+  - nextjs
+  - react
+  - payload-cms
+  - cms
+  - shadcn
+  - tailwindcss
+upforgrabs:
+  name: good first issue
+  link: https://github.com/Ducksss/payload-components/labels/good%20first%20issue

--- a/_data/projects/payload-components.yml
+++ b/_data/projects/payload-components.yml
@@ -4,7 +4,7 @@ site: https://github.com/Ducksss/payload-components
 tags:
   - typescript
   - nextjs
-  - react
+  - reactjs
   - payload-cms
   - cms
   - shadcn


### PR DESCRIPTION
## Summary
- Add Payload Components to the Up For Grabs project list.
- Link newcomers to the repository's `good first issue` label.

## Project fit
Payload Components is an MIT registry and CLI for installing wired Payload CMS blocks into Payload v3 and Next.js projects. The repository has active beginner-labeled tasks and maintainer-owned contribution guidance.

## Validation
- Ruby structural YAML check for `_data/projects/payload-components.yml`

Official validation note:
- `bundle exec ruby scripts/validate_data_files.rb` was not run locally because this repository now requires Ruby 4 / Bundler 4.0.3, while this machine has system Ruby 2.6.
