### PR TITLE
Add BlindAssist project

### DIFF
--- a/_data/projects/blindassist.yml
+++ b/_data/projects/blindassist.yml
@@ -1,0 +1,19 @@
+---
+name: BlindAssist
+desc: >-
+  An open-source Android prototype for on-device assistive perception,
+  reproducible evaluation, and evidence-bounded accessibility research.
+site: https://github.com/violetljj/blind-assist
+tags:
+- android
+- kotlin
+- accessibility
+- assistive-technology
+- on-device-ml
+- computer-vision
+- tflite
+- reproducible-research
+- social-impact
+upforgrabs:
+  name: good first issue
+  link: https://github.com/violetljj/blind-assist/labels/good%20first%20issue


### PR DESCRIPTION
## What changed

- Add BlindAssist to the project directory.
- Point the listing at the repository's `good first issue` queue.
- Describe the Android, Kotlin, accessibility, on-device ML, and reproducible-research scope.

## Why

BlindAssist is an open-source Android research prototype with four currently open, bounded newcomer issues covering Linux setup verification, documentation regression fixtures, accessibility-string checks, and deterministic unit tests:

- https://github.com/violetljj/blind-assist/issues/26
- https://github.com/violetljj/blind-assist/issues/27
- https://github.com/violetljj/blind-assist/issues/28
- https://github.com/violetljj/blind-assist/issues/29

I maintain the project and am available to clarify tasks and review contributions.

## Validation

- Parsed the new file as YAML.
- Checked the expected top-level fields, lower-case tags, and issue-label link.
- The repository's Ruby validator was not available in the local Windows environment; the submitted change is intentionally limited to one project data file so CI can perform the canonical validation.
