### PR TITLE
Add Launchloom

### DIFF
--- a/_data/projects/Launchloom.yml
+++ b/_data/projects/Launchloom.yml
@@ -1,0 +1,16 @@
+---
+name: Launchloom
+desc: 'Turns one product brief and a real recording of your product into a film, a vertical cut, a landing page and reviewable social drafts — from the same plan, on your own machine.'
+site: https://github.com/FORIFOR/Launchloom
+tags:
+- python
+- fastapi
+- ffmpeg
+- playwright
+- video
+- marketing
+- devtools
+- self-hosted
+upforgrabs:
+  name: good first issue
+  link: https://github.com/FORIFOR/Launchloom/labels/good%20first%20issue


### PR DESCRIPTION
Launchloom is an Apache-2.0 tool that turns one product brief and a real recording of your product into a film, a separately composed vertical cut, a self-contained landing page and reviewable social drafts — from the same plan, locally. Python, FastAPI, SQLite, Playwright, Pillow, FFmpeg.

Against the criteria in `docs/list-a-project.md`:

- **Available maintainers.** I am the maintainer and I am actively working on it; the repository is a few weeks old and under regular commits.
- **Small tasks curated for new contributors.** Two are open and labelled `good first issue`, each scoped so that nothing else in the codebase has to be understood first:
  - [#3 Add a third language to the studio](https://github.com/FORIFOR/Launchloom/issues/3) — one table in one file, with three existing tests guarding it.
  - [#4 A fourth visual direction for the film](https://github.com/FORIFOR/Launchloom/issues/4) — one style entry plus the drawing it implies.
  Both issues explain the surrounding context, the verification step, and the two or three things that have historically gone wrong there, rather than assuming familiarity.
- **Willing to review and help people learn.** [CONTRIBUTING.md](https://github.com/FORIFOR/Launchloom/blob/main/CONTRIBUTING.md) states what is welcome and what will be declined up front, so nobody spends a weekend on something that was never going to be merged.

There are also three `help wanted` issues for verification on platforms I do not have, which is the project's real bottleneck.

Happy to adjust the tags or the description if any of them do not fit your conventions.