### PR TITLE
ci(fix): pin actions/stale to full commit SHA

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10
         with:
           repo-token: ${{ secrets.SHIFTBOT_TOKEN }}
           stale-pr-message: 'This pull request is stale because it has been open 30 days with no activity and requires further work. Remove the stale label or comment otherwise this will be closed in a week.'


### PR DESCRIPTION
Fixes #5914

This PR pins the `actions/stale` GitHub Action to a full-length commit SHA instead of the version tag `@v10`, as required by the repository's branch protection rules for supply chain security.

Changed `actions/stale@v10` to `actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10` in `.github/workflows/stale.yml`.