### PR TITLE
Add SolderHub Simulator project configuration

### DIFF
--- a/_data/projects/solderhub-simulator.yml
+++ b/_data/projects/solderhub-simulator.yml
@@ -1,0 +1,15 @@
+name: SolderHub Simulator
+desc: An open-source, browser-based circuit simulator for Arduino and ESP32 — drag components onto a canvas, wire them up, and run a live simulation entirely client-side. No installs, no backend.
+site: https://simulator.solderhub.com
+tags:
+- typescript
+- react
+- nextjs
+- arduino
+- esp32
+- electronics
+- simulator
+- svg
+upforgrabs:
+  name: good first issue
+  link: https://github.com/solderhubofficial/solderhub-simulator/labels/good%20first%20issue

--- a/_data/projects/solderhub-simulator.yml
+++ b/_data/projects/solderhub-simulator.yml
@@ -3,7 +3,7 @@ desc: An open-source, browser-based circuit simulator for Arduino and ESP32 — 
 site: https://simulator.solderhub.com
 tags:
 - typescript
-- react
+- reactjs
 - nextjs
 - arduino
 - esp32


### PR DESCRIPTION
Adding SolderHub Simulator — open-source Arduino/ESP32 circuit simulator with several good-first-issue tasks open for new contributors.