### PR TITLE
Add SDP (Social Daily Poster)

### DIFF
--- a/_data/projects/sdp.yml
+++ b/_data/projects/sdp.yml
@@ -1,0 +1,14 @@
+---
+name: SDP (Social Daily Poster)
+desc: Self-hosted daily social poster. It reads your Claude Code or Codex sessions, screenshots and messages at the end of the day, drafts a LinkedIn or X post from what you actually did, and sends it to a private Telegram bot for approval before anything publishes.
+site: https://github.com/dimamak/sdp
+tags:
+- python
+- linkedin
+- telegram
+- ai
+- self-hosted
+- automation
+upforgrabs:
+  name: good first issue
+  link: https://github.com/dimamak/sdp/labels/good%20first%20issue


### PR DESCRIPTION
Adds `_data/projects/sdp.yml`.

**SDP (Social Daily Poster)** is a self-hosted tool that reads your Claude Code or Codex sessions, screenshots and messages at the end of the day, drafts a LinkedIn or X post from what you actually did, and sends it to a private Telegram bot for approval before anything publishes. Python 3, MIT.

Against the criteria in `docs/list-a-project.md`:

- **Available maintainer interested in guiding new contributors** — yes, I maintain it and I am watching the issue tracker daily.
- **Curated small tasks for new contributors** — four issues labelled `good first issue`, each scoped to a single file with the acceptance criteria written out: [#1](https://github.com/dimamak/sdp/issues/1), [#2](https://github.com/dimamak/sdp/issues/2), [#3](https://github.com/dimamak/sdp/issues/3), [#4](https://github.com/dimamak/sdp/issues/4).
- **Willing to review and work with new contributors** — the first one already has a PR from a first-time contributor, reviewed and passing.

`CONTRIBUTING.md` covers local setup and the test suite; no server, bot or paid API key is needed to run the tests.

Tags are lower case with no spaces. `stats` is omitted as the docs say, since it is generated by your tooling.