### PR TITLE
Add HFlow

### DIFF
--- a/_data/projects/hflow.yml
+++ b/_data/projects/hflow.yml
@@ -1,0 +1,17 @@
+name: HFlow
+desc: >-
+  HFlow is an open-source Python SDK for building observable data pipelines for robotics and physical AI.
+  It stamps each processed episode with provenance, visualizes the pipeline as an Airflow graph, and lets
+  you query metadata and quality evidence without loading the underlying recordings.
+site: https://github.com/Hebbian-Robotics/hflow
+tags:
+- python
+- robotics
+- physical-ai
+- data-engineering
+- airflow
+- mcap
+- parquet
+upforgrabs:
+  name: good first issue
+  link: https://github.com/Hebbian-Robotics/hflow/labels/good%20first%20issue


### PR DESCRIPTION
## Summary

- Add HFlow, an open-source Python SDK for robotics and physical-AI data pipelines.
- Link new contributors to HFlow's curated `good first issue` tasks.

## Validation

- `bundle exec ruby scripts/validate_data_files.rb`
- `bundle exec rubocop`
- `bundle exec jekyll build`
- `npm run build`
- `npm run lint`
- `npm run lint-new`
- `npm run prettier`
- `npm test`
