### PR TITLE
Add Wandful

### DIFF
--- a/_data/projects/wandful.yml
+++ b/_data/projects/wandful.yml
@@ -1,0 +1,17 @@
+---
+name: Wandful
+desc: >-
+  Mouse gestures that fire keyboard shortcuts on macOS and Windows. Draw a shape you can repeat,
+  and the shortcut you bound to it is typed into the app you were already using.
+site: https://github.com/ostapondo/wandful
+tags:
+- rust
+- typescript
+- tauri
+- macos
+- windows
+- desktop
+- productivity
+upforgrabs:
+  name: good first issue
+  link: https://github.com/ostapondo/wandful/labels/good%20first%20issue


### PR DESCRIPTION
Wandful is a mouse-gesture launcher for keyboard shortcuts on macOS and Windows: press a hotkey, draw a shape with the mouse, and the shortcut you bound to that shape is typed into the app you were already using. Rust + Tauri 2, MIT.

It is a young project and I am the only maintainer, but I am here every day and happy to walk newcomers through the code. The `good first issue` ones are small and self-contained — a new action type, a preview of the matched shape while you draw, multi-stroke recognition — and CONTRIBUTING.md covers the build on both platforms.

Label: `good first issue` — https://github.com/ostapondo/wandful/labels/good%20first%20issue
