### PR TITLE
Add Podiom

### DIFF
--- a/_data/projects/podiom.yml
+++ b/_data/projects/podiom.yml
@@ -1,0 +1,26 @@
+---
+name: Podiom
+desc: >-
+  Podiom is a thin orchestration layer for local LLM agents. It gives agents durable sessions,
+  profiles and memory on your own machine, plus scheduling and native MCP, tool and skill
+  integration, so several named agents can collaborate on the same projects through a shared
+  ledger. Runs as a local daemon with a web UI, a CLI and a Home Assistant add-on.
+site: https://github.com/Podiom/Podiom
+tags:
+- go
+- svelte
+- typescript
+- sqlite
+- ai-agents
+- agent-orchestration
+- llm
+- llm-orchestration
+- mcp
+- cli
+- self-hosted
+- local-first
+- developer-tools
+- automation
+upforgrabs:
+  name: good first issue
+  link: https://github.com/Podiom/Podiom/labels/good%20first%20issue


### PR DESCRIPTION
Podiom runs LLM agents as a local daemon: durable sessions, per-agent memory, scheduling, and native MCP/tool/skill integration. Go and Svelte, MIT licensed.

I curate the `good first issue` label and keep it stocked. 7 are open and unclaimed right now. 19 people have had PRs merged so far. I review each one by actually running it rather than reading it, so contributors get specific feedback whether it lands or not.

Label: https://github.com/Podiom/Podiom/labels/good%20first%20issue