### PR TITLE
Add Aura

### DIFF
--- a/_data/projects/aura.yml
+++ b/_data/projects/aura.yml
@@ -1,0 +1,13 @@
+---
+name: Aura
+desc: Open-source VCS layer for reviewing AI-agent code changes with semantic diffs and provenance.
+site: https://github.com/Naridon-Inc/aura
+tags:
+- rust
+- git
+- developer-tools
+- ai-agents
+- code-review
+upforgrabs:
+  name: up-for-grabs
+  link: https://github.com/Naridon-Inc/aura/labels/up-for-grabs


### PR DESCRIPTION
Adds Aura as a project with curated newcomer issues labeled up-for-grabs.\n\nAura is an Apache-2.0 developer tool for reviewing AI-agent code changes with semantic diffs and provenance. The linked repo now has small documentation/integration issues for new contributors.\n\nValidation:\n- Parsed _data/projects/aura.yml with Ruby YAML successfully.\n- Full bundle validator did not run locally because this macOS environment is missing Bundler 4.0.3 required by Gemfile.lock.