### PR TITLE
Add Moon Downloader

### DIFF
--- a/_data/projects/moondownloader.yml
+++ b/_data/projects/moondownloader.yml
@@ -1,6 +1,6 @@
 ---
 name: Moon Downloader
-desc: A bulk file downloader for datanodes.to and fuckingfast.co, with a WebView2 GUI and a headless CLI.
+desc: A bulk file downloader for Windows: real-Chrome extraction over CDP, aiohttp streaming, a WebView2 GUI and a headless CLI.
 site: https://github.com/LeyckerS/moondownloader
 tags:
 - python

--- a/_data/projects/moondownloader.yml
+++ b/_data/projects/moondownloader.yml
@@ -1,0 +1,14 @@
+---
+name: Moon Downloader
+desc: A bulk file downloader for datanodes.to and fuckingfast.co, with a WebView2 GUI and a headless CLI.
+site: https://github.com/LeyckerS/moondownloader
+tags:
+- python
+- windows
+- aiohttp
+- playwright
+- documentation
+- ci
+upforgrabs:
+  name: good first issue
+  link: https://github.com/LeyckerS/moondownloader/labels/good%20first%20issue

--- a/_data/projects/moondownloader.yml
+++ b/_data/projects/moondownloader.yml
@@ -1,6 +1,6 @@
 ---
 name: Moon Downloader
-desc: A bulk file downloader for Windows: real-Chrome extraction over CDP, aiohttp streaming, a WebView2 GUI and a headless CLI.
+desc: A bulk file downloader for Windows, with real-Chrome extraction over CDP, aiohttp streaming, a WebView2 GUI and a headless CLI.
 site: https://github.com/LeyckerS/moondownloader
 tags:
 - python


### PR DESCRIPTION
Adds [Moon Downloader](https://github.com/LeyckerS/moondownloader) — a bulk file downloader for datanodes.to and fuckingfast.co (Python, Windows, MIT, 1.5k stars).

**Curated tasks:** six open issues, four labelled `good first issue`, each one written up with the files to touch and the acceptance criteria stated, so a newcomer doesn't have to guess what "done" means. Roadmap issue with difficulty and scope for each: https://github.com/LeyckerS/moondownloader/issues/39

**On the Windows question:** the app itself is Windows-only, but most of the curated work isn't. The documentation, CI and dependency issues run on any OS, and the test suite stubs Chrome and the network at the extraction boundary so it needs no browser and no display. Each issue states up front whether Windows is required.

Maintainer is active and reviewing — 19 external contributors have had PRs merged, and `CONTRIBUTING.md` documents the architecture, the non-negotiable rules and the verification commands.

`stats` omitted per the template, since it's generated by your tooling.