### PR TITLE
Add career-ops

### DIFF
--- a/_data/projects/career-ops.yml
+++ b/_data/projects/career-ops.yml
@@ -1,0 +1,13 @@
+---
+name: career-ops
+desc: CLI-agnostic AI job-search automation - pipeline tracking, offer evaluation, CV generation, and zero-token job scanning
+site: https://github.com/santifer/career-ops
+tags:
+- oss
+- javascript
+- cli
+- job-search
+- ai
+upforgrabs:
+  name: good first issue
+  link: https://github.com/santifer/career-ops/labels/good%20first%20issue


### PR DESCRIPTION
Adds **career-ops** - a CLI-agnostic AI job-search automation tool (pipeline tracking, offer evaluation, CV generation, zero-token job scanning).

- Repo: https://github.com/santifer/career-ops
- `good first issue` label: https://github.com/santifer/career-ops/labels/good%20first%20issue (8 open, beginner-scoped with time estimates)
- Active project, welcoming CONTRIBUTING with a contribution ladder.