### PR TITLE
Fix incorrect URL for City Scrapers (closes #5863)

### DIFF
--- a/_data/projects/city-scrapers.yml
+++ b/_data/projects/city-scrapers.yml
@@ -1,7 +1,7 @@
 ---
 name: City Scrapers
 desc: Scrape public meetings to increase access and transparency around local government.
-site: https://cityscrapers.org/
+site:  https://city-scrapers.org/
 tags:
 - python
 - web-scraping


### PR DESCRIPTION
This pull request updates the City Scrapers project URL in "_data/projects/city-scrapers.yml".

The previous URL no longer points to the intended project website. This change updates it to the current and correct website:

"https://city-scrapers.org/ "

Closes #5863
