### PR TITLE
Add OffPDF

### DIFF
--- a/_data/projects/offpdf.yml
+++ b/_data/projects/offpdf.yml
@@ -1,0 +1,17 @@
+name: OffPDF
+desc: Open-source, offline-first desktop PDF tools for editing, organizing, converting, compressing, securing, and OCR without uploading files.
+site: https://github.com/McanKul/offpdf
+tags:
+  - rust
+  - tauri
+  - typescript
+  - reactjs
+  - pdf
+  - desktop
+  - offline
+  - privacy
+  - macos
+  - windows
+upforgrabs:
+  name: good first issue
+  link: https://github.com/McanKul/offpdf/labels/good%20first%20issue


### PR DESCRIPTION
Adds OffPDF, an open-source offline-first desktop PDF toolkit, to the project directory.

The listing points directly to the curated `good first issue` label. I maintain OffPDF and am available to guide contributors and review their pull requests.

Validation: `bundle exec ruby scripts/validate_data_files.rb` — 1263 files processed with no errors.