### PR TITLE
Add HackRadar project

### DIFF
--- a/_data/projects/HackRadar.yml
+++ b/_data/projects/HackRadar.yml
@@ -1,0 +1,18 @@
+name: HackRadar
+desc: A global discovery engine for hackathons that aggregates public hackathon listings into one searchable and filterable platform.
+site: https://github.com/ZainabTravadi/HackRadar
+tags:
+  - typescript
+  - javascript
+  - reactjs
+  - node.js
+  - backend
+  - frontend
+  - web
+  - crawler
+  - postgresql
+  - playwright
+  - open-source
+upforgrabs:
+  name: up-for-grabs
+  link: https://github.com/ZainabTravadi/HackRadar/labels/up-for-grabs


### PR DESCRIPTION
## Project

HackRadar is an open-source global discovery engine for hackathons.

It aggregates public hackathon listings from multiple sources into a searchable and filterable platform.

## Contributions

HackRadar welcomes contributions across frontend, backend, crawler/data, testing, documentation, accessibility, and design/UX.

The project uses the `up-for-grabs` label for contributor-friendly tasks.

Repository:
https://github.com/ZainabTravadi/HackRadar

Up-for-grabs issues:
https://github.com/ZainabTravadi/HackRadar/labels/up-for-grabs