### PR TITLE
Add YazSes — offline voice dictation (Linux/macOS/Windows)

### DIFF
--- a/_data/projects/yazses.yml
+++ b/_data/projects/yazses.yml
@@ -1,0 +1,18 @@
+---
+name: YazSes
+desc: 'Offline, hold-to-talk voice dictation for Linux, macOS and Windows — hold a key, speak, release, and it types into any focused app. On-device faster-whisper speech-to-text plus voice commands and macros. No cloud, no API key.'
+site: https://github.com/MSKazemi/yazses
+tags:
+- python
+- speech-to-text
+- voice
+- dictation
+- accessibility
+- linux
+- macos
+- windows
+- offline
+- whisper
+upforgrabs:
+  name: good first issue
+  link: https://github.com/MSKazemi/yazses/labels/good%20first%20issue

--- a/_data/projects/yazses.yml
+++ b/_data/projects/yazses.yml
@@ -1,12 +1,13 @@
 ---
 name: YazSes
-desc: 'Offline, hold-to-talk voice dictation for Linux, macOS and Windows — hold a key, speak, release, and it types into any focused app. On-device faster-whisper speech-to-text plus voice commands and macros. No cloud, no API key.'
+desc: 'Free, open-source voice dictation and speech-to-text for Linux, macOS and Windows — hold a key, speak, release, and the text is typed into whatever window has focus. Runs on the CPU with faster-whisper; nothing leaves the machine by default. Also transcribes recordings and captures meetings with speaker labels. No cloud, no API key.'
 site: https://github.com/MSKazemi/yazses
 tags:
 - python
 - speech-to-text
 - voice
 - dictation
+- transcription
 - accessibility
 - linux
 - macos


### PR DESCRIPTION
Adds [YazSes](https://github.com/MSKazemi/yazses), an open-source, fully-offline hold-to-talk voice-dictation tool for Linux, macOS and Windows (on-device faster-whisper, no cloud).

The project actively welcomes new contributors and maintains a set of beginner-friendly issues under the `good first issue` label — docs, translations, shell completion, example config, and more:
https://github.com/MSKazemi/yazses/labels/good%20first%20issue

- License: Apache-2.0
- Language: Python 3.11+
- Label link is valid and currently has multiple open, unassigned good-first issues.