### PR TITLE
Add GitHub Traffic Archive

### DIFF
--- a/_data/projects/github-traffic-archive.yml
+++ b/_data/projects/github-traffic-archive.yml
@@ -1,0 +1,13 @@
+---
+name: GitHub Traffic Archive
+desc: Archive repository views, clones, referrers, and popular paths before GitHub's 14-day traffic window discards them.
+site: https://github.com/HafidIdrissi/github-traffic-archive
+tags:
+- python
+- github
+- github-actions
+- analytics
+- privacy
+upforgrabs:
+  name: good first issue
+  link: https://github.com/HafidIdrissi/github-traffic-archive/labels/good%20first%20issue


### PR DESCRIPTION
## Project

Adds GitHub Traffic Archive, a dependency-free Python CLI and GitHub Action that preserves repository traffic beyond GitHub's rolling 14-day window.

## Contributor readiness

- Four small, scoped issues currently carry the good first issue label.
- The repository includes a contribution guide, issue forms, a pull request template, and a code of conduct.
- Pull requests run 26 tests on Linux and Windows with Python 3.9 and 3.12.
- The maintainer is available to assign issues and review focused pull requests.

The listing points directly to the live good first issue backlog.