### PR TITLE
Add fastdocparse

### DIFF
--- a/_data/projects/fastdocparse.yml
+++ b/_data/projects/fastdocparse.yml
@@ -1,0 +1,12 @@
+name: fastdocparse
+desc: Extract structured data from documents using any OpenAI-compatible LLM, with per-field grounding and confidence.
+site: https://github.com/pranjalparmar/fastdocparse
+tags:
+- python
+- llm
+- document-processing
+- pdf
+- ocr
+upforgrabs:
+  name: good first issue
+  link: https://github.com/pranjalparmar/fastdocparse/labels/good%20first%20issue


### PR DESCRIPTION
fastdocparse extracts structured data from documents (invoices, forms, resumes) using any OpenAI-compatible LLM, with per-field grounding/confidence to flag hallucinated values. MIT licensed, typed, 74 tests.

We maintain 4 curated `good first issue`-labeled tasks, each scoped to a specific file/ruff-rule with exact fix instructions so a new contributor doesn't need to read the whole codebase first: https://github.com/pranjalparmar/fastdocparse/labels/good%20first%20issue