### PR TITLE
Add OSS Accessibility Inclusion project

### DIFF
--- a/_data/projects/OSS-Accessibility-Inclusion.yml
+++ b/_data/projects/OSS-Accessibility-Inclusion.yml
@@ -1,9 +1,9 @@
 ---
 name: OSS Accessibility Inclusion
-desc: >-
-  Investigating how accessibility contributions to open source are reviewed in
-  practice — case studies, a review rubric, and reusable a11y contribution
-  templates.
+desc: Research into how accessibility contributions to open source are reviewed
+  in practice - scored case studies, a public review rubric, and reusable a11y
+  contribution templates. Tasks are evidence and documentation work, not
+  feature code.
 site: https://github.com/ecogetaway/oss-accessibility-inclusion
 tags:
 - accessibility
@@ -11,7 +11,6 @@ tags:
 - documentation
 - research
 - oss
-- markdown
 upforgrabs:
-  name: help wanted
-  link: https://github.com/ecogetaway/oss-accessibility-inclusion/labels/help%20wanted
+  name: tier-a
+  link: https://github.com/ecogetaway/oss-accessibility-inclusion/labels/tier-a

--- a/_data/projects/OSS-Accessibility-Inclusion.yml
+++ b/_data/projects/OSS-Accessibility-Inclusion.yml
@@ -1,0 +1,17 @@
+---
+name: OSS Accessibility Inclusion
+desc: >-
+  Investigating how accessibility contributions to open source are reviewed in
+  practice — case studies, a review rubric, and reusable a11y contribution
+  templates.
+site: https://github.com/ecogetaway/oss-accessibility-inclusion
+tags:
+- accessibility
+- a11y
+- documentation
+- research
+- oss
+- markdown
+upforgrabs:
+  name: help wanted
+  link: https://github.com/ecogetaway/oss-accessibility-inclusion/labels/help%20wanted


### PR DESCRIPTION
## Project

OSS Accessibility Inclusion investigates how accessibility contributions to open source are reviewed in practice. It publishes scored case studies, a public review rubric, and reusable a11y contribution templates. Tasks are evidence and documentation work, not feature code.

Repository:
https://github.com/ecogetaway/oss-accessibility-inclusion

## Contributions

The project uses the `tier-a` label for cold-claimable newcomer tasks (standalone documentation and evidence work).

Up-for-grabs issues:
https://github.com/ecogetaway/oss-accessibility-inclusion/labels/tier-a