### PR TITLE
Add OpenLivery

### DIFF
--- a/_data/projects/openlivery.yml
+++ b/_data/projects/openlivery.yml
@@ -1,0 +1,14 @@
+name: OpenLivery
+desc: Self-hosted WhatsApp AI agents with separate client workspaces for agencies
+site: https://github.com/sarrazola/openlivery
+tags:
+  - python
+  - typescript
+  - go
+  - fastapi
+  - nextjs
+  - self-hosted
+  - whatsapp
+upforgrabs:
+  name: good first issue
+  link: https://github.com/sarrazola/openlivery/labels/good%20first%20issue


### PR DESCRIPTION
Add OpenLivery, an MIT-licensed application for running WhatsApp AI agents in separate client workspaces from one self-hosted installation

I maintain the project and have opened three small documentation tasks for new contributors, each with source references, a limited scope and acceptance criteria

- [Quickstart host requirements](https://github.com/sarrazola/openlivery/issues/66)
- [First-run registration and the multi-agency setting](https://github.com/sarrazola/openlivery/issues/67)
- [Backing up uploaded files](https://github.com/sarrazola/openlivery/issues/68)

The listing links to the `good first issue` label, and contributors can ask questions on the individual issues before starting

Validation: the new YAML passes the current JSON schema from up-for-grabs/tooling, including URI checks, and the upstream TagsValidator

I have not run the complete Jekyll build or repository test suite locally
