### PR TITLE
Add Doberman

### DIFF
--- a/_data/projects/doberman.yml
+++ b/_data/projects/doberman.yml
@@ -1,0 +1,12 @@
+---
+name: Doberman
+desc: Gives every AI-agent tool call an allow/authenticate/block verdict from a local policy engine
+site: https://github.com/DobermanCore/Doberman-Core
+tags:
+- python
+- security
+- ai
+- llm
+upforgrabs:
+  name: good first issue
+  link: https://github.com/DobermanCore/Doberman-Core/labels/good%20first%20issue


### PR DESCRIPTION
Adds Doberman, an Apache-2.0 Python authorization layer for AI coding agents. We keep the good-first-issue label stocked and answer newcomer issues; 19 contributors have merged PRs so far.
