### PR TITLE
Add mcp-migrate

### DIFF
--- a/_data/projects/mcp-migrate.yml
+++ b/_data/projects/mcp-migrate.yml
@@ -7,7 +7,7 @@ tags:
 - typescript
 - cli
 - linter
-- static analysis
+- static-analysis
 - ai
 upforgrabs:
   name: up-for-grabs

--- a/_data/projects/mcp-migrate.yml
+++ b/_data/projects/mcp-migrate.yml
@@ -1,0 +1,14 @@
+---
+name: mcp-migrate
+desc: 'Finds and mechanically fixes what the MCP 2026-07-28 spec revision breaks in your server. 21 rules, 5 autofixers, and a graded board of real servers.'
+site: https://github.com/dheerajjha/mcp-migrate
+tags:
+- python
+- typescript
+- cli
+- linter
+- static analysis
+- ai
+upforgrabs:
+  name: up-for-grabs
+  link: https://github.com/dheerajjha/mcp-migrate/labels/up-for-grabs


### PR DESCRIPTION
Adds `mcp-migrate` — a CLI that finds and mechanically fixes what the MCP 2026-07-28 spec revision breaks in a server.

- Repo: https://github.com/dheerajjha/mcp-migrate (Apache-2.0)
- Label: [`up-for-grabs`](https://github.com/dheerajjha/mcp-migrate/labels/up-for-grabs) — 49 open issues currently carry it
- Issues are sized (`size: XS` / `S` / `M`) and 31 are marked `mentored`, meaning the maintainer will walk you through it in the thread

Most of them are self-contained: 13 documentation recipes, 18 single-rule TypeScript ports with two merged reference implementations to copy, and 16 autofixers. One external contributor has already landed a port this way.