### PR TITLE
Add Onyx Launcher

### DIFF
--- a/_data/projects/onyx-launcher.yml
+++ b/_data/projects/onyx-launcher.yml
@@ -4,7 +4,7 @@ site: https://lonestill.github.io
 tags:
 - electron
 - typescript
-- react
+- reactjs
 - minecraft
 - linux
 - windows

--- a/_data/projects/onyx-launcher.yml
+++ b/_data/projects/onyx-launcher.yml
@@ -1,0 +1,13 @@
+name: Onyx Launcher
+desc: Open-source desktop Minecraft launcher for Windows and Linux with isolated instances, Modrinth, automatic Java, diagnostics, and safe backups.
+site: https://lonestill.github.io
+tags:
+- electron
+- typescript
+- react
+- minecraft
+- linux
+- windows
+upforgrabs:
+  name: up for grabs
+  link: https://github.com/lonestill/onyx-launcher/labels/up%20for%20grabs


### PR DESCRIPTION
## Summary

List Onyx Launcher, an active MIT-licensed Electron/TypeScript desktop Minecraft launcher for Windows and Linux.

The project currently maintains three small, curated documentation tasks under the `up for grabs` label. Each issue has explicit scope and acceptance criteria, and the maintainer is available to review focused pull requests:

- SHA-256 verification on Windows and Linux
- First-launch troubleshooting for Windows and Linux
- Snapshots, backups, trash, and instance recovery

Label query: https://github.com/lonestill/onyx-launcher/labels/up%20for%20grabs