### PR TITLE
Add RunnerDeck

### DIFF
--- a/_data/projects/RunnerDeck.yml
+++ b/_data/projects/RunnerDeck.yml
@@ -1,0 +1,13 @@
+---
+name: RunnerDeck
+desc: A small, local-only web UI for managing a pool of self-hosted GitHub Actions runners on a single machine.
+site: https://github.com/AnikethTS/RunnerDeck
+tags:
+- php
+- github-actions
+- self-hosted-runners
+- dashboard
+- devops
+upforgrabs:
+  name: up-for-grabs
+  link: https://github.com/AnikethTS/RunnerDeck/labels/up-for-grabs


### PR DESCRIPTION
## Project

[RunnerDeck](https://github.com/AnikethTS/RunnerDeck) — a small, local-only web UI for managing a pool of self-hosted GitHub Actions runners on a single machine: live GitHub-reported status vs. actual local process state, live log tailing, CPU/RAM/uptime, and start/stop/restart individually, in bulk, or all at once.

Plain PHP, no framework, no build step, no Composer runtime dependency.

## Checklist

- [x] Maintainer available and interested in guiding new contributors
- [x] The project curates a list of small tasks for new contributors — `up-for-grabs` label: https://github.com/AnikethTS/RunnerDeck/labels/up-for-grabs (4 open issues at time of submission, each scoped to a single self-contained feature with a "how to verify" section)
- [x] `CONTRIBUTING.md` in place, including an AI-contribution disclosure policy