### PR TITLE
ci(fix): pin github-script and checkout actions to commit SHAs

### DIFF
--- a/.github/workflows/review-pull-request-state.yml
+++ b/.github/workflows/review-pull-request-state.yml
@@ -21,7 +21,7 @@ jobs:
           echo "$GITHUB_CONTEXT"
 
       - name: 'Download artifact'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
@@ -52,7 +52,7 @@ jobs:
           unzip pr_number.zip -d "${{ runner.temp }}/artifacts"
 
       - name: 'Get issue number from file'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         id: get-number
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-project-stats-scheduled.yml
+++ b/.github/workflows/update-project-stats-scheduled.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           token: ${{ secrets.SHIFTBOT_TOKEN }}
 


### PR DESCRIPTION
## What

Pins the remaining un-pinned actions to full-length commit SHAs:

- `.github/workflows/review-pull-request-state.yml`: `actions/github-script@v9` → `3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0` (2 occurrences)
- `.github/workflows/update-project-stats-scheduled.yml`: `actions/checkout@v7` → `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0` (same pin already used in `continuous-integration.yml`)

## Why

The repository's Actions policy requires all actions to be pinned to a full-length commit SHA, so every **Review Pull Request** run currently fails at job setup:

> The action actions/github-script@v9 is not allowed in up-for-grabs/up-for-grabs.net because all actions must be pinned to a full-length commit SHA.

Example failed runs (each one emails the contributor whose PR triggered CI): [28943866937](https://github.com/up-for-grabs/up-for-grabs.net/actions/runs/28943866937), [28943982885](https://github.com/up-for-grabs/up-for-grabs.net/actions/runs/28943982885). As a side effect the `needs-review`/`needs-work` labels are never applied.

Follows up on #5913, which pinned the Jekyll workflow. `stale.yml` (`actions/stale@v10`) is intentionally left out — it's tracked in #5914.

🤖 Generated with [Claude Code](https://claude.com/claude-code)