### PR TITLE
Add Hermes Tag

### DIFF
--- a/_data/projects/hermes-tag.yml
+++ b/_data/projects/hermes-tag.yml
@@ -1,0 +1,14 @@
+---
+name: Hermes Tag
+desc: "A Claude-Tag-style context-selection layer for the Hermes agent framework: @-mention it in a Feishu/Lark or Slack group and it replies in-thread from bounded per-chat memory."
+site: https://github.com/DanielLi202/hermes-tag
+tags:
+- python
+- feishu
+- lark
+- slack
+- agents
+- llm
+upforgrabs:
+  name: help wanted
+  link: https://github.com/DanielLi202/hermes-tag/labels/help%20wanted


### PR DESCRIPTION
Adds **Hermes Tag** — a Claude-Tag-style context-selection layer for the Hermes agent framework (Feishu/Lark + Slack).

Criteria:
- **Active & maintained** — recent commits + a v0.2.0 release.
- **Maintainer guides newcomers** — good-first-issues are scoped with exact file paths + a runnable verify command and an explicit mentor offer.
- **Curated small tasks** — https://github.com/DanielLi202/hermes-tag/labels/help%20wanted (also labeled `good first issue`).

`upforgrabs.link` points to the `help wanted` label.