### PR TITLE
Add Redential CLI

### DIFF
--- a/_data/projects/redential-cli.yml
+++ b/_data/projects/redential-cli.yml
@@ -1,0 +1,11 @@
+name: Redential CLI
+desc: Open-source CLI that turns private git history into an NDA-safe skill credential. Metadata only, the code never leaves the machine. Many starter issues are one-line additions to a JSON signature database, no code required.
+site: https://github.com/Redential/redential-cli
+tags:
+- typescript
+- cli
+- privacy
+- developer-tools
+upforgrabs:
+  name: up-for-grabs
+  link: https://github.com/Redential/redential-cli/labels/up-for-grabs


### PR DESCRIPTION
Adds Redential CLI, an Apache-2.0 CLI that turns private git history into an NDA-safe skill credential (metadata only, code never leaves the machine).

The `up-for-grabs` label currently has 6 open issues. Several are one-line additions to a JSON signature database, scoped so a first-time contributor can finish one in an evening. CONTRIBUTING has a five-step first-PR guide.