### PR TITLE
Add nod3

### DIFF
--- a/_data/projects/nod3.yml
+++ b/_data/projects/nod3.yml
@@ -1,0 +1,15 @@
+---
+name: nod3
+desc: >-
+  A local-first trainer for algorithm interviews. It records what you say and what you type on one
+  clock, then shows you the stretches where you were coding in silence.
+site: https://github.com/ostapondo/nod3
+tags:
+- typescript
+- javascript
+- node.js
+- next.js
+- python
+upforgrabs:
+  name: good first issue
+  link: https://github.com/ostapondo/nod3/labels/good%20first%20issue


### PR DESCRIPTION
Adding [nod3](https://github.com/ostapondo/nod3). It's a trainer for algorithm interviews — it records your voice and your keystrokes on one clock and shows you where you were coding in silence.

Against the criteria in [list-a-project.md](https://github.com/up-for-grabs/up-for-grabs.net/blob/gh-pages/docs/list-a-project.md):

- **Maintainer around.** I wrote it and I'm working on it daily. Issues get an answer within a few days.
- **Small tasks curated.** Four issues under [`good first issue`](https://github.com/ostapondo/nod3/labels/good%20first%20issue), each written for someone who's never seen the code — they name files and line numbers and say what a PR needs. Two of them need no microphone, speech model or model access to work on.
- **Happy to guide newcomers.** [CONTRIBUTING.md](https://github.com/ostapondo/nod3/blob/main/CONTRIBUTING.md) says it plainly: draft PRs welcome, no question is too basic, nobody will comment on your English. There are also issue templates for people who want to contribute interview experience rather than code, which is honestly most of what this project needs.

Being upfront: it's new and has no stars yet. If you'd rather list projects with an existing contributor base, say so and I'll come back later.
