### PR TITLE
Add Authier project

### DIFF
--- a/_data/projects/Authier.yml
+++ b/_data/projects/Authier.yml
@@ -1,0 +1,17 @@
+---
+name: Authier
+desc: >-
+  An open-source, browser-first password manager and TOTP vault with client-side encrypted sync and trusted-device
+  approval.
+site: https://www.authier.pm/
+tags:
+- typescript
+- password-manager
+- browser-extension
+- security
+- privacy
+- totp
+- web
+upforgrabs:
+  name: good first issue
+  link: https://github.com/authier-pm/authier/labels/good%20first%20issue


### PR DESCRIPTION
## What changed

- Add Authier to the project directory.
- Point the listing at Authier's curated `good first issue` queue.
- Describe the TypeScript, browser-extension, password-manager, privacy, and TOTP scope.

## Why

Authier is an actively maintained open-source browser-first password manager and
TOTP vault. The newcomer queue currently contains three bounded issues with
explicit context, acceptance criteria, and validation commands:

- https://github.com/authier-pm/authier/issues/532
- https://github.com/authier-pm/authier/issues/533
- https://github.com/authier-pm/authier/issues/534

I maintain Authier and am available to clarify these tasks, review pull
requests, and help new contributors work through the repository.

## Validation

- Parsed the new file as YAML and checked its exact top-level fields.
- Verified every tag uses the documented lower-case character set.
- Verified the GitHub label exists and currently has three open issues.
- `npm run prettier` passes.
- `npm run lint-new` passes.
- `npm test` passes 63 tests across 9 files when temporary files are routed
  around this host's inode-exhausted `/tmp` mount.
- `npm run build` completes successfully.
- `git diff --check` passes.

The repository's Ruby validator requires Ruby 4, while the local host currently
has Ruby 3.3, so CI remains the canonical validation for that step. The
repository-wide `npm run check` also currently reports the two existing missing
Vue-module declarations in `ForkCount.test.ts` and `SearchResults.test.ts`; this
data-only change does not touch those files.
