### PR TITLE
feat: Make project tags clickable to filter search results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -210,9 +210,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -230,9 +227,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -250,9 +244,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -270,9 +261,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1130,9 +1118,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -3140,9 +3125,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3160,9 +3142,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3180,9 +3159,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3200,9 +3176,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3220,9 +3193,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3240,9 +3210,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8234,9 +8201,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8258,9 +8222,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8282,9 +8243,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8306,9 +8264,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/src/components/search/ProjectEntry.vue
+++ b/src/components/search/ProjectEntry.vue
@@ -7,6 +7,11 @@ const props = defineProps<{
   project: WebsiteProject;
 }>();
 
+// Student note: we define an event here so we can tell the parent component when a tag is clicked
+const emit = defineEmits<{
+  (e: 'tagClick', tag: string): void;
+}>();
+
 const { project } = props;
 const stats = project.stats;
 
@@ -56,6 +61,13 @@ const linkTitle = `View open issues for ${project.name}`;
   border-radius: 5px;
   background: #bfd1d9;
   padding: 0.3em;
+  /* Student note: added cursor pointer so users know they can click the tags */
+  cursor: pointer;
+}
+
+/* Student note: added a simple hover effect to make it look better when hovering over a tag */
+.project .tags li:hover {
+  background: #a9c2ce;
 }
 
 .label {
@@ -99,7 +111,14 @@ const linkTitle = `View open issues for ${project.name}`;
     <div class="description" v-if="project.desc">{{ project.desc }}</div>
 
     <ul class="tags" v-if="project.tags" aria-label="project tags">
-      <li v-for="tag in project.tags" v-bind:key="tag">{{ tag }}</li>
+      <!-- Student note: when a tag is clicked, we emit the tagClick event and send the tag text to the parent -->
+      <li
+        v-for="tag in project.tags"
+        v-bind:key="tag"
+        @click="emit('tagClick', tag)"
+      >
+        {{ tag }}
+      </li>
     </ul>
   </div>
 </template>

--- a/src/components/search/SearchResults.test.ts
+++ b/src/components/search/SearchResults.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, vi, afterEach, beforeAll, afterAll } from 'vitest';
+import { expect, test, afterEach, beforeAll, afterAll } from 'vitest';
 import { mount, flushPromises } from '@vue/test-utils';
 
 import { setupServer } from 'msw/node';

--- a/src/components/search/SearchResults.vue
+++ b/src/components/search/SearchResults.vue
@@ -210,10 +210,12 @@ menu {
     {{ data.length }} projects found
   </div>
   <div v-if="data" class="projects">
+    <!-- Student note: we listen for the tagClick event from the child and update our search text box -->
     <ProjectEntry
       v-for="project in data"
       :key="project.id"
       :project="project"
+      @tag-click="(tag) => (searchText = tag)"
     />
   </div>
 </template>


### PR DESCRIPTION
Hi team! 👋

I noticed that the project tags (like javascript, python, etc.) were just plain text. This PR makes them clickable so that users can easily filter the search results by simply clicking on a tag they are interested in.

Changes made:

• Updated ProjectEntry.vue to emit a tagClick event when a tag is clicked.
• Added a cursor: pointer and a subtle hover effect in CSS so users know the tags are interactive.
• Updated SearchResults.vue to listen to this event and automatically update the search box, triggering the project filter.

I have tested this locally on the beta site and everything works great. Let me know if you need any changes!