### PR TITLE
Add SysKnife

### DIFF
--- a/_data/projects/sysknife.yml
+++ b/_data/projects/sysknife.yml
@@ -1,0 +1,13 @@
+name: SysKnife
+desc: A Linux sysadmin co-pilot that runs as an MCP server and accepts typed actions only, with out-of-band terminal approval and an Ed25519-signed audit chain.
+site: https://lacs-project.github.io/sysknife/
+tags:
+- rust
+- linux
+- mcp
+- security
+- devops
+- sysadmin
+upforgrabs:
+  name: good first issue
+  link: https://github.com/lacs-project/sysknife/labels/good%20first%20issue


### PR DESCRIPTION
Adding SysKnife, a Linux sysadmin co-pilot that runs as an MCP server. It turns a
plain-language request into typed, risk-classified actions that a privileged
daemon runs only after a human approves them in a terminal, and it records every
authorisation decision in an Ed25519-signed hash chain a third party can verify
with only the public key.

Against the criteria in `docs/list-a-project.md`:

**Small tasks curated for new contributors.** 15 open issues carry
`good first issue`, and 14 carry `easy`. Each one names the file and line, quotes
the code, states what breaks, and proposes the test to write first. Recent
examples: a sanitizer that strips invisible characters but skips the two its
sibling module treats as line breaks; a 4 MiB frame limit declared once per side
of a protocol with nothing holding the two equal; a shell assertion that cannot
fail because `pipefail` makes the pipeline status the scanner's own exit code.

**Maintainers available and willing.** Two contributors picked up issues
yesterday and both got a substantive answer the same day, including corrections
to my own issue text where they had found it wrong. Difficulty labels are
`easy`, `medium`, `hard` and `tedious`, and issues that someone has claimed carry
a `claimed` label so nobody duplicates work.

**Getting started.** No CLA and no copyright waiver, MIT licensed. The test suite
runs in about ninety seconds, and a local pre-commit hook runs the same fmt,
clippy, doc and nextest gates as CI, so a contributor finds out before pushing
rather than after. `CONTRIBUTING.md` covers the build, the workflow and the
trust-boundary rules.

Tags are lowercase and within the documented character set. No `stats` block, per
the template note that tooling generates it.
