### PR TITLE
Add AI Skill Navigator

### DIFF
--- a/_data/projects/ai-skill-navigator.yml
+++ b/_data/projects/ai-skill-navigator.yml
@@ -1,0 +1,13 @@
+name: AI Skill Navigator
+desc: AI-powered Moodle plugin for tutoring, quizzes, mind maps, RAG course materials and beginner-friendly open source contributions.
+site: https://github.com/Berserk-hub150/moodle-ai-skill-navigator
+tags:
+  - php
+  - moodle
+  - ai
+  - rag
+  - edtech
+  - education
+upforgrabs:
+  name: good first issue
+  link: https://github.com/Berserk-hub150/moodle-ai-skill-navigator/labels/good%20first%20issue


### PR DESCRIPTION
Adds AI Skill Navigator to Up For Grabs.

The project provides actively maintained beginner-friendly issues labelled good first issue, including small browser-only contribution tasks.

Project: https://github.com/Berserk-hub150/moodle-ai-skill-navigator
Issues: https://github.com/Berserk-hub150/moodle-ai-skill-navigator/labels/good%20first%20issue
