### PR TITLE
Add ResuMorph

### DIFF
--- a/_data/projects/resumorph.yml
+++ b/_data/projects/resumorph.yml
@@ -1,0 +1,20 @@
+---
+name: ResuMorph
+desc: >-
+  Browser extension and self-hosted FastAPI backend that tailor a resume and cover letter to a job
+  posting using your own OpenAI, Claude or Gemini API key
+site: https://github.com/hannibalevit/resumorph
+tags:
+- python
+- typescript
+- reactjs
+- fastapi
+- chrome-extension
+- docker
+- llm
+- ai
+- privacy
+- self-hosted
+upforgrabs:
+  name: good first issue
+  link: https://github.com/hannibalevit/resumorph/labels/good%20first%20issue


### PR DESCRIPTION
ResuMorph is a browser extension plus a self-hosted FastAPI backend that tailors a resume and cover letter to a specific job posting, and drafts answers for application-form fields. You supply your own OpenAI, Claude or Gemini key and run the backend in Docker on localhost, so nothing is proxied through a server I control. Apache-2.0, Python and TypeScript/React, roughly 7.8k lines of source.

I maintain the project and I'm looking for contributors. Two issues currently carry `good first issue`:

- [#26](https://github.com/hannibalevit/resumorph/issues/26) — job-site extractors for iCIMS, Taleo and BambooHR. Seven extractors already exist, so this is the same file pattern three more times, no new design work.
- [#27](https://github.com/hannibalevit/resumorph/issues/27) — fixture-based unit tests for those extractors, which have no coverage today.

Three more (DeepSeek, Mistral and Ollama as LLM providers) sit under `help wanted`. Every issue names the files involved and how to verify the change, and CONTRIBUTING.md covers dev setup for both halves of the repo. I'll review PRs and answer questions from anyone picking one of these up.
