### PR TITLE
Add crapkit

### DIFF
--- a/_data/projects/crapkit.yml
+++ b/_data/projects/crapkit.yml
@@ -1,0 +1,13 @@
+name: crapkit
+desc: Per-function CRAP scores (complexity times uncovered risk) for Python and JavaScript repos, with a CLI, a GitHub Action and an MCP server.
+site: https://github.com/JeanFrancoisGagne/crapkit
+tags:
+- python
+- javascript
+- testing
+- code-quality
+- coverage
+- mcp
+upforgrabs:
+  name: good first issue
+  link: https://github.com/JeanFrancoisGagne/crapkit/labels/good%20first%20issue


### PR DESCRIPTION
Adds `_data/projects/crapkit.yml`.

crapkit scores every function as complexity times uncovered risk and ranks the worst by how often the file changes; Python and JavaScript, with a CLI, a GitHub Action and an MCP server. MIT, active, maintainer available to review.

Four issues carry the `good first issue` label today, each with a done-when list and the file to start from: https://github.com/JeanFrancoisGagne/crapkit/labels/good%20first%20issue

Tags are lowercase and inside `a-z 0-9 + # . -` as the guide asks; none is in the preferred-tag rename map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
