### PR TITLE
Add Clippy Vision project details to YAML

### DIFF
--- a/_data/projects/clippy-vision.yml
+++ b/_data/projects/clippy-vision.yml
@@ -1,0 +1,13 @@
+name: Clippy Vision
+desc: Fully local AI assistant that watches your screen (windows, clipboard, screenshots) so you can query your own activity history instead of re-explaining context to an LLM every time. Runs on Ollama + a local vision model, nothing leaves your machine.
+site: https://github.com/protocorn/clippy-vision
+tags:
+  - python
+  - javascript
+  - electron
+  - ollama
+  - local-ai
+  - privacy
+upforgrabs:
+  name: good first issue
+  link: https://github.com/protocorn/clippy-vision/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22


### PR DESCRIPTION
Title: Add Clippy Vision

Adding Clippy Vision, a fully local screen-memory assistant (Electron + Ollama + local vision model, no cloud). It lets you query your own screen activity history instead of re-explaining context to an LLM every time.

The project has active good first issue-labeled tasks with clear context, hints, and acceptance criteria, and has already had one PR merged from an outside contributor, so there's a track record of actually reviewing and merging contributions, not just posting issues.