### PR TITLE
Add PatchRail to project list

### DIFF
--- a/_data/projects/PatchRail.yml
+++ b/_data/projects/PatchRail.yml
@@ -1,0 +1,13 @@
+---
+name: PatchRail
+desc: Local-first CLI that classifies CI failure logs by root cause and suggests a fix, running fully offline so no data leaves your machine.
+site: https://github.com/patchrail/patchrail
+tags:
+- python
+- cli
+- ci
+- devops
+- testing
+upforgrabs:
+  name: good first issue
+  link: https://github.com/patchrail/patchrail/labels/good%20first%20issue


### PR DESCRIPTION
Adds [PatchRail](https://github.com/patchrail/patchrail) to the project list.

PatchRail is a local-first CLI that classifies CI failure logs by root cause and suggests a fix, running fully offline.

Against the listing criteria:

- **Active open source project** — Apache-2.0, published on PyPI, with regular releases (latest 0.7.2).
- **Curated tasks for new contributors** — the `good first issue` label (referenced in the entry) has open, scoped issues; there are also `good-first-fixture` and `help wanted` issues with clear acceptance criteria.
- **Maintainer available to guide newcomers** — recent external contributions have been reviewed and merged, and issues are triaged and answered.

The label link in the entry points to the live `good first issue` list. The `stats` block was omitted so the site's tooling can generate it.

Pablo Guillén · PatchRail
