### PR TITLE
Add 8StarLabs UI

### DIFF
--- a/_data/projects/8StarLabs-UI.yml
+++ b/_data/projects/8StarLabs-UI.yml
@@ -1,7 +1,7 @@
 ---
 name: 8StarLabs UI
 desc: A component library built on top of shadcn/ui offering niche, high-utility UI elements you won't find in standard libraries
-site: https://ui.8starlabs.com/
+site: https://ui.8starlabs.com/?utm_source=up-for-grabs&utm_medium=referral&utm_campaign=directory_listing
 tags:
 - reactjs
 - nextjs

--- a/_data/projects/8StarLabs-UI.yml
+++ b/_data/projects/8StarLabs-UI.yml
@@ -3,7 +3,7 @@ name: 8StarLabs UI
 desc: A component library built on top of shadcn/ui offering niche, high-utility UI elements you won't find in standard libraries
 site: https://ui.8starlabs.com/
 tags:
-- react
+- reactjs
 - nextjs
 - typescript
 - ui

--- a/_data/projects/8StarLabs-UI.yml
+++ b/_data/projects/8StarLabs-UI.yml
@@ -1,0 +1,16 @@
+---
+name: 8StarLabs UI
+desc: A component library built on top of shadcn/ui offering niche, high-utility UI elements you won't find in standard libraries
+site: https://ui.8starlabs.com/
+tags:
+- react
+- nextjs
+- typescript
+- ui
+- components
+- shadcn
+- tailwindcss
+- design-system
+upforgrabs:
+  name: help wanted
+  link: https://github.com/8starlabs/ui/labels/help%20wanted


### PR DESCRIPTION
Adds **8StarLabs UI**, a component library built on top of shadcn/ui.

- **Site:** https://ui.8starlabs.com/?utm_source=up-for-grabs&utm_medium=referral&utm_campaign=directory_listing
- **up-for-grabs label:** [`help wanted`](https://github.com/8starlabs/ui/labels/help%20wanted) — currently has open, contributor-ready feature-request issues (new component requests, etc.)

**Eligibility:**
- [x] Maintainers actively guide new contributors
- [x] Curated small/self-contained tasks (component requests labeled `help wanted`)
- [x] Maintainers willing to review and mentor new contributors

File added: `_data/projects/8StarLabs-UI.yml` (stats omitted — auto-generated).