### PR TITLE
Add audiobard to Up for Grabs

### DIFF
--- a/_data/projects/audiobard.yml
+++ b/_data/projects/audiobard.yml
@@ -1,0 +1,13 @@
+---
+name: audiobard
+desc: Multi-voice audiobooks from public-domain books with a local LLM and TTS
+site: https://github.com/oscarbol09/audiobard
+tags:
+  - python
+  - llm
+  - tts
+  - audiobook
+  - cli
+upforgrabs:
+  name: good first issue
+  link: https://github.com/oscarbol09/audiobard/labels/good%20first%20issue


### PR DESCRIPTION
Adds [audiobard](https://github.com/oscarbol09/audiobard) to Up for Grabs.

Audiobard converts public-domain books into multi-voice audiobooks using a local LLM (Ollama) and local TTS (Piper/Edge). It now has 5 open issues labeled `good first issue`, each:

- isolated to a single module with exact file:line pointers
- self-contained reproductions confirmed against the current code
- acceptance criteria with a failing test pin
- no LLM/benchmark required (no prompts or parser changes involved)

The project has CI gates (ruff, mypy, tests with 100% coverage, guards) and a CONTRIBUTING.md that documents the evidence bar, so new contributors have a clear feedback loop.

Maintainer is available to guide new contributors and review PRs promptly.