### PR TITLE
Add OSS Language Inclusion project

### DIFF
--- a/_data/projects/OSS-Language-Inclusion.yml
+++ b/_data/projects/OSS-Language-Inclusion.yml
@@ -1,0 +1,17 @@
+---
+name: OSS Language Inclusion
+desc: >-
+  Evidence on how Indic and other under-served locales get reviewed
+  upstream, plus i18n tooling including a translated-string security
+  linter. Tasks are bounded localization and documentation work.
+site: https://github.com/ecogetaway/oss-language-inclusion
+tags:
+- i18n
+- l10n
+- localization
+- documentation
+- research
+- oss
+upforgrabs:
+  name: tier-a
+  link: https://github.com/ecogetaway/oss-language-inclusion/labels/tier-a


### PR DESCRIPTION
## Project

OSS Language Inclusion collects evidence on how Indic and other under-served locales get reviewed upstream, plus i18n tooling including a translated-string security linter. Tasks are bounded localization and documentation work.

Repository:
https://github.com/ecogetaway/oss-language-inclusion

## Contributions

The project uses the `tier-a` label for cold-claimable newcomer tasks (standalone localization and documentation work).

Up-for-grabs issues:
https://github.com/ecogetaway/oss-language-inclusion/labels/tier-a