### PR TITLE
Add deepLocal

### DIFF
--- a/_data/projects/deeplocal.yml
+++ b/_data/projects/deeplocal.yml
@@ -1,0 +1,15 @@
+name: deepLocal
+desc: A local-first AI workbench for downloading, managing, chatting with, and serving GGUF models on your own computer.
+site: https://github.com/petertzy/deepLocal
+tags:
+  - rust
+  - react
+  - typescript
+  - ai
+  - local-ai
+  - gguf
+  - llama-cpp
+  - desktop
+upforgrabs:
+  name: up-for-grabs
+  link: https://github.com/petertzy/deepLocal/labels/up-for-grabs

--- a/_data/projects/deeplocal.yml
+++ b/_data/projects/deeplocal.yml
@@ -3,7 +3,7 @@ desc: A local-first AI workbench for downloading, managing, chatting with, and s
 site: https://github.com/petertzy/deepLocal
 tags:
   - rust
-  - react
+  - reactjs
   - typescript
   - ai
   - local-ai


### PR DESCRIPTION
Adds deepLocal, a local-first AI workbench for downloading, managing, chatting with, and serving GGUF models locally.

The project is MIT licensed and has issues suitable for new contributors.