### PR TITLE
Add Plonk

### DIFF
--- a/_data/projects/Plonk.yml
+++ b/_data/projects/Plonk.yml
@@ -1,0 +1,18 @@
+---
+name: Plonk
+desc: >-
+  A window manager for macOS. Draw the zones you want on each monitor, then drop windows into them
+  with a drag, a shortcut or by saying so out loud. It keeps Rectangle's shortcuts, puts apps back on
+  the right monitor when a display comes back, and runs on-device.
+site: https://ostapondo.github.io/Plonk/
+tags:
+- swift
+- swiftui
+- macos
+- window-manager
+- menubar
+- accessibility
+- mcp
+upforgrabs:
+  name: good first issue
+  link: https://github.com/ostapondo/Plonk/labels/good%20first%20issue


### PR DESCRIPTION
Adding [Plonk](https://github.com/ostapondo/Plonk), a window manager for macOS. You draw the zones you want on each monitor and drop windows into them with a drag, a shortcut or by saying so out loud. It keeps Rectangle's shortcuts and rectangle:// URLs so people can switch without relearning anything. Swift, MIT, macOS 13 and up, no dependencies.

Against the criteria in [list-a-project.md](https://github.com/up-for-grabs/up-for-grabs.net/blob/gh-pages/docs/list-a-project.md):

- **Maintainer around.** I wrote it and I work on it daily. [CONTRIBUTING.md](https://github.com/ostapondo/Plonk/blob/main/CONTRIBUTING.md) promises an answer within 48 hours, even if the answer is that it needs another week of thought.
- **Small tasks curated.** Seven issues under [`good first issue`](https://github.com/ostapondo/Plonk/labels/good%20first%20issue), each written for someone who has never seen the code: they name the files and say what a PR needs. Two of them need no Xcode at all (a setup page for another MCP client, a layout file for zone-sets/).
- **Happy to guide newcomers.** Review asks for changes instead of pushing them, a declined change comes with the reason, and anyone whose change lands is named in the release notes. There is also a `reserved-for-contributors` label for issues I leave alone on purpose.

Two people besides me have landed changes so far. Still a small project; if you would rather wait for a bigger contributor base, say so and I will come back later.

Label: `good first issue`, https://github.com/ostapondo/Plonk/labels/good%20first%20issue
