### PR TITLE
Add enclave (self-hosted agent runtime)

### DIFF
--- a/_data/projects/enclave.yml
+++ b/_data/projects/enclave.yml
@@ -1,0 +1,14 @@
+name: enclave
+desc: Security-first, brain-agnostic self-hosted sandboxed runtime for building and operating cost-efficient autonomous agents (Apache-2.0).
+site: https://github.com/wartzar-bee/enclave
+tags:
+  - sandbox
+  - agents
+  - ai
+  - runtime
+  - docker
+  - python
+  - security
+upforgrabs:
+  name: help wanted
+  link: https://github.com/wartzar-bee/enclave/labels/help%20wanted


### PR DESCRIPTION
Adds **enclave** — an Apache-2.0, security-first self-hosted sandboxed runtime for building/operating cost-efficient autonomous agents.

- Project: https://github.com/wartzar-bee/enclave
- up-for-grabs label: [`help wanted`](https://github.com/wartzar-bee/enclave/labels/help%20wanted) (2 curated open issues)

Follows `_data/projects/*.yml` schema.