### PR TITLE
Add Pip

### DIFF
--- a/_data/projects/pip.yml
+++ b/_data/projects/pip.yml
@@ -1,0 +1,15 @@
+---
+name: Pip
+desc: 'Single-player Texas Hold''em in the browser: a poker engine, an AI opponent and a PWA, all in TypeScript. Play money only, no ads, no accounts required. The engine is pure and unit-tested, so a rules change is a test change.'
+site: https://playpip.io
+tags:
+- typescript
+- javascript
+- reactjs
+- nextjs
+- game
+- pwa
+- poker
+upforgrabs:
+  name: good first issue
+  link: https://github.com/playpip/pip-web/labels/good%20first%20issue


### PR DESCRIPTION
Adds `_data/projects/pip.yml`.

**Pip** is a single-player Texas Hold'em game for the browser — a poker engine, an AI opponent and a PWA, all TypeScript. Play money only, no ads, no accounts.

Against the criteria in [`docs/list-a-project.md`](https://github.com/up-for-grabs/up-for-grabs.net/blob/gh-pages/docs/list-a-project.md):

- **Maintainers who guide new contributors** — four people outside the core team have landed changes in `pip-web`, and every one of them was walked through review.
- **A curated list of small tasks** — 8 open [`good first issue`](https://github.com/playpip/pip-web/labels/good%20first%20issue) right now, each scoped to one file or one test.
- **Willing to review and work with new contributors** — yes, and the engine (`src/lib/poker/`) is pure and unit-tested, so a first-timer can change a rule and watch a test prove it.

Repo: https://github.com/playpip/pip-web (MIT, actively pushed to). Site: https://playpip.io

Happy to change anything the review asks for.