### PR TITLE
Add AI Language Partner project

### DIFF
--- a/_data/projects/ai-language-partner.yml
+++ b/_data/projects/ai-language-partner.yml
@@ -1,0 +1,16 @@
+name: AI Language Partner
+desc: Local-first Japanese speaking practice app for Korean learners with Expo, FastAPI, and local STT/TTS.
+site: https://github.com/duct-tape2/ai-language-partner
+tags:
+- react-native
+- expo
+- fastapi
+- typescript
+- python
+- education
+- language-learning
+- local-first
+- accessibility
+upforgrabs:
+  name: up-for-grabs
+  link: https://github.com/duct-tape2/ai-language-partner/labels/up-for-grabs


### PR DESCRIPTION
Adds AI Language Partner to the Up For Grabs project list.

Project fit:
- Maintainer is actively preparing first-time contributor issues.
- The repo has 18 open `up-for-grabs` starter issues and 16 `first-timers-only` issues.
- Useful contribution lanes include Korean/Japanese docs, language review, accessibility, FastAPI/OpenAPI examples, and focused tests.

Validation:
- Checked the new YAML with Ruby stdlib `YAML.safe_load` plus the documented required fields/tag regex.
- Could not run `bundle exec ruby scripts/validate_data_files.rb` locally because this machine has Ruby 2.6/Bundler mismatch while the repo now requires Ruby 4/Bundler 4.
