### PR TITLE
feat: Add FaultPlane project to directory

### DIFF
--- a/_data/projects/faultplane.yml
+++ b/_data/projects/faultplane.yml
@@ -1,0 +1,11 @@
+name: FaultPlane
+desc: An open-source Go runtime that provides zero-code-intrusion state resilience for long-running AI agent workloads.
+site: https://github.com/devloperdevesh/FaultPlane
+tags:
+  - go
+  - ai-agents
+  - service-mesh
+  - devops
+upforgrabs:
+  name: good-first-issue
+  link: https://github.com


### PR DESCRIPTION
### Project Description
Added `faultplane.yml` to register **FaultPlane** in the Up For Grabs directory. 

FaultPlane is an open-source Go runtime that provides zero-code-intrusion state resilience for long-running AI agent workloads.

### Label Configuration
- **Label Used:** `good-first-issue`
- **Verified Link:** https://github.com
