### PR TITLE
Add organic-os

### DIFF
--- a/_data/projects/organic-os.yml
+++ b/_data/projects/organic-os.yml
@@ -1,0 +1,13 @@
+---
+name: organic-os
+desc: An always-on organic growth loop for your website, as a free Claude plugin. It watches search and AI-answer performance, proposes work with the reasoning attached, applies approved changes to WordPress, verifies they landed, and learns from the outcome. Every write is gated on a recorded human approval.
+site: https://organicos.shivaatripathi.com
+tags:
+- python
+- seo
+- wordpress
+- automation
+- claude
+upforgrabs:
+  name: good first issue
+  link: https://github.com/shalintripathi/organic-os/labels/good%20first%20issue


### PR DESCRIPTION
Adding organic-os, an MIT-licensed Claude plugin that runs a continuous SEO/AEO growth loop on a site you own (observe, propose, human-approve, apply, verify, learn).

- Repo: https://github.com/shalintripathi/organic-os
- Label: `good first issue` — 8 open issues currently carry it, each with a step-by-step guide, exact file paths, and a verification command.
- License: MIT

Happy to adjust tags or wording if any of it doesn't fit the conventions here.