### PR TITLE
Add RoleCraft project

### DIFF
--- a/_data/projects/rolecraft.yml
+++ b/_data/projects/rolecraft.yml
@@ -1,0 +1,12 @@
+name: RoleCraft
+desc: The package manager for AI agents — install, test, publish, and manage skills and MCP servers across 87 AI coding agents. Zero-dependency CLI.
+site: https://rolecraft-sh.github.io/rolecraft/
+tags:
+  - ai
+  - cli
+  - ai-agents
+  - mcp
+  - developer-tools
+upforgrabs:
+  name: good first issue
+  link: https://github.com/rolecraft-sh/rolecraft/labels/good%20first%20issue


### PR DESCRIPTION
Adds [rolecraft-sh/rolecraft](https://github.com/rolecraft-sh/rolecraft) — a zero-dependency Node.js CLI that installs, tests, and publishes AI agent skills and MCP servers across 87 coding agents.

The project actively curates beginner-friendly tasks: currently **11 open issues labeled `good first issue`**, each with repro steps, scope notes, and acceptance criteria (e.g. [#252](https://github.com/rolecraft-sh/rolecraft/issues/252), [#253](https://github.com/rolecraft-sh/rolecraft/issues/253)). The repo has contributing guidelines and maintainers who review first-time PRs.

- Label used: `good first issue` ([issue list](https://github.com/rolecraft-sh/rolecraft/labels/good%20first%20issue))
- Site: https://rolecraft-sh.github.io/rolecraft/