### PR TITLE
Add KubeIntellect — natural-language Kubernetes operations with human approval gates

### DIFF
--- a/_data/projects/kubeintellect.yml
+++ b/_data/projects/kubeintellect.yml
@@ -1,0 +1,17 @@
+---
+name: KubeIntellect
+desc: 'KubeIntellect lets operators ask Kubernetes questions in plain English, gathers live evidence from cluster tools such as kubectl, Prometheus and Loki, and pauses for explicit human approval before destructive operations. It is a research system rather than a production-certified product: synthesized tools are validated and approval-gated, but currently execute in-process rather than in an isolated container. Python, FastAPI and LangGraph; AGPL-3.0.'
+site: https://github.com/MSKazemi/kubeintellect
+tags:
+- python
+- kubernetes
+- devops
+- sre
+- observability
+- llm
+- ai-agents
+- fastapi
+- documentation
+upforgrabs:
+  name: good first issue
+  link: https://github.com/MSKazemi/kubeintellect/labels/good%20first%20issue


### PR DESCRIPTION
Adds [KubeIntellect](https://github.com/MSKazemi/kubeintellect), an open-source (AGPL-3.0) system that lets operators ask Kubernetes questions in plain English, gathers live evidence from cluster tools such as kubectl, Prometheus and Loki, and pauses for explicit human approval before destructive operations.

It is a research system rather than a production-certified product, and the description says so — synthesized tools are validated and approval-gated but currently execute in-process rather than in an isolated container.

The project maintains a set of beginner-friendly issues under the `good first issue` label, tagged by area (`area/agents`, `area/detectors`, `area/server`, `area/kube-q`, `area/memory`, `area/packaging`) so a newcomer can pick by subsystem:
https://github.com/MSKazemi/kubeintellect/labels/good%20first%20issue

- License: AGPL-3.0
- Language: Python (FastAPI, LangGraph)
- Docs: https://kubeintellect.com
- CONTRIBUTING.md, CODE_OF_CONDUCT.md and CITATION.cff are in place, and the maintainer reviews and merges contributions promptly.

Happy to adjust the description or tags if anything does not fit the list conventions.