### PR TITLE
Add Posnic

### DIFF
--- a/_data/projects/posnic.yml
+++ b/_data/projects/posnic.yml
@@ -1,0 +1,19 @@
+---
+name: Posnic
+desc: >-
+  Offline-first open source POS and billing software for retail shops and
+  restaurants, built with Electron, JavaScript, Node.js, and MongoDB.
+site: https://github.com/Posnic/POS
+tags:
+- pos
+- billing-software
+- offline-pos
+- retail
+- restaurant
+- electron
+- javascript
+- node.js
+- mongodb
+upforgrabs:
+  name: good first issue
+  link: https://github.com/Posnic/POS/labels/good%20first%20issue


### PR DESCRIPTION
## Summary

Adds Posnic, an offline-first open source POS and billing application for retail shops and restaurants, to the contributor project catalog.

The listing points to:

- project: https://github.com/Posnic/POS
- curated newcomer queue: https://github.com/Posnic/POS/labels/good%20first%20issue

The queue currently contains 180 open issues and Posnic publishes contribution and newcomer guidance in the repository.

## Validation

- `git diff --check`
- parsed `_data/projects/posnic.yml` with the repository's installed `js-yaml`
- `npm test` (63 tests passed)
- confirmed the project and label URLs return successfully

Ruby is unavailable on this Windows host, so `ruby scripts/validate_data_files.rb` was not run locally; upstream CI remains authoritative for that check.

Disclosure: I contribute to Posnic's open-source visibility work. Automation assistance was used to research the catalog requirements, prepare this one-file change, and run validation.