### PR TITLE
Fix malicious redirect: update Notepad project site URL to GitHub repo

### DIFF
--- a/_data/projects/notepad-web.yml
+++ b/_data/projects/notepad-web.yml
@@ -1,7 +1,7 @@
 ---
 name: Notepad
 desc: Windows notepad in web with additional features!
-site: https://rahif.me/Notepad
+site: https://github.com/Muhammed-Rahif/Notpad
 tags:
 - reactjs
 - typescript


### PR DESCRIPTION
## Issue

Fixes #5731

## Problem

The Notepad project entry (`_data/projects/notepad-web.yml`) had its `site` field pointing to `https://rahif.me/Notepad`, which performs a 301 redirect to a malicious phishing site (`phisitzogradway.com`).

## Fix

Updated the `site` field to point directly to the project's GitHub repository at `https://github.com/Muhammed-Rahif/Notpad`, matching the same domain used in the `upforgrabs.link` field.

## Verification

- The project's GitHub repository is still active and has open issues
- The new site URL matches the domain used for the `upforgrabs` link field
- No other project entries reference the compromised domain