### PR TITLE
Add zero-shelter

### DIFF
--- a/_data/projects/zero-shelter.yml
+++ b/_data/projects/zero-shelter.yml
@@ -1,0 +1,16 @@
+---
+name: zero-shelter
+desc: Reconciles the output of several dependency scanners into one ranked list of
+  what to fix now. Runs locally, makes no network calls of its own, and prints the
+  rule behind every number so the ranking can be argued with.
+site: https://github.com/zero-shelter/zero-shelter
+tags:
+- typescript
+- javascript
+- node.js
+- security
+- cli
+- npm
+upforgrabs:
+  name: good first issue
+  link: https://github.com/zero-shelter/zero-shelter/labels/good%20first%20issue


### PR DESCRIPTION
Adds [zero-shelter](https://github.com/zero-shelter/zero-shelter), an Apache-2.0 CLI that reconciles the output of several dependency scanners into one ranked list of what to fix now. It runs locally, makes no network calls of its own, and prints the rule behind every number.

Against the three criteria in [`docs/list-a-project.md`](https://github.com/up-for-grabs/up-for-grabs.net/blob/gh-pages/docs/list-a-project.md), with evidence rather than assertion:

**Curated tasks for new contributors.** [16 open `good first issue`](https://github.com/zero-shelter/zero-shelter/labels/good%20first%20issue), all also carrying `help wanted`. Each names the file and line, includes a command that reproduces the defect, and says which part needs a judgement rather than typing. Several deliberately leave a decision to the contributor — [#144](https://github.com/zero-shelter/zero-shelter/issues/144) turns on whether a field should be frozen-if-present or always emitted, and asks for the reasoning in the PR rather than just a passing test.

**Maintainers who review.** Three contributions from outside the team merged in the last four days:

| | | |
|---|---|---|
| [#143](https://github.com/zero-shelter/zero-shelter/pull/143) | first-time contributor | merged within a day |
| [#155](https://github.com/zero-shelter/zero-shelter/pull/155) | first-time contributor | opened 15 minutes after the issue was filed |
| [#157](https://github.com/zero-shelter/zero-shelter/pull/157) | first-time contributor | added a CI check that closes the whole class |

**Willing to work with them.** Two specifics, because this is the criterion that is easy to claim:

- On #143 I asked for one cosmetic change, then merged without waiting rather than hold a first contribution open over a rendering nit — and filed the remainder as [#150](https://github.com/zero-shelter/zero-shelter/issues/150) so it was not a debt sitting on their PR. Someone else took it the same day.
- When CI went red on #157 for six hours because npm's advisory endpoint was down, I diagnosed it and [posted the evidence on the PR](https://github.com/zero-shelter/zero-shelter/pull/157) so the author would not spend their evening chasing a failure that was not theirs.

Fork PRs need a maintainer to release the workflow run, and we watch for that — a contributor should not be waiting on a button.

**Fair warning on scale:** this project is young and small (4 stars). The issues are real and the reviews are prompt, but a contributor arriving here is not joining a large community. Happy to be declined on that basis if it is not the fit you are looking for.
