### PR TITLE
Add AOBench — benchmark for AI agents operating HPC systems

### DIFF
--- a/_data/projects/aobench.yml
+++ b/_data/projects/aobench.yml
@@ -1,0 +1,17 @@
+---
+name: AOBench
+desc: 'A role-aware, permission-enforced benchmark for evaluating AI agents that operate HPC systems — SLURM job control, telemetry inspection, RBAC, documentation and facility tasks. Runs are trace-based and reproducible against deterministic environment snapshots, and a permission violation hard-fails the task rather than being scored as a near miss. Some environments are grounded in telemetry from a real production supercomputer.'
+site: https://github.com/MSKazemi/AOBench
+tags:
+- python
+- benchmark
+- evaluation
+- llm
+- ai-agents
+- hpc
+- slurm
+- documentation
+- testing
+upforgrabs:
+  name: good first issue
+  link: https://github.com/MSKazemi/AOBench/labels/good%20first%20issue

--- a/_data/projects/aobench.yml
+++ b/_data/projects/aobench.yml
@@ -14,4 +14,4 @@ tags:
 - testing
 upforgrabs:
   name: good first issue
-  link: https://github.com/MSKazemi/AOBench/labels/good%20first%20issue
+  link: https://github.com/MSKazemi/aobench/labels/good%20first%20issue


### PR DESCRIPTION
Adds [AOBench](https://github.com/MSKazemi/AOBench), an open-source (Apache-2.0) benchmark for evaluating AI agents that operate HPC systems — SLURM job control, telemetry inspection, RBAC, documentation and facility tasks.

The project keeps a curated set of beginner-friendly tasks under the `good first issue` label, and a broader `help wanted` set. Issues are additionally tagged by area (`area: docs`, `area: cli`, `area: scorers`, `area: mcp`) and by effort (`effort: small` / `medium` / `large`), so a newcomer can pick by both topic and size:
https://github.com/MSKazemi/AOBench/labels/good%20first%20issue

- License: Apache-2.0
- Language: Python
- Docs: https://mskazemi.com/aobench/
- CONTRIBUTING.md, CODE_OF_CONDUCT.md and CITATION.cff are all in place, and the maintainer reviews and merges contributions promptly.

Happy to adjust the description or tags if anything does not fit the list conventions.