### PR TITLE
Add elm.chat contributor tasks

### DIFF
--- a/_data/projects/elm-chat.yml
+++ b/_data/projects/elm-chat.yml
@@ -4,7 +4,7 @@ desc: Open-source, account-free, disposable encrypted chat rooms with single-use
 site: https://github.com/shawnbure/elm-chat
 tags:
 - typescript
-- react
+- reactjs
 - cloudflare
 - privacy
 - cryptography

--- a/_data/projects/elm-chat.yml
+++ b/_data/projects/elm-chat.yml
@@ -1,0 +1,15 @@
+---
+name: elm.chat
+desc: Open-source, account-free, disposable encrypted chat rooms with single-use invites and no persisted server-side transcript.
+site: https://github.com/shawnbure/elm-chat
+tags:
+- typescript
+- react
+- cloudflare
+- privacy
+- cryptography
+- websockets
+- security
+upforgrabs:
+  name: good first issue
+  link: https://github.com/shawnbure/elm-chat/labels/good%20first%20issue


### PR DESCRIPTION
Adds elm.chat, an AGPL-3.0 TypeScript/React project on Cloudflare Workers and Durable Objects.

The linked `good first issue` label currently has eight open, scoped tasks covering accessibility, UX, reliability, deployment verification, and threat-model documentation. I maintain elm.chat and am available to review changes and guide new contributors. I closed two already-completed issues before submitting so the listing does not send newcomers to stale work.

Local verification:
- YAML parsed successfully
- `npm test` (63 tests)
- `npm run lint`
- `npm run prettier`
- `npm run build`