### PR TITLE
Add LoopTroop project entry

### DIFF
--- a/_data/projects/looptroop.yml
+++ b/_data/projects/looptroop.yml
@@ -1,0 +1,12 @@
+---
+name: LoopTroop
+desc: Local-first AI coding orchestrator powered by LLM Council planning, Ralph Loops, and atomic git worktrees.
+site: https://github.com/looptroop-ai/LoopTroop
+tags:
+- ai
+- developer-tools
+- typescript
+- agentic-ai
+upforgrabs:
+  name: good first issue
+  link: https://github.com/looptroop-ai/LoopTroop/labels/good%20first%20issue


### PR DESCRIPTION
### Summary

This PR adds **LoopTroop** (`looptroop.yml`) to Up For Grabs project directory under `_data/projects/`.

- **Project Name:** LoopTroop
- **Description:** Local-first AI coding orchestrator powered by LLM Council planning, Ralph Loops, and atomic git worktrees.
- **Repository / Website:** https://github.com/looptroop-ai/LoopTroop
- **Issue Label:** `good first issue` (https://github.com/looptroop-ai/LoopTroop/labels/good%20first%20issue)
- **License:** MIT License