### PR TITLE
Add Nora

### DIFF
--- a/_data/projects/nora.yml
+++ b/_data/projects/nora.yml
@@ -1,0 +1,17 @@
+---
+name: Nora
+desc: Self-hosted control plane to deploy, monitor, and operate OpenClaw and Hermes AI agents on Docker or Kubernetes.
+site: https://github.com/solomon2773/nora
+tags:
+- typescript
+- nextjs
+- node.js
+- docker
+- kubernetes
+- ai-agents
+- openclaw
+- hermes
+- mcp
+upforgrabs:
+  name: help wanted
+  link: https://github.com/solomon2773/nora/labels/help%20wanted


### PR DESCRIPTION
## Summary

- Add Nora, a self-hosted control plane for operating OpenClaw and Hermes AI agents on Docker or Kubernetes.
- Point contributors to the `help wanted` issue list.
- Include relevant, validator-approved technology tags.

## Contributor readiness

Nora maintainers are available to guide and review new contributors, and five curated `help wanted` issues are currently open.

## Validation

- `bundle exec ruby scripts/validate_data_files.rb` (Ruby 4 Docker toolchain): 1201 files processed, no errors
- `git diff --check`