### PR TITLE
Add ItsPaint

### DIFF
--- a/_data/projects/itspaint.yml
+++ b/_data/projects/itspaint.yml
@@ -1,0 +1,16 @@
+---
+name: ItsPaint
+desc: >-
+  A native macOS paint app in Swift. The raster engine, PaintKit, is a UI-free
+  SwiftPM package with 275 tests that builds and tests from a fresh clone with
+  the command-line toolchain alone, so contributors do not need Xcode.
+site: https://github.com/joshlin2201/itspaint
+tags:
+- swift
+- macos
+- swiftpm
+- graphics
+- image-editing
+upforgrabs:
+  name: good first issue
+  link: https://github.com/joshlin2201/itspaint/labels/good%20first%20issue


### PR DESCRIPTION
Adds ItsPaint, a native macOS paint app written in Swift.

Against the three criteria in `docs/list-a-project.md`:

**Curated small tasks.** Five open `good first issue` items, each one naming the file and line where the work goes and explaining why the change is small:

- [#3 grow and shrink a selection by a pixel amount](https://github.com/joshlin2201/itspaint/issues/3)
- [#4 make a selection from the alpha channel](https://github.com/joshlin2201/itspaint/issues/4)
- [#5 arrowheads as a line style, not a separate shape](https://github.com/joshlin2201/itspaint/issues/5)
- [#6 flip and rotate the selection, not the whole image](https://github.com/joshlin2201/itspaint/issues/6)
- [#7 add to and subtract from a selection](https://github.com/joshlin2201/itspaint/issues/7)

They are scoped deliberately: each one is a single pass over a `[UInt8]` mask, or one enum threaded from the options bar to the draw call, with an existing precedent in the codebase to copy. Each names the wrinkle that is easy to get wrong and suggests the one test that catches it.

**A contributor can actually build it.** The raster engine is `PaintKit`, a SwiftPM package with no AppKit, no SwiftUI and no third-party dependency. `swift test` from a fresh clone runs 275 tests in 40 suites in under five seconds with the command-line toolchain alone — no Xcode, and nothing to install. All five issues are scoped to that package on purpose, so a first contribution does not need a Mac IDE, only a Mac.

**Available maintainer.** Sole maintainer, actively developing, `CONTRIBUTING.md` in the repo. I will review promptly and work through the change with anyone who picks one up.

Omitted `stats` per the docs, since your tooling generates it.
