### PR TITLE
ItsPaint: describe the engine by what does not decay

### DIFF
--- a/_data/projects/itspaint.yml
+++ b/_data/projects/itspaint.yml
@@ -2,8 +2,9 @@
 name: ItsPaint
 desc: >-
   A native macOS paint app in Swift. The raster engine, PaintKit, is a UI-free
-  SwiftPM package with 275 tests that builds and tests from a fresh clone with
-  the command-line toolchain alone, so contributors do not need Xcode.
+  SwiftPM package with 321 tests and no third-party dependencies, which builds and
+  tests from a fresh clone with the command-line toolchain alone, so contributors do
+  not need Xcode.
 site: https://github.com/joshlin2201/itspaint
 tags:
 - swift

--- a/_data/projects/itspaint.yml
+++ b/_data/projects/itspaint.yml
@@ -2,9 +2,9 @@
 name: ItsPaint
 desc: >-
   A native macOS paint app in Swift. The raster engine, PaintKit, is a UI-free
-  SwiftPM package with 321 tests and no third-party dependencies, which builds and
-  tests from a fresh clone with the command-line toolchain alone, so contributors do
-  not need Xcode.
+  SwiftPM package with no third-party dependencies, so `git clone && swift test` runs
+  the whole suite with the command-line toolchain alone. Contributors do not need
+  Xcode, a GUI session, or a dependency resolve.
 site: https://github.com/joshlin2201/itspaint
 tags:
 - swift


### PR DESCRIPTION
The listing said 275 tests. The engine suite has moved twice while this PR was open,
which is the point: a test count in a listing is stale the next time anyone writes a
test, and nothing on either side can check it.

So this states the property that makes the fresh-clone claim work and does not decay.
PaintKit declares no third-party dependencies, so `git clone && swift test` has
nothing to resolve first, and needs no Xcode and no GUI session.

One file, description only. The label link, tags and site are unchanged.