### PR TITLE
Add Urusilla

### DIFF
--- a/_data/projects/urusilla.yml
+++ b/_data/projects/urusilla.yml
@@ -1,8 +1,8 @@
 ---
 name: Urusilla
 desc: >-
-  Experimental no-install semantic language and public evaluation lab for safe, efficient communication
-  between unfamiliar AI agents.
+  Experimental no-install semantic language and public evaluation lab for safe communication and falsifiable
+  efficiency claims between unfamiliar AI agents.
 site: https://github.com/jaden3824/urusilla
 tags:
 - ai

--- a/_data/projects/urusilla.yml
+++ b/_data/projects/urusilla.yml
@@ -1,0 +1,17 @@
+---
+name: Urusilla
+desc: >-
+  Experimental no-install semantic language and public evaluation lab for safe, efficient communication
+  between unfamiliar AI agents.
+site: https://github.com/jaden3824/urusilla
+tags:
+- ai
+- agents
+- python
+- protocols
+- interoperability
+- llm
+- research
+upforgrabs:
+  name: good first issue
+  link: https://github.com/jaden3824/urusilla/labels/good%20first%20issue


### PR DESCRIPTION
## Project readiness

- Urusilla is an active Apache-2.0 experimental research project for communication between unfamiliar AI agents.
- Five scoped `good first issue` tasks are currently open, including a 60-second question, decode reproduction, adversarial test, and design review.
- The maintainer is available to guide contributors and review evidence or code contributions.
- A no-install quickstart and machine-validatable public challenge keep the first contribution bounded.

The project explicitly welcomes exact matches, mismatches, refusals, failures, and null results; participation is not presented as adoption or efficiency proof.