### PR TITLE
Add enclave

### DIFF
--- a/_data/projects/enclave.yml
+++ b/_data/projects/enclave.yml
@@ -1,0 +1,14 @@
+name: enclave
+desc: Security-first, brain-agnostic self-hosted sandboxed runtime for building and operating cost-efficient autonomous agents (Apache-2.0).
+site: https://github.com/wartzar-bee/enclave
+tags:
+  - sandbox
+  - agents
+  - ai
+  - runtime
+  - docker
+  - python
+  - security
+upforgrabs:
+  name: help wanted
+  link: https://github.com/wartzar-bee/enclave/labels/help%20wanted


### PR DESCRIPTION
Adds **enclave** — a security-first, brain-agnostic self-hosted sandboxed agent runtime (Apache-2.0). Available maintainer + curated `help wanted` / `good first issue` tasks with instructions.

- Repo: https://github.com/wartzar-bee/enclave
- up-for-grabs label: https://github.com/wartzar-bee/enclave/labels/help%20wanted