### PR TITLE
Add django-orm-lens

### DIFF
--- a/_data/projects/django-orm-lens.yml
+++ b/_data/projects/django-orm-lens.yml
@@ -1,0 +1,15 @@
+---
+name: Django ORM Lens
+desc: Static analysis for Django models (VS Code extension + Python CLI + MCP server for AI agents). Zero database, zero Django boot, zero credentials — just parse models.py. Translations, docs, small CLI fixes, and golden fixtures all welcome as first contributions.
+site: https://github.com/FROWNINGdev/django-orm-lens
+tags:
+- python
+- django
+- typescript
+- vscode
+- static-analysis
+- developer-tools
+- mcp
+upforgrabs:
+  name: good first issue
+  link: https://github.com/FROWNINGdev/django-orm-lens/labels/good%20first%20issue


### PR DESCRIPTION
Adds `django-orm-lens` — static analysis for Django models with 8 open `good first issue` tickets covering translations (RU/ZH/ES), CLI paper-cuts, docs, and a new golden fixture. All under 1-hour scope with clear acceptance criteria.

- Repo: https://github.com/FROWNINGdev/django-orm-lens
- License: MIT
- Language: Python + TypeScript
- Good first issues: https://github.com/FROWNINGdev/django-orm-lens/labels/good%20first%20issue (8 open)