### PR TITLE
Add PhilanthroPy

### DIFF
--- a/_data/projects/philanthropy.yml
+++ b/_data/projects/philanthropy.yml
@@ -1,0 +1,20 @@
+---
+name: PhilanthroPy
+desc: >-
+  PhilanthroPy is a scikit-learn native toolkit for nonprofit and academic-medical-center
+  fundraising analytics. It provides pipeline-safe, leakage-safe estimators and transformers
+  for donor propensity, lapse prediction, planned-giving intent, wealth-screening imputation,
+  and walk-forward fiscal-year cross-validation. Every estimator passes scikit-learn's
+  check_estimator battery, and the library sends no data anywhere.
+site: https://philanthropy-project.github.io/PhilanthroPy/
+tags:
+- python
+- machine-learning
+- scikit-learn
+- data-science
+- preprocessing
+- model-selection
+- nonprofit
+upforgrabs:
+  name: good first issue
+  link: https://github.com/PhilanthroPy-Project/PhilanthroPy/labels/good%20first%20issue


### PR DESCRIPTION
Adds `_data/projects/philanthropy.yml`.

[PhilanthroPy](https://github.com/PhilanthroPy-Project/PhilanthroPy) is a scikit-learn native toolkit for nonprofit and academic-medical-center fundraising analytics: leakage-safe estimators and transformers for donor propensity, lapse prediction, planned-giving intent, wealth-screening imputation, and walk-forward fiscal-year cross-validation.

Against the criteria in `docs/list-a-project.md`:

- **Available maintainers interested in guiding new contributors.** 33 merged pull requests from 10 external contributors to date. Every `good first issue` is filed from a template that names the file, the exact `grep` to locate the code, the change, and the test to write, so a first-time contributor is not asked to find the problem as well as fix it. `CONTRIBUTING.md` has a claim-before-PR rule so two people do not land on the same issue.
- **A curated list of small tasks.** 8 issues currently carry `good first issue`, and the count is deliberately kept at 5 or more.
- **Willing to review and work with new contributors.** Median review turnaround has been same-day. CI is a single `make ci` (lint, types, doctests, tests, coverage floor) that runs on the pull request, so feedback is mechanical rather than a matter of taste.

`site:` points at the documentation site (<https://philanthropy-project.github.io/PhilanthroPy/>) rather than the repository, per the template. No `stats:` block, since that is generated by your tooling.