### PR TITLE
Update KubeIntellect description to match the current architecture

### DIFF
--- a/_data/projects/kubeintellect.yml
+++ b/_data/projects/kubeintellect.yml
@@ -1,11 +1,11 @@
 ---
 name: KubeIntellect
 desc: >-
-  KubeIntellect lets operators ask Kubernetes questions in plain English, gathers live evidence from cluster
-  tools such as kubectl, Prometheus and Loki, and pauses for explicit human approval before destructive
-  operations. It is a research system rather than a production-certified product: synthesized tools are
-  validated and approval-gated, but currently execute in-process rather than in an isolated container.
-  Python, FastAPI and LangGraph; AGPL-3.0.
+  KubeIntellect answers Kubernetes questions in plain English: it investigates a live cluster with
+  real tools - kubectl, Prometheus (PromQL) and Loki (LogQL) - correlates the evidence, and explains
+  the root cause. Any change to the cluster pauses for explicit human approval, gated by role-based
+  access control. Python, FastAPI and LangGraph; peer-reviewed in the Journal of Grid Computing
+  (2026); AGPL-3.0. Good first issues are curated, and CONTRIBUTING.md walks one end to end.
 site: https://github.com/MSKazemi/kubeintellect
 tags:
 - python


### PR DESCRIPTION
I maintain KubeIntellect (listed here since #6030) and the description has fallen out of date with the project.

The current text ends on a caveat about synthesized tools executing in-process rather than in an isolated container. That is accurate for the **v1** generation, which the project's own README marks as Legacy, but there is no tool-synthesis code in the current v4 tree at all — so the sentence describes an architecture three generations old and not what people actually install.

This PR replaces the description with what the project does today:

- live investigation through kubectl, Prometheus (PromQL) and Loki (LogQL)
- a human approval gate with role-based access control on every mutating operation
- the curated good-first-issue set, which is the reason it is listed here

No production-certification claim is made, and the `stats:` block is untouched so shiftbot keeps maintaining it.

Only the `desc` field changes.