### PR TITLE
Add Swift Learning Roadmap

### DIFF
--- a/_data/projects/swift-learning-roadmap.yml
+++ b/_data/projects/swift-learning-roadmap.yml
@@ -1,0 +1,12 @@
+name: Swift Learning Roadmap
+desc: A Swift learning roadmap with Turkish resources and an English index.
+site: https://github.com/asimcanyagiz/Swift-Roadmap
+tags:
+  - swift
+  - ios
+  - education
+  - documentation
+  - markdown
+upforgrabs:
+  name: good first issue
+  link: https://github.com/asimcanyagiz/Swift-Roadmap/labels/good%20first%20issue


### PR DESCRIPTION
Add Swift Learning Roadmap, a collection of 23 topic pages linking to mainly Turkish-language Swift and iOS learning resources, with English and Turkish indexes.

The project has a bilingual contribution guide and five open, unassigned `good first issue` tasks. They include four small Swift examples and a Markdown navigation fix that does not require Swift or Xcode.

Each issue includes a target file, a bounded scope, and acceptance criteria. I maintain the project and will review contributions and help contributors through the issue or PR discussion.

- Repository: https://github.com/asimcanyagiz/Swift-Roadmap
- Contribution guide: https://github.com/asimcanyagiz/Swift-Roadmap/blob/main/CONTRIBUTING.md
- Starter tasks: https://github.com/asimcanyagiz/Swift-Roadmap/labels/good%20first%20issue

Validation:

- `bundle exec ruby scripts/validate_data_files.rb`: 1,263 files processed, no errors.
- `bundle exec jekyll build`: passed; the generated project JSON includes the new entry.
- `prettier --check _data/projects/swift-learning-roadmap.yml` with lockfile version 3.9.6: passed.
- `git diff --cached --check`: passed.

Only `_data/projects/swift-learning-roadmap.yml` is added.
