### PR TITLE
Add Civic Nightmare

### DIFF
--- a/_data/projects/civic-nightmare.yml
+++ b/_data/projects/civic-nightmare.yml
@@ -1,0 +1,14 @@
+---
+name: Civic Nightmare
+desc: A surreal political satire RPG about renewing a passport, built with Godot.
+site: https://daniele-cangi.github.io/civic-nightmare/
+tags:
+- godot
+- gdscript
+- game
+- rpg
+- open-source
+- pixel-art
+upforgrabs:
+  name: up-for-grabs
+  link: https://github.com/Daniele-Cangi/civic-nightmare/labels/up-for-grabs


### PR DESCRIPTION
Adds Civic Nightmare, an open-source Godot 4.6 and GDScript RPG, to the project directory. The entry points to the playable browser build and to the up-for-grabs label, which currently contains five small, scoped issues. The repository includes a contributor guide covering setup, validation, and the PR workflow. Local checks passed: Prettier on the new YAML file and the static site build.