### PR TITLE
Add py-simple-wrap

### DIFF
--- a/_data/projects/py-simple-wrap.yml
+++ b/_data/projects/py-simple-wrap.yml
@@ -6,5 +6,5 @@ tags:
   - beginner-friendly
   - education
 upforgrabs:
-  name: good-first-issue
+  name: good first issue
   link: https://github.com/sara-czasak/py-simple-wrap/labels/good%20first%20issue

--- a/_data/projects/py-simple-wrap.yml
+++ b/_data/projects/py-simple-wrap.yml
@@ -1,10 +1,10 @@
 name: py-simple-wrap
-   desc: A beginner-friendly Python toolbox that removes boilerplate for common tasks
-   site: https://github.com/sara-czasak/py-simple-wrap
-   tags:
-     - python
-     - beginner-friendly
-     - education
-   upforgrabs:
-     name: good-first-issue
-     link: https://github.com/sara-czasak/py-simple-wrap/labels/good-first-issue
+desc: A beginner-friendly Python toolbox that removes boilerplate for common tasks
+site: https://github.com/sara-czasak/py-simple-wrap
+tags:
+  - python
+  - beginner-friendly
+  - education
+upforgrabs:
+  name: good-first-issue
+  link: https://github.com/sara-czasak/py-simple-wrap/labels/good-first-issue

--- a/_data/projects/py-simple-wrap.yml
+++ b/_data/projects/py-simple-wrap.yml
@@ -7,4 +7,4 @@ tags:
   - education
 upforgrabs:
   name: good-first-issue
-  link: https://github.com/sara-czasak/py-simple-wrap/labels/good-first-issue
+  link: https://github.com/sara-czasak/py-simple-wrap/labels/good%20first%20issue

--- a/_data/projects/py-simple-wrap.yml
+++ b/_data/projects/py-simple-wrap.yml
@@ -1,0 +1,10 @@
+name: py-simple-wrap
+   desc: A beginner-friendly Python toolbox that removes boilerplate for common tasks
+   site: https://github.com/sara-czasak/py-simple-wrap
+   tags:
+     - python
+     - beginner-friendly
+     - education
+   upforgrabs:
+     name: good-first-issue
+     link: https://github.com/sara-czasak/py-simple-wrap/labels/good-first-issue


### PR DESCRIPTION
Adds py-simple-wrap to the project list.

py-simple-wrap is a beginner-friendly Python toolbox that wraps common
tasks (file handling, string/number helpers, web scraping, unit
conversions, CSV/JSON handling, and more) into simple, readable
function calls, so newcomers can build something working without
memorizing boilerplate or complex syntax.

The project actively curates issues labeled `good-first-issue` for
new contributors, and the maintainer is available to review PRs and
help contributors get started.

- Repo: https://github.com/sara-czasak/py-simple-wrap
- Docs: https://sara-czasak.github.io/py-simple-wrap/docs/
- Good first issues: https://github.com/sara-czasak/py-simple-wrap/labels/good-first-issue