### PR TITLE
Add LibreDB Studio

### DIFF
--- a/_data/projects/libredb-studio.yml
+++ b/_data/projects/libredb-studio.yml
@@ -1,0 +1,18 @@
+---
+name: LibreDB Studio
+desc: Web-based SQL IDE for 16 database engines (PostgreSQL, MySQL, MongoDB, Redis, ClickHouse, DuckDB and more) with optional AI query assistance, shipped as one container next to your databases.
+site: https://github.com/libredb/libredb-studio
+tags:
+- typescript
+- reactjs
+- nextjs
+- sql
+- database
+- postgresql
+- mysql
+- mongodb
+- docker
+- kubernetes
+upforgrabs:
+  name: good first issue
+  link: https://github.com/libredb/libredb-studio/labels/good%20first%20issue


### PR DESCRIPTION
Adds LibreDB Studio, a web-based SQL IDE for 16 database engines (TypeScript, Next.js, Bun; MIT).

Issues for new contributors: https://github.com/libredb/libredb-studio/labels/good%20first%20issue

Each issue names the file, the fix and what "done" means, plus the one command that runs the same gates CI runs. Contributors claim an issue by commenting on it. The last three first-time PRs merged the same day they were opened.
