### PR TITLE
Add deja-vu

### DIFF
--- a/_data/projects/deja-vu.yml
+++ b/_data/projects/deja-vu.yml
@@ -1,0 +1,14 @@
+---
+name: deja-vu
+desc: 'Memory for coding agents, built from the session files they already write to disk: search, MCP recall and automatic recall across twenty agents, with no LLM and no embeddings.'
+site: https://github.com/vshulcz/deja-vu
+tags:
+- go
+- cli
+- ai
+- memory
+- developer-tools
+- mcp
+upforgrabs:
+  name: good first issue
+  link: https://github.com/vshulcz/deja-vu/labels/good%20first%20issue


### PR DESCRIPTION
deja-vu is a local memory layer for coding agents: it indexes the session files Claude Code, Codex, Cursor, opencode and sixteen more agents already write to disk, and serves them back over MCP or the terminal. Go, MIT, no LLM and no embeddings.

Three issues are labelled `good first issue` right now — a formatting fix, a bounded counting bug, and a documentation page — and I review and answer on the repository daily; thirty-two pull requests from other people are merged so far.