### PR TITLE
Add DQ QuestionBank Core

### DIFF
--- a/_data/projects/dq-questionbank-core.yml
+++ b/_data/projects/dq-questionbank-core.yml
@@ -1,0 +1,15 @@
+name: DQ QuestionBank Core
+desc: Local-first visual question bank workspace for LaTeX authoring, importing, reviewing, editing, and Word/DOCX publishing.
+site: https://github.com/wzsisshadiao-crypto/dq-questionbank-core
+tags:
+  - python
+  - education
+  - edtech
+  - latex
+  - docx
+  - math
+  - testing
+  - question-bank
+upforgrabs:
+  name: good first issue
+  link: https://github.com/wzsisshadiao-crypto/dq-questionbank-core/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22


### PR DESCRIPTION
## Summary

- Add DQ QuestionBank Core to the Up For Grabs project list.
- Link the `good first issue` queue used by the project.
- Describe the local-first Python, education, LaTeX, DOCX, math, and question-bank scope.

DQ QuestionBank Core is actively maintained with CI, public contribution guidance, and an available maintainer for newcomer pull requests. The linked repository currently has several small, clearly scoped `good first issue` tasks, including fixture-only, no-code, LaTeX, DOCX, testing, and frontend work.