### PR TITLE
Add gnt to the projects list

### DIFF
--- a/_data/projects/gnt.yml
+++ b/_data/projects/gnt.yml
@@ -1,0 +1,12 @@
+name: gnt
+desc: git-native rules layer for AI agents. Every rule is a file, reviewed and merged like code
+site: https://gntai.dev
+tags:
+- ai-agents
+- ai-safety
+- governance
+- mcp
+- policy-as-code
+upforgrabs:
+  name: help wanted
+  link: https://github.com/gnt-ai/gnt/labels/help%20wanted


### PR DESCRIPTION
Adding gnt (https://github.com/gnt-ai/gnt), a git-native rules layer for AI agents — rules live as files in a repo and ship through normal reviewed PRs.

- Apache-2.0 licensed, actively maintained
- Beginner-friendly issues tracked under the `help wanted` label: https://github.com/gnt-ai/gnt/labels/help%20wanted
- CONTRIBUTING.md with dev setup and test/lint instructions