### PR TITLE
Add Lians

### DIFF
--- a/_data/projects/Lians.yml
+++ b/_data/projects/Lians.yml
@@ -1,0 +1,16 @@
+---
+name: Lians
+desc: Local-first, open-source memory for AI agents with MCP and multi-language SDKs
+site: https://github.com/Lians-ai/Lians
+tags:
+- python
+- ai
+- ai-agents
+- mcp
+- memory
+- sqlite
+- local-first
+- llm
+upforgrabs:
+  name: good first issue
+  link: https://github.com/Lians-ai/Lians/labels/good%20first%20issue


### PR DESCRIPTION
Adds Lians, an Apache-2.0 local-first memory project for AI agents.

The Lians maintainers actively guide new contributors and currently maintain two bounded `good first issue` tasks: a credential-free LangGraph example and Cline CLI installer support. One has already been claimed with prompt maintainer scoping; the other is open.

Project: https://github.com/Lians-ai/Lians
Issues: https://github.com/Lians-ai/Lians/labels/good%20first%20issue

Validation:

- `npx --yes yaml-lint _data/projects/Lians.yml` passes
- project and issue-label URLs return HTTP 200
- the label currently has two open issues
- `git diff --check` passes

I am affiliated with Lians. This submission was prepared with AI assistance and manually reviewed against the listing criteria and schema.