### PR TITLE
Add MergeWarden

### DIFF
--- a/_data/projects/mergewarden.yml
+++ b/_data/projects/mergewarden.yml
@@ -1,0 +1,16 @@
+---
+name: MergeWarden
+desc: >-
+  GitHub Action that reports when a pull request edits the files coding agents
+  read as instructions (CLAUDE.md, AGENTS.md, .mcp.json), plus workflow
+  permission changes. It comments only and never closes anything.
+site: https://github.com/sjh9714/mergewarden
+tags:
+- typescript
+- github-actions
+- ai
+- code-review
+- developer-tools
+upforgrabs:
+  name: good first issue
+  link: https://github.com/sjh9714/mergewarden/labels/good%20first%20issue


### PR DESCRIPTION
MergeWarden is a GitHub Action that reports when a pull request edits the files coding agents read as instructions (CLAUDE.md, AGENTS.md, .mcp.json and similar), along with workflow permission changes. It comments only and never closes anything.

On the criteria:

- Active: 10 releases since June 2026, CI green, latest release this week.
- Curated small tasks: the [good first issue label](https://github.com/sjh9714/mergewarden/labels/good%20first%20issue) has five open tasks, and each one names the file to change, the command to verify it, and what done looks like.
- Maintainer review: three external contributors have landed PRs so far, each reviewed and merged, one of them a first-time contributor whose workflow run needed manual approval and got it the same day.